### PR TITLE
feat(spark): support FIRO Spark verbose tx

### DIFF
--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -3335,7 +3335,6 @@ where
                     match coin.tx_details_by_hash(&txid.0, &mut input_transactions).await {
                         Ok(mut tx_details) => {
                             mm_counter!(ctx.metrics, "tx.history.response.count", 1, "coin" => coin.as_ref().conf.ticker.clone(), "method" => "tx_detail_by_hash");
-
                             if tx_details.block_height == 0 && height > 0 {
                                 tx_details.block_height = height;
                             }
@@ -3628,6 +3627,7 @@ pub async fn tx_details_by_hash<T: UtxoCommonOps>(
         let fee = verbose_tx.vin.iter().fold(0., |cur, input| {
             let fee = match input {
                 TransactionInputEnum::Lelantus(lelantus) => lelantus.n_fees,
+                TransactionInputEnum::Spark(spark) => spark.n_fees,
                 _ => 0.,
             };
             cur + fee

--- a/mm2src/coins/utxo/utxo_common/utxo_tx_history_v2_common.rs
+++ b/mm2src/coins/utxo/utxo_common/utxo_tx_history_v2_common.rs
@@ -199,6 +199,7 @@ where
         let fee = verbose_tx.vin.iter().fold(0., |cur, input| {
             let fee = match input {
                 TransactionInputEnum::Lelantus(lelantus) => lelantus.n_fees,
+                TransactionInputEnum::Spark(spark) => spark.n_fees,
                 _ => 0.,
             };
             cur + fee

--- a/mm2src/mm2_bitcoin/rpc/src/v1/types/script.rs
+++ b/mm2src/mm2_bitcoin/rpc/src/v1/types/script.rs
@@ -19,6 +19,7 @@ pub enum ScriptType {
     Call,
     Create,
     LelantusMint,
+    SparkMint,
     ColdStaking,
     // Komodo smart chains specific
     CryptoCondition,
@@ -64,6 +65,7 @@ impl Serialize for ScriptType {
             ScriptType::Call => "call".serialize(serializer),
             ScriptType::Create => "create".serialize(serializer),
             ScriptType::LelantusMint => "lelantusmint".serialize(serializer),
+            ScriptType::SparkMint => "sparksmint".serialize(serializer),
             ScriptType::ColdStaking => "cold_staking".serialize(serializer),
             ScriptType::CryptoCondition => "cryptocondition".serialize(serializer),
         }
@@ -102,6 +104,7 @@ impl<'a> Deserialize<'a> for ScriptType {
                     "call" => Ok(ScriptType::Call),
                     "create" => Ok(ScriptType::Create),
                     "lelantusmint" => Ok(ScriptType::LelantusMint),
+                    "sparksmint" => Ok(ScriptType::SparkMint),
                     "cold_staking" => Ok(ScriptType::ColdStaking),
                     "cryptocondition" => Ok(ScriptType::CryptoCondition),
                     _ => Err(E::invalid_value(Unexpected::Str(value), &self)),

--- a/mm2src/mm2_bitcoin/rpc/src/v1/types/transaction.rs
+++ b/mm2src/mm2_bitcoin/rpc/src/v1/types/transaction.rs
@@ -75,6 +75,8 @@ pub enum TransactionInputEnum {
     Sigma(SigmaInput),
     /// FIRO specific
     Lelantus(LelantusInput),
+    /// FIRO specific
+    Spark(SparkInput),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -96,6 +98,16 @@ pub struct LelantusInput {
     #[serde(rename = "nFees")]
     pub n_fees: f64,
     serials: Vec<String>,
+    sequence: u32,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct SparkInput {
+    #[serde(rename = "scriptSig")]
+    pub script_sig: TransactionInputScript,
+    #[serde(rename = "nFees")]
+    pub n_fees: f64,
+    lTags: Vec<String>,
     sequence: u32,
 }
 


### PR DESCRIPTION
This update introduces support for Spark verbose. The new integration ensures that the framework now supports Spark transaction parsing, expanding its capabilities for handling privacy-focused transactions.

The implementation maintains the core functionality while enhancing the framework’s versatility. I believe this addition will benefit users by providing a broader range of supported transactions within the Komodo Defi framework.