### PR TITLE
fix(kdf_walletconnect): apply explicit MmError mapping

### DIFF
--- a/mm2src/kdf_walletconnect/src/lib.rs
+++ b/mm2src/kdf_walletconnect/src/lib.rs
@@ -298,8 +298,7 @@ impl WalletConnectCtxImpl {
             .timeout_secs(PUBLISH_TIMEOUT_SECS)
             .await
             .map_to_mm(|_| WalletConnectError::TimeoutError)?
-            .map_to_mm(|e| e)
-            .map_mm_err()?;
+            .map_to_mm(|e| e.into())?;
 
         info!("[{topic}] Subscribed to topic");
 
@@ -475,8 +474,7 @@ impl WalletConnectCtxImpl {
             .timeout_secs(PUBLISH_TIMEOUT_SECS)
             .await
             .map_to_mm(|_| WalletConnectError::TimeoutError)?
-            .map_to_mm(|e| e)
-            .map_mm_err()?;
+            .map_to_mm(|e| e.into())?;
 
         info!("[{topic}] Message published successfully");
         Ok(())


### PR DESCRIPTION
This PR resolves compilation errors in the `kdf_walletconnect` crate that arose after merging staging into dev. The fix involves applying the explicit `.map_mm_err()` helper for some `MmError` conversions.

**Context**
Recent Rust compiler updates introduced stricter coherence rules, which invalidated our previous blanket `From<MmError>` for `MmError` conversions. PR #2443 addressed this across the codebase by replacing implicit error conversions with an explicit call to a new `.map_mm_err()` helper.

The two instances in `kdf_walletconnect/src/lib.rs` were missed as they were added by the merge from staging, leading to build failures in the dev environment as #2443 is not in staging yet.