### PR TITLE
feat(evm): implement transaction replacement (speed up/cancel)

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -47,10 +47,10 @@ use crate::rpc_command::init_scan_for_new_addresses::{InitScanAddressesRpcOps, S
 use crate::rpc_command::init_withdraw::{InitWithdrawCoin, WithdrawTaskHandleShared};
 use crate::rpc_command::{account_balance, get_new_address, init_account_balance, init_create_account,
                          init_scan_for_new_addresses};
-use crate::{coin_balance, scan_for_new_addresses_impl, BalanceResult, CoinWithDerivationMethod, DerivationMethod,
-            DexFee, Eip1559Ops, MakerNftSwapOpsV2, ParseCoinAssocTypes, ParseNftAssocTypes, PayForGasParams,
-            PrivKeyPolicy, RpcCommonOps, SendNftMakerPaymentArgs, SpendNftMakerPaymentArgs, ToBytes,
-            ValidateNftMakerPaymentArgs, ValidateWatcherSpendInput, WatcherSpendType};
+use crate::{coin_balance, BalanceResult, CoinWithDerivationMethod, DerivationMethod, DexFee, Eip1559Ops,
+            MakerNftSwapOpsV2, ParseCoinAssocTypes, ParseNftAssocTypes, PayForGasParams, PrivKeyPolicy, RpcCommonOps,
+            SendNftMakerPaymentArgs, SpendNftMakerPaymentArgs, ToBytes, ValidateNftMakerPaymentArgs,
+            ValidateWatcherSpendInput, WatcherSpendType};
 use async_trait::async_trait;
 use bitcrypto::{dhash160, keccak256, ripemd160, sha256};
 use common::custom_futures::repeatable::{Ready, Retry, RetryOnError};
@@ -62,7 +62,7 @@ use common::number_type_casting::SafeTypeCastingNumbers;
 use common::wait_until_sec;
 use common::{now_sec, small_rng, DEX_FEE_ADDR_RAW_PUBKEY};
 use crypto::privkey::key_pair_from_secret;
-use crypto::{Bip44Chain, CryptoCtx, CryptoCtxError, GlobalHDAccountArc, KeyPairPolicy};
+use crypto::{Bip44Chain, CryptoCtx, CryptoCtxError, GlobalHDAccountArc, KeyPairPolicy, StandardHDPath};
 use derive_more::Display;
 use enum_derives::EnumFromStringify;
 
@@ -899,6 +899,10 @@ pub struct EthCoinImpl {
     pub(crate) gas_limit: EthGasLimit,
     /// Config provided gas limits v2 for swap v2 transactions
     pub(crate) gas_limit_v2: EthGasLimitV2,
+    /// A local cache for transactions sent from this wallet. Only kept in memory for a running KDF instance.
+    /// This allows replacing a transaction even if it was sent through a private node
+    /// and is not yet publicly visible.
+    local_tx_cache: Arc<AsyncMutex<HashMap<H256, BytesJson>>>,
     /// This spawner is used to spawn coin's related futures that should be aborted on coin deactivation
     /// and on [`MmArc::stop`].
     pub abortable_system: AbortableQueue,
@@ -5848,6 +5852,200 @@ impl MmCoin for EthCoin {
         Box::new(get_tx_hex_by_hash_impl(self.clone(), tx_hash).boxed().compat())
     }
 
+    async fn replace_transaction(
+        &self,
+        tx_hash: String,
+        fee: WithdrawFee,
+        action: ReplacementAction,
+        broadcast: bool,
+    ) -> Result<TransactionDetails, MmError<ReplaceTxError>> {
+        // 1. Try to fetch the transaction from the local cache first.
+        // This allows replacing transactions sent via a private node
+        // and are not yet publicly visible.
+        let tx_hash_h256 = H256::from_str(&tx_hash).map_to_mm(|e| ReplaceTxError::InvalidTxHash(e.to_string()))?;
+        let tx_hex_from_cache = self.local_tx_cache.lock().await.get(&tx_hash_h256).cloned();
+
+        let original_tx_raw = if let Some(tx_hex) = tx_hex_from_cache {
+            RawTransactionRes { tx_hex }
+        } else {
+            // 2. If not in the cache, fall back to fetching from the RPC node.
+            self.get_raw_transaction(RawTransactionRequest {
+                coin: self.ticker().to_string(),
+                tx_hash: tx_hash.clone(),
+            })
+            .compat()
+            .await
+            .map_err(|e| ReplaceTxError::TxNotFound(e.to_string()))?
+        };
+
+        let original_tx: UnverifiedTransactionWrapper =
+            rlp::decode(&original_tx_raw.tx_hex.0).map_to_mm(|e| ReplaceTxError::TxDecodeError(e.to_string()))?;
+
+        let signed_original_tx =
+            SignedEthTx::new(original_tx.clone()).map_to_mm(|e| ReplaceTxError::TxDecodeError(e.to_string()))?;
+
+        let from_addr = signed_original_tx.sender();
+        let nonce_to_replace = original_tx.unsigned().nonce();
+
+        let from = match self.derivation_method() {
+            DerivationMethod::SingleAddress(my_address) => {
+                if *my_address != from_addr {
+                    return MmError::err(ReplaceTxError::TxNotSentFromAddress {
+                        address: from_addr.display_address(),
+                    });
+                }
+                None
+            },
+            DerivationMethod::HDWallet(hd_wallet) => {
+                let hd_address = self
+                    .find_wallet_address(hd_wallet, &from_addr)
+                    .await
+                    .map_err(|e| ReplaceTxError::InternalError(e.to_string()))?
+                    .ok_or_else(|| {
+                        MmError::new(ReplaceTxError::TxNotSentFromAddress {
+                            address: from_addr.display_address(),
+                        })
+                    })?;
+
+                let standard_path =
+                    StandardHDPath::from_str(&hd_address.derivation_path().to_string()).map_to_mm(|e| {
+                        ReplaceTxError::InternalError(format!(
+                            "Invalid HD path for the original transaction's sender address: {:?}",
+                            e,
+                        ))
+                    })?;
+
+                Some(HDAddressSelector::AddressId(standard_path.into()))
+            },
+        };
+
+        // Check if the transaction is a swap contract interaction and disallow replacement if so.
+        // This is crucial because the counterparty in a swap would not be aware of the new transaction hash.
+        // Note: This check is a temporary measure until we implement a proper replacement mechanism for swaps.
+        // Replacing spending transactions from swap contracts is allowed though.
+        if let Call(to_addr) = original_tx.unsigned().action() {
+            let is_swap_v1 = *to_addr == self.swap_contract_address || self.fallback_swap_contract == Some(*to_addr);
+            let is_swap_v2 = self.swap_v2_contracts.map_or(false, |c| {
+                c.maker_swap_v2_contract == *to_addr
+                    || c.taker_swap_v2_contract == *to_addr
+                    || c.nft_maker_swap_v2_contract == *to_addr
+            });
+
+            if is_swap_v1 || is_swap_v2 {
+                return MmError::err(ReplaceTxError::NotSupported(
+                    "Replacing transactions for swaps is not yet supported.".to_string(),
+                ));
+            }
+        }
+
+        // 3. Determine parameters for the new transaction.
+        let (to_addr_str, amount, max) = match action {
+            ReplacementAction::SpeedUp => {
+                let to_addr = match original_tx.unsigned().action() {
+                    Call(addr) => addr,
+                    Create => {
+                        return MmError::err(ReplaceTxError::NotSupported(
+                            "Speeding up contract creation is not yet supported.".to_string(),
+                        ))
+                    },
+                };
+
+                match self.coin_type {
+                    EthCoinType::Eth => {
+                        let original_amount_wei = original_tx.unsigned().value();
+
+                        // Try to estimate the new fee to see if we have enough balance.
+                        let details_res = get_eth_gas_details_from_withdraw_fee(
+                            self,
+                            Some(fee.clone()),
+                            original_amount_wei,
+                            original_tx.unsigned().data().clone().into(),
+                            from_addr,
+                            *to_addr,
+                            false, // We don't know if it's a max withdrawal yet
+                        )
+                        .await;
+
+                        match details_res {
+                            Ok(_) => {
+                                // If successful, it means there's enough balance to cover the original amount and the new fee.
+                                let amount_dec = u256_to_big_decimal(original_amount_wei, self.decimals())
+                                    .mm_err(|e| ReplaceTxError::InternalError(e.to_string()))?;
+                                (to_addr.display_address(), amount_dec, false)
+                            },
+                            Err(e) => match e.into_inner() {
+                                // This error indicates we don't have enough funds for the original amount + new fee.
+                                // This is a strong indicator that the original transaction was a "max" withdrawal.
+                                // In this case, we switch to a max withdrawal for the replacement transaction.
+                                EthGasDetailsErr::AmountTooLow { .. } => {
+                                    (to_addr.display_address(), BigDecimal::from(0), true)
+                                },
+                                // For any other error, we propagate it.
+                                other => {
+                                    let withdraw_error: WithdrawError = other.into();
+                                    return Err(withdraw_error.into());
+                                },
+                            },
+                        }
+                    },
+                    EthCoinType::Erc20 { token_addr, .. } => {
+                        if to_addr != &token_addr {
+                            return MmError::err(ReplaceTxError::NotSupported(
+                                "Transaction does not belong to this ERC20 token.".to_string(),
+                            ));
+                        }
+                        let function = ERC20_CONTRACT
+                            .function("transfer")
+                            .map_to_mm(|e| ReplaceTxError::TxDecodeError(e.to_string()))?;
+                        let tokens = function
+                            .decode_input(&original_tx.unsigned().data()[4..])
+                            .map_to_mm(|e| ReplaceTxError::TxDecodeError(e.to_string()))?;
+
+                        let recipient_addr =
+                            tokens.first().and_then(|t| t.clone().into_address()).ok_or_else(|| {
+                                MmError::new(ReplaceTxError::TxDecodeError("Couldn't decode recipient".into()))
+                            })?;
+                        let token_amount = tokens.get(1).and_then(|t| t.clone().into_uint()).ok_or_else(|| {
+                            MmError::new(ReplaceTxError::TxDecodeError("Couldn't decode amount".into()))
+                        })?;
+
+                        let amount_dec = u256_to_big_decimal(token_amount, self.decimals())
+                            .map_err(|e| MmError::new(ReplaceTxError::InternalError(e.to_string())))?;
+
+                        (recipient_addr.display_address(), amount_dec, false)
+                    },
+                    // Todo: Handle NFT transactions
+                    EthCoinType::Nft { .. } => {
+                        return MmError::err(ReplaceTxError::NotSupported(
+                            "Speeding up NFT transactions is not yet supported.".to_string(),
+                        ));
+                    },
+                }
+            },
+            ReplacementAction::Cancel => (from_addr.display_address(), 0.into(), false),
+        };
+
+        // 4. Create the WithdrawRequest.
+        let withdraw_req = WithdrawRequest {
+            coin: self.ticker().to_string(),
+            to: to_addr_str,
+            amount,
+            from,
+            max,
+            fee: Some(fee),
+            memo: None,
+            broadcast,
+            ibc_source_channel: None,
+        };
+
+        // 5. Use the builder pattern to set the nonce and build the transaction.
+        let mut withdraw_flow = StandardEthWithdraw::new(self.clone(), withdraw_req).map_mm_err()?;
+        withdraw_flow.set_nonce_override(nonce_to_replace);
+
+        let result = withdraw_flow.build().await.map_mm_err()?;
+        Ok(result)
+    }
+
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
         Box::new(Box::pin(withdraw_impl(self.clone(), req)).compat())
     }
@@ -6673,6 +6871,7 @@ pub async fn eth_coin_from_conf_and_request(
         nfts_infos: Default::default(),
         gas_limit,
         gas_limit_v2,
+        local_tx_cache: Arc::new(AsyncMutex::new(HashMap::new())),
         abortable_system,
     };
 
@@ -7540,6 +7739,7 @@ impl EthCoin {
             nfts_infos: Arc::clone(&self.nfts_infos),
             gas_limit: EthGasLimit::default(),
             gas_limit_v2: EthGasLimitV2::default(),
+            local_tx_cache: Arc::new(AsyncMutex::new(HashMap::new())),
             abortable_system: self.abortable_system.create_subsystem().unwrap(),
         };
         EthCoin(Arc::new(coin))

--- a/mm2src/coins/eth/eth_hd_wallet.rs
+++ b/mm2src/coins/eth/eth_hd_wallet.rs
@@ -37,6 +37,8 @@ impl ExtractExtendedPubkey for EthCoin {
 impl HDWalletCoinOps for EthCoin {
     type HDWallet = EthHDWallet;
 
+    fn bip44_chains(&self) -> Vec<Bip44Chain> { vec![Bip44Chain::External] }
+
     fn address_from_extended_pubkey(
         &self,
         extended_pubkey: &Secp256k1ExtendedPublicKey,
@@ -108,24 +110,6 @@ impl HDWalletBalanceOps for EthCoin {
         XPubExtractor: HDXPubExtractor + Send,
     {
         coin_balance::common_impl::enable_hd_wallet(self, hd_wallet, xpub_extractor, params, path_to_address).await
-    }
-
-    async fn scan_for_new_addresses(
-        &self,
-        hd_wallet: &Self::HDWallet,
-        hd_account: &mut EthHDAccount,
-        address_scanner: &Self::HDAddressScanner,
-        gap_limit: u32,
-    ) -> BalanceResult<Vec<HDAddressBalance<Self::BalanceObject>>> {
-        scan_for_new_addresses_impl(
-            self,
-            hd_wallet,
-            hd_account,
-            address_scanner,
-            Bip44Chain::External,
-            gap_limit,
-        )
-        .await
     }
 
     async fn all_known_addresses_balances(

--- a/mm2src/coins/eth/for_tests.rs
+++ b/mm2src/coins/eth/for_tests.rs
@@ -78,6 +78,7 @@ pub(crate) fn eth_coin_from_keypair(
         nfts_infos: Arc::new(Default::default()),
         gas_limit,
         gas_limit_v2,
+        local_tx_cache: Arc::new(AsyncMutex::new(HashMap::new())),
         abortable_system: AbortableQueue::default(),
     }));
     (ctx, eth_coin)

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -494,6 +494,7 @@ impl EthCoin {
             nfts_infos: Default::default(),
             gas_limit,
             gas_limit_v2,
+            local_tx_cache: Arc::new(AsyncMutex::new(HashMap::new())),
             abortable_system,
         };
 
@@ -583,6 +584,7 @@ impl EthCoin {
             nfts_infos: Arc::new(AsyncMutex::new(nft_infos)),
             gas_limit,
             gas_limit_v2,
+            local_tx_cache: Arc::new(AsyncMutex::new(HashMap::new())),
             abortable_system,
         };
         Ok(EthCoin(Arc::new(global_nft)))
@@ -723,6 +725,7 @@ pub async fn eth_coin_from_conf_and_request_v2(
         nfts_infos: Default::default(),
         gas_limit,
         gas_limit_v2,
+        local_tx_cache: Arc::new(AsyncMutex::new(HashMap::new())),
         abortable_system,
     };
 

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -47,9 +47,8 @@ use common::custom_futures::timeout::TimeoutError;
 use common::executor::{abortable_queue::WeakSpawner, AbortedError, SpawnFuture};
 use common::log::{warn, LogOnError};
 use common::{calc_total_pages, now_sec, ten, HttpStatusCode, DEX_BURN_ADDR_RAW_PUBKEY, DEX_FEE_ADDR_RAW_PUBKEY};
-use crypto::{derive_secp256k1_secret, Bip32Error, Bip44Chain, CryptoCtx, CryptoCtxError, DerivationPath,
-             GlobalHDAccountArc, HDPathToCoin, HwRpcError, KeyPairPolicy, RpcDerivationPath,
-             Secp256k1ExtendedPublicKey, Secp256k1Secret, WithHwRpcError};
+use crypto::{derive_secp256k1_secret, Bip32Error, CryptoCtx, CryptoCtxError, DerivationPath, GlobalHDAccountArc,
+             HDPathToCoin, HwRpcError, KeyPairPolicy, Secp256k1ExtendedPublicKey, Secp256k1Secret, WithHwRpcError};
 use derive_more::Display;
 use enum_derives::{EnumFromStringify, EnumFromTrait};
 use ethereum_types::{Address as EthAddress, H256, H264, H520, U256};
@@ -207,7 +206,6 @@ macro_rules! ok_or_continue_after_sleep {
 }
 
 pub mod coin_balance;
-use coin_balance::{AddressBalanceStatus, HDAddressBalance, HDWalletBalanceOps};
 
 pub mod lp_price;
 pub mod watcher_common;
@@ -224,9 +222,9 @@ use eth::{eth_coin_from_conf_and_request, get_eth_address, EthCoin, EthGasDetail
           GetEthAddressError, GetValidEthWithdrawAddError, SignedEthTx};
 
 pub mod hd_wallet;
-use hd_wallet::{AccountUpdatingError, AddressDerivingError, HDAccountOps, HDAddressId, HDAddressOps,
-                HDAddressSelector, HDCoinAddress, HDCoinHDAccount, HDExtractPubkeyError, HDPathAccountToAddressId,
-                HDWalletAddress, HDWalletCoinOps, HDWalletOps, HDWithdrawError, HDXPubExtractor, WithdrawSenderAddress};
+use hd_wallet::{AccountUpdatingError, AddressDerivingError, HDAddressOps, HDAddressSelector, HDCoinAddress,
+                HDExtractPubkeyError, HDPathAccountToAddressId, HDWalletAddress, HDWalletCoinOps, HDWalletOps,
+                HDWithdrawError, HDXPubExtractor, WithdrawSenderAddress};
 
 #[cfg(not(target_arch = "wasm32"))] pub mod lightning;
 #[cfg_attr(target_arch = "wasm32", allow(dead_code, unused_imports))]
@@ -275,8 +273,8 @@ use nft::nft_errors::GetNftInfoError;
 use script::Script;
 
 pub mod z_coin;
-use crate::coin_balance::{BalanceObjectOps, HDWalletBalanceObject};
-use crate::hd_wallet::{AddrToString, DisplayAddress};
+use crate::coin_balance::BalanceObjectOps;
+use crate::hd_wallet::AddrToString;
 use z_coin::{ZCoin, ZcoinProtocolInfo};
 
 pub type TransactionFut = Box<dyn Future<Item = TransactionEnum, Error = TransactionErr> + Send>;
@@ -2230,6 +2228,57 @@ pub struct WithdrawRequest {
     broadcast: bool,
 }
 
+/// Defines the action to be taken when replacing a transaction.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum ReplacementAction {
+    /// Re-broadcast the transaction with a higher fee to speed up confirmation.
+    SpeedUp,
+    /// Send a zero-value transaction to oneself with the same nonce to effectively cancel the original transaction.
+    Cancel,
+}
+
+#[derive(Debug, Display, Serialize, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum ReplaceTxError {
+    #[display(fmt = "Transaction hash is invalid: {}", _0)]
+    InvalidTxHash(String),
+    #[display(fmt = "Transaction not found for hash: {}", _0)]
+    TxNotFound(String),
+    #[display(fmt = "Failed to decode transaction: {}", _0)]
+    TxDecodeError(String),
+    #[display(fmt = "The specified fee type is not valid for this coin")]
+    InvalidFeeType,
+    #[display(
+        fmt = "Transaction was not sent from an address belonging to this wallet: {}",
+        address
+    )]
+    TxNotSentFromAddress { address: String },
+    #[display(fmt = "This operation is not supported: {}", _0)]
+    NotSupported(String),
+    #[display(fmt = "Internal error: {}", _0)]
+    InternalError(String),
+    #[display(fmt = "Error from withdrawal logic: {}", _0)]
+    WithdrawError(WithdrawError),
+}
+
+impl From<WithdrawError> for ReplaceTxError {
+    fn from(e: WithdrawError) -> Self { ReplaceTxError::WithdrawError(e) }
+}
+
+impl HttpStatusCode for ReplaceTxError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            ReplaceTxError::InvalidTxHash(_)
+            | ReplaceTxError::TxNotFound(_)
+            | ReplaceTxError::InvalidFeeType
+            | ReplaceTxError::TxNotSentFromAddress { .. }
+            | ReplaceTxError::NotSupported(_) => StatusCode::BAD_REQUEST,
+            ReplaceTxError::InternalError(_) | ReplaceTxError::TxDecodeError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            ReplaceTxError::WithdrawError(e) => e.status_code(),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
 pub enum StakingDetails {
@@ -3457,6 +3506,19 @@ pub trait MmCoin: SwapOps + WatcherOps + MarketCoinOps + Send + Sync + 'static {
 
     fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut;
 
+    // Todo: UTXO RBF
+    async fn replace_transaction(
+        &self,
+        _tx_hash: String,
+        _fee: WithdrawFee,
+        _action: ReplacementAction,
+        _broadcast: bool,
+    ) -> Result<TransactionDetails, MmError<ReplaceTxError>> {
+        MmError::err(ReplaceTxError::InternalError(
+            "`replace_transaction` is not supported for this coin yet!".to_string(),
+        ))
+    }
+
     /// Maximum number of digits after decimal point used to denominate integer coin units (satoshis, wei, etc.)
     fn decimals(&self) -> u8;
 
@@ -4511,14 +4573,11 @@ pub trait CoinWithDerivationMethod: HDWalletCoinOps {
                 // but this will not happen in most use cases where addresses will be below the capacity.
                 let mut all_addresses = HashSet::with_capacity(ADDRESSES_CAPACITY);
                 for (_, hd_account) in hd_accounts {
-                    let external_addresses = self.derive_known_addresses(&hd_account, Bip44Chain::External).await?;
-                    let internal_addresses = self.derive_known_addresses(&hd_account, Bip44Chain::Internal).await?;
-
-                    let addresses_it = external_addresses
-                        .into_iter()
-                        .chain(internal_addresses)
-                        .map(|hd_address| hd_address.address());
-                    all_addresses.extend(addresses_it);
+                    for chain in self.bip44_chains() {
+                        let addresses = self.derive_known_addresses(&hd_account, chain).await?;
+                        let addresses_it = addresses.into_iter().map(|hd_address| hd_address.address());
+                        all_addresses.extend(addresses_it);
+                    }
                 }
 
                 Ok(all_addresses)
@@ -5937,87 +5996,6 @@ pub async fn set_swap_transaction_fee_policy(ctx: MmArc, req: SwapTxFeePolicyReq
         },
         _ => MmError::err(SwapTxFeePolicyError::NotSupported(req.coin)),
     }
-}
-
-/// Checks addresses that either had empty transaction history last time we checked or has not been checked before.
-/// The checking stops at the moment when we find `gap_limit` consecutive empty addresses.
-pub async fn scan_for_new_addresses_impl<T>(
-    coin: &T,
-    hd_wallet: &T::HDWallet,
-    hd_account: &mut HDCoinHDAccount<T>,
-    address_scanner: &T::HDAddressScanner,
-    chain: Bip44Chain,
-    gap_limit: u32,
-) -> BalanceResult<Vec<HDAddressBalance<HDWalletBalanceObject<T>>>>
-where
-    T: HDWalletBalanceOps + Sync,
-{
-    let mut balances = Vec::with_capacity(gap_limit as usize);
-
-    // Get the first unknown address id.
-    let mut checking_address_id = hd_account
-        .known_addresses_number(chain)
-        // A UTXO coin should support both [`Bip44Chain::External`] and [`Bip44Chain::Internal`].
-        .mm_err(|e| BalanceError::Internal(e.to_string()))?;
-
-    let mut unused_addresses_counter = 0;
-    let max_addresses_number = hd_account.address_limit();
-    while checking_address_id < max_addresses_number && unused_addresses_counter <= gap_limit {
-        let hd_address = coin
-            .derive_address(hd_account, chain, checking_address_id)
-            .await
-            .map_mm_err()?;
-        let checking_address = hd_address.address();
-        let checking_address_der_path = hd_address.derivation_path();
-
-        match coin.is_address_used(&checking_address, address_scanner).await? {
-            // We found a non-empty address, so we have to fill up the balance list
-            // with zeros starting from `last_non_empty_address_id = checking_address_id - unused_addresses_counter`.
-            AddressBalanceStatus::Used(non_empty_balance) => {
-                let last_non_empty_address_id = checking_address_id - unused_addresses_counter;
-
-                // First, derive all empty addresses and put it into `balances` with default balance.
-                let address_ids = (last_non_empty_address_id..checking_address_id)
-                    .map(|address_id| HDAddressId { chain, address_id });
-                let empty_addresses = coin
-                    .derive_addresses(hd_account, address_ids)
-                    .await
-                    .map_mm_err()?
-                    .into_iter()
-                    .map(|empty_address| HDAddressBalance {
-                        address: empty_address.address().display_address(),
-                        derivation_path: RpcDerivationPath(empty_address.derivation_path().clone()),
-                        chain,
-                        balance: HDWalletBalanceObject::<T>::new(),
-                    });
-                balances.extend(empty_addresses);
-
-                // Then push this non-empty address.
-                balances.push(HDAddressBalance {
-                    address: checking_address.display_address(),
-                    derivation_path: RpcDerivationPath(checking_address_der_path.clone()),
-                    chain,
-                    balance: non_empty_balance,
-                });
-                // Reset the counter of unused addresses to zero since we found a non-empty address.
-                unused_addresses_counter = 0;
-            },
-            AddressBalanceStatus::NotUsed => unused_addresses_counter += 1,
-        }
-
-        checking_address_id += 1;
-    }
-
-    coin.set_known_addresses_number(
-        hd_wallet,
-        hd_account,
-        chain,
-        checking_address_id - unused_addresses_counter,
-    )
-    .await
-    .map_mm_err()?;
-
-    Ok(balances)
 }
 
 #[cfg(test)]

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -1429,16 +1429,6 @@ impl HDWalletBalanceOps for BchCoin {
         coin_balance::common_impl::enable_hd_wallet(self, hd_wallet, xpub_extractor, params, path_to_address).await
     }
 
-    async fn scan_for_new_addresses(
-        &self,
-        hd_wallet: &Self::HDWallet,
-        hd_account: &mut UtxoHDAccount,
-        address_scanner: &Self::HDAddressScanner,
-        gap_limit: u32,
-    ) -> BalanceResult<Vec<HDAddressBalance<Self::BalanceObject>>> {
-        utxo_common::scan_for_new_addresses(self, hd_wallet, hd_account, address_scanner, gap_limit).await
-    }
-
     async fn all_known_addresses_balances(
         &self,
         hd_account: &UtxoHDAccount,

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -1077,16 +1077,6 @@ impl HDWalletBalanceOps for QtumCoin {
         coin_balance::common_impl::enable_hd_wallet(self, hd_wallet, xpub_extractor, params, path_to_address).await
     }
 
-    async fn scan_for_new_addresses(
-        &self,
-        hd_wallet: &Self::HDWallet,
-        hd_account: &mut UtxoHDAccount,
-        address_scanner: &Self::HDAddressScanner,
-        gap_limit: u32,
-    ) -> BalanceResult<Vec<HDAddressBalance<Self::BalanceObject>>> {
-        utxo_common::scan_for_new_addresses(self, hd_wallet, hd_account, address_scanner, gap_limit).await
-    }
-
     async fn all_known_addresses_balances(
         &self,
         hd_account: &UtxoHDAccount,

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -12,14 +12,14 @@ use crate::utxo::tx_cache::TxCacheResult;
 use crate::utxo::utxo_hd_wallet::UtxoHDAddress;
 use crate::utxo::utxo_withdraw::{InitUtxoWithdraw, StandardUtxoWithdraw, UtxoWithdraw};
 use crate::watcher_common::validate_watcher_reward;
-use crate::{scan_for_new_addresses_impl, CanRefundHtlc, CoinBalance, CoinWithDerivationMethod, ConfirmPaymentInput,
-            DexFee, DexFeeBurnDestination, GenPreimageResult, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs,
-            GetWithdrawSenderAddress, RawTransactionError, RawTransactionRequest, RawTransactionRes,
-            RawTransactionResult, RefundFundingSecretArgs, RefundMakerPaymentSecretArgs, RefundPaymentArgs,
-            RewardTarget, SearchForSwapTxSpendInput, SendMakerPaymentArgs, SendMakerPaymentSpendPreimageInput,
-            SendPaymentArgs, SendTakerFundingArgs, SignRawTransactionEnum, SignRawTransactionRequest,
-            SignUtxoTransactionParams, SignatureError, SignatureResult, SpendMakerPaymentArgs, SpendPaymentArgs,
-            SwapOps, SwapTxTypeWithSecretHash, TradePreimageValue, TransactionData, TransactionFut, TransactionResult,
+use crate::{CanRefundHtlc, CoinBalance, CoinWithDerivationMethod, ConfirmPaymentInput, DexFee, DexFeeBurnDestination,
+            GenPreimageResult, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs, GetWithdrawSenderAddress,
+            RawTransactionError, RawTransactionRequest, RawTransactionRes, RawTransactionResult,
+            RefundFundingSecretArgs, RefundMakerPaymentSecretArgs, RefundPaymentArgs, RewardTarget,
+            SearchForSwapTxSpendInput, SendMakerPaymentArgs, SendMakerPaymentSpendPreimageInput, SendPaymentArgs,
+            SendTakerFundingArgs, SignRawTransactionEnum, SignRawTransactionRequest, SignUtxoTransactionParams,
+            SignatureError, SignatureResult, SpendMakerPaymentArgs, SpendPaymentArgs, SwapOps,
+            SwapTxTypeWithSecretHash, TradePreimageValue, TransactionData, TransactionFut, TransactionResult,
             TxFeeDetails, TxGenError, TxMarshalingErr, TxPreimageWithSig, ValidateAddressResult,
             ValidateOtherPubKeyErr, ValidatePaymentFut, ValidatePaymentInput, ValidateSwapV2TxError,
             ValidateSwapV2TxResult, ValidateTakerFundingArgs, ValidateTakerFundingSpendPreimageError,
@@ -166,41 +166,6 @@ where
     UtxoAddressScanner::init(coin.as_ref().rpc_client.clone())
         .await
         .map_mm_err()
-}
-
-pub async fn scan_for_new_addresses<T>(
-    coin: &T,
-    hd_wallet: &T::HDWallet,
-    hd_account: &mut HDCoinHDAccount<T>,
-    address_scanner: &T::HDAddressScanner,
-    gap_limit: u32,
-) -> BalanceResult<Vec<HDAddressBalance<HDWalletBalanceObject<T>>>>
-where
-    T: HDWalletBalanceOps + Sync,
-    HDCoinAddress<T>: std::fmt::Display,
-{
-    let mut addresses = scan_for_new_addresses_impl(
-        coin,
-        hd_wallet,
-        hd_account,
-        address_scanner,
-        Bip44Chain::External,
-        gap_limit,
-    )
-    .await?;
-    addresses.extend(
-        scan_for_new_addresses_impl(
-            coin,
-            hd_wallet,
-            hd_account,
-            address_scanner,
-            Bip44Chain::Internal,
-            gap_limit,
-        )
-        .await?,
-    );
-
-    Ok(addresses)
 }
 
 pub async fn all_known_addresses_balances<T>(

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -1183,16 +1183,6 @@ impl HDWalletBalanceOps for UtxoStandardCoin {
         coin_balance::common_impl::enable_hd_wallet(self, hd_wallet, xpub_extractor, params, path_to_address).await
     }
 
-    async fn scan_for_new_addresses(
-        &self,
-        hd_wallet: &Self::HDWallet,
-        hd_account: &mut UtxoHDAccount,
-        address_scanner: &Self::HDAddressScanner,
-        gap_limit: u32,
-    ) -> BalanceResult<Vec<HDAddressBalance<Self::BalanceObject>>> {
-        utxo_common::scan_for_new_addresses(self, hd_wallet, hd_account, address_scanner, gap_limit).await
-    }
-
     async fn all_known_addresses_balances(
         &self,
         hd_account: &UtxoHDAccount,

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -27,6 +27,7 @@ use crate::rpc::lp_commands::trezor::trezor_connection_status;
 use crate::rpc::rate_limiter::{process_rate_limit, RateLimitContext};
 use crate::rpc::wc_commands::{new_connection, ping_session};
 
+use crate::rpc::lp_commands::transactions::replace_transaction;
 use coins::eth::fee_estimation::rpc::get_eth_estimated_fee_per_gas;
 use coins::eth::EthCoin;
 use coins::my_tx_history_v2::my_tx_history_v2_rpc;
@@ -240,6 +241,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "orderbook" => handle_mmrpc(ctx, request, orderbook_rpc_v2).await,
         "recreate_swap_data" => handle_mmrpc(ctx, request, recreate_swap_data).await,
         "refresh_nft_metadata" => handle_mmrpc(ctx, request, refresh_nft_metadata).await,
+        "replace_transaction" => handle_mmrpc(ctx, request, replace_transaction).await,
         "remove_node_from_version_stat" => handle_mmrpc(ctx, request, remove_node_from_version_stat).await,
         "sign_message" => handle_mmrpc(ctx, request, sign_message).await,
         "sign_raw_transaction" => handle_mmrpc(ctx, request, sign_raw_transaction).await,

--- a/mm2src/mm2_main/src/rpc/lp_commands/mod.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod lr_swap;
 pub(crate) mod one_inch;
 pub(crate) mod pubkey;
 pub(crate) mod tokens;
+pub(crate) mod transactions;
 pub(crate) mod trezor;

--- a/mm2src/mm2_main/src/rpc/lp_commands/transactions.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/transactions.rs
@@ -1,0 +1,35 @@
+use coins::{lp_coinfind_or_err, ReplaceTxError, ReplacementAction, TransactionDetails, WithdrawFee};
+use mm2_core::mm_ctx::MmArc;
+use mm2_err_handle::prelude::*;
+use serde::Deserialize;
+
+/// Request structure for the `replace_transaction` RPC.
+#[derive(Deserialize)]
+pub struct ReplaceTransactionRequest {
+    /// The ticker of the coin for which the transaction is being replaced.
+    pub coin: String,
+    /// The hash of the transaction to be replaced.
+    pub tx_hash: String,
+    /// The new fee to be used for the replacement transaction.
+    pub fee: WithdrawFee,
+    /// The action to perform: either speed up or cancel the transaction.
+    pub action: ReplacementAction,
+    /// If `true`, the replacement transaction will be broadcast to the network.
+    #[serde(default)]
+    pub broadcast: bool,
+}
+
+/// Handles the `replace_transaction` RPC request.
+/// This allows for speeding up or canceling a pending transaction by re-issuing it with the same nonce.
+pub async fn replace_transaction(
+    ctx: MmArc,
+    req: ReplaceTransactionRequest,
+) -> Result<TransactionDetails, MmError<ReplaceTxError>> {
+    let coin = lp_coinfind_or_err(&ctx, &req.coin)
+        .await
+        .map_err(|e| ReplaceTxError::InternalError(e.to_string()))?;
+
+    // Call the trait method directly with the parameters from the request.
+    coin.replace_transaction(req.tx_hash, req.fee, req.action, req.broadcast)
+        .await
+}


### PR DESCRIPTION
This PR introduces a crucial feature for EVM-based coins: the ability to replace pending transactions. When a transaction is stuck due to low gas fees on a congested network, users can now use the new `replace_transaction RPC` to either speed it up (by re-broadcasting with a higher fee) or cancel it (by sending a zero-value transaction to themselves with the same nonce).

### Note:
This is not yet integrated with the legacy swaps or TPU. Attempting to replace an HTLC locking transaction will currently fail on purpose, as the counterparty would not be aware of the changed transaction hex or hash. To properly support transaction replacement for swaps, the following must be addressed in future work:

- When a transaction is replaced (sped up), the change must be communicated to the swap counterparty via p2p. The counterparty must be able to listen for and process this message while waiting for the on-chain events due to the first message.

- A specific timeout should be defined during which a transaction can be replaced. This window should align with the different timeouts in the swap code.

- GUIs should only present the "Speed Up" option during this defined timeout window if a transaction is not confirmed.

### Todo in next PR:

- [ ] Replacing NFT transactions.
- [ ] Task managed RPCs
- [ ] Swap transactions replacements