### PR TITLE
fix(utxo): deserialize sapling root for PIVX block headers

### DIFF
--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -5729,13 +5729,13 @@ fn test_electrum_v14_block_hash() {
 fn test_scan_and_deserialize_block_headers() {
     // ========================== CONFIGURATION ==========================
     /// The ticker of the coin to test (e.g., "NMC", "CHTA", "RVN").
-    const COIN_TICKER: &str = "NMC";
+    const COIN_TICKER: &str = "PIVX";
     /// A list of active Electrum servers for the specified coin.
-    const ELECTRUM_URLS: &[&str] = &["nmc2.bitcoins.sk:57001", "nmc2.bitcoins.sk:57002"];
+    const ELECTRUM_URLS: &[&str] = &["electrum01.chainster.org:50001", "electrum02.chainster.org:50001"];
     /// The block height to start scanning from.
-    const START_HEIGHT: u64 = 701614;
+    const START_HEIGHT: u64 = 4903982;
     /// The block height to stop scanning at. Set to `None` to scan to the tip of the chain.
-    const END_HEIGHT: Option<u64> = Some(701616);
+    const END_HEIGHT: Option<u64> = Some(4913982);
     /// The number of headers to fetch in a single RPC call.
     const CHUNK_SIZE: u64 = 100;
     // ===================================================================

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -3283,6 +3283,14 @@ fn rvn_mtp() {
 }
 
 #[test]
+fn pivx_mtp() {
+    let electrum = electrum_client_for_test(&["electrum01.chainster.org:50001", "electrum02.chainster.org:50001"]);
+    let mtp =
+        block_on_f01(electrum.get_median_time_past(5014894, NonZeroU64::new(11).unwrap(), CoinVariant::PIVX)).unwrap();
+    assert_eq!(mtp, 1754356500);
+}
+
+#[test]
 fn qtum_mtp() {
     let electrum = electrum_client_for_test(&[
         "electrum1.cipig.net:10050",

--- a/mm2src/mm2_bitcoin/serialization/src/reader.rs
+++ b/mm2src/mm2_bitcoin/serialization/src/reader.rs
@@ -65,6 +65,7 @@ pub enum CoinVariant {
     /// Same reason as RICK.
     MORTY,
     RVN,
+    PIVX,
 }
 
 impl CoinVariant {
@@ -85,6 +86,10 @@ impl CoinVariant {
     }
     pub fn is_rvn(&self) -> bool {
         matches!(self, CoinVariant::RVN)
+    }
+
+    pub fn is_pivx(&self) -> bool {
+        matches!(self, CoinVariant::PIVX)
     }
 }
 
@@ -111,6 +116,8 @@ impl From<&str> for CoinVariant {
             t if ticker_matches(t, "MORTY") => CoinVariant::MORTY,
             // "RVN"
             t if ticker_matches(t, "RVN") => CoinVariant::RVN,
+            // "PIVX"
+            t if ticker_matches(t, "PIVX") => CoinVariant::PIVX,
             _ => CoinVariant::Standard,
         }
     }


### PR DESCRIPTION
This PR resolves a deserialization failure for `PIVX` block headers that was causing an `UnexpectedEnd` error.

The root cause was that the `BlockHeader` deserializer did not account for the `hash_final_sapling_root` field, which is present in all current `PIVX` headers. This caused the stream reader to consume an incorrect number of bytes, leading to a misaligned stream for subsequent headers.

The fix introduces a `PIVX` variant to `CoinVariant` and updates the `BlockHeader::deserialize` function to correctly read the `hash_final_sapling_root` field when the coin is identified as `PIVX`, ensuring proper headers parsing.

fixes https://github.com/KomodoPlatform/komodo-defi-framework/issues/2048#issuecomment-3152520745