### PR TITLE
fix(ordermatch): ignore loop-back; clear on null root; reject stale keep-alives

### DIFF
--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -1443,7 +1443,7 @@ fn should_process_request_only_once() {
     let request: TakerRequest = json::from_str(
         r#"{"base":"ETH","rel":"JST","base_amount":"0.1","base_amount_rat":[[1,[1]],[1,[10]]],"rel_amount":"0.2","rel_amount_rat":[[1,[1]],[1,[5]]],"action":"Buy","uuid":"2f9afe84-7a89-4194-8947-45fba563118f","method":"request","sender_pubkey":"031d4256c4bc9f99ac88bf3dba21773132281f65f9bf23a59928bce08961e2f3","dest_pub_key":"0000000000000000000000000000000000000000000000000000000000000000","match_by":{"type":"Any"}}"#,
     ).unwrap();
-    block_on(process_taker_request(ctx, Default::default(), request));
+    block_on(process_taker_request(ctx, request));
     let maker_orders = &ordermatch_ctx.maker_orders_ctx.lock().orders;
     let order = block_on(maker_orders.get(&uuid).unwrap().lock());
     // when new request is processed match is replaced with new instance resetting


### PR DESCRIPTION
### Summary
This PR hardens order matching to prevent “ghost orders” where a cancelled maker order can reappear or stick in the order book.

### Changes
- Ignore loop-back messages at `process_msg`
  - If an incoming message’s pubkey matches the node’s own (persistent or per-order), it’s treated as loop-back and ignored. Prevents acting on echoed versions of our own messages.

- Clear pair on null or hashed-null trie root
  - When a `PubkeyKeepAlive` advertises a zero or hashed-null root for a pair, delete all local orders for that (pubkey, pair) and persist the null root (“tombstone”) in `pubkeys_state.trie_roots`. Avoids unnecessary re-sync until a non-null root appears.

- Reject stale/replayed `PubkeyKeepAlive` by timestamp
  - Track the maker-published timestamp per pubkey (`latest_maker_timestamp`).
  - Drop `PubkeyKeepAlive` if `message.timestamp <= latest_maker_timestamp` to prevent out-of-order/replayed keep-alives from triggering stale syncs.
  - Preserve GC semantics: `last_keep_alive` remains a local receive timestamp (`now_sec()`) used by inactivity cleanup.

- Cleanup
  - Removed redundant self-origin checks from downstream handlers (e.g., `process_maker_reserved`, `process_taker_request`) since loop-back filtering happens at the entry point.
  - `recently_cancelled` cache remains unchanged to handle out-of-order messages from other peers.

### Impact
- Prevents self-corruption via looped-back messages.
- Blocks stale state from being reintroduced via replayed or out-of-order keep-alives.
- Ensures null-root deletions are remembered and propagated.

### QA plan (high level)
- Cancellation propagation: create and cancel a maker order; verify it disappears locally and across peers and does not reappear after network churn or node restarts.
- Null-root handling: after cancellation, verify the affected (pubkey, pair) is cleared and remains empty until a new non-null root is observed (a new maker order is created remotely).
- Replay/out-of-order robustness: under normal network conditions (including transient delays), verify cancelled orders do not reappear and the order book converges across peers.
- Regression checks: normal order creation/updates continue to propagate; inactivity cleanup still purges inactive pubkeys as before. Also make sure that memory on seednodes are not affected and that this fix https://github.com/KomodoPlatform/komodo-defi-framework/pull/1054 is still actual.

Related: #2575