### PR TITLE
chore(rust 1.89): fix CI clippy (wasm32, all-targets) and fmt

### DIFF
--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -5880,11 +5880,11 @@ impl MmCoin for EthCoin {
         self.abortable_system.weak_spawner()
     }
 
-    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut<'_> {
         Box::new(get_raw_transaction_impl(self.clone(), req).boxed().compat())
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         if tx_hash.len() != H256::len_bytes() {
             let error = format!(
                 "TX hash should have exactly {} bytes, got {}",

--- a/mm2src/coins/hd_wallet/pubkey.rs
+++ b/mm2src/coins/hd_wallet/pubkey.rs
@@ -196,26 +196,3 @@ where
             .mm_err(HDExtractPubkeyError::from)
     }
 }
-
-/// This is a wrapper over `XPubExtractor`. The main goal of this structure is to allow construction of an Xpub extractor
-/// even if HD wallet is not supported. But if someone tries to extract an Xpub despite HD wallet is not supported,
-/// it fails with an inner `HDExtractPubkeyError` error.
-pub struct XPubExtractorUnchecked<XPubExtractor>(MmResult<XPubExtractor, HDExtractPubkeyError>);
-
-#[async_trait]
-impl<XPubExtractor> HDXPubExtractor for XPubExtractorUnchecked<XPubExtractor>
-where
-    XPubExtractor: HDXPubExtractor + Send + Sync,
-{
-    async fn extract_xpub(
-        &self,
-        trezor_coin: String,
-        derivation_path: DerivationPath,
-    ) -> MmResult<XPub, HDExtractPubkeyError> {
-        self.0
-            .as_ref()
-            .map_err(Clone::clone)?
-            .extract_xpub(trezor_coin, derivation_path)
-            .await
-    }
-}

--- a/mm2src/coins/hd_wallet/storage/sqlite_storage.rs
+++ b/mm2src/coins/hd_wallet/storage/sqlite_storage.rs
@@ -224,7 +224,7 @@ impl HDWalletSqliteStorage {
             .or_mm_err(|| HDWalletStorageError::Internal("'HDWalletSqliteStorage::conn' doesn't exist".to_owned()))
     }
 
-    fn lock_conn_mutex(conn: &SqliteConnShared) -> HDWalletStorageResult<MutexGuard<Connection>> {
+    fn lock_conn_mutex(conn: &SqliteConnShared) -> HDWalletStorageResult<MutexGuard<'_, Connection>> {
         conn.lock()
             .map_to_mm(|e| HDWalletStorageError::Internal(format!("Error locking sqlite connection: {e}")))
     }

--- a/mm2src/coins/lightning.rs
+++ b/mm2src/coins/lightning.rs
@@ -1235,7 +1235,7 @@ impl MmCoin for LightningCoin {
         self.platform.abortable_system.weak_spawner()
     }
 
-    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut<'_> {
         let fut = async move {
             MmError::err(RawTransactionError::InternalError(
                 "get_raw_transaction method is not supported for lightning, please use get_payment_details method instead.".into(),
@@ -1244,7 +1244,7 @@ impl MmCoin for LightningCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn get_tx_hex_by_hash(&self, _tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, _tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         let fut = async move {
             MmError::err(RawTransactionError::InternalError(
                 "get_tx_hex_by_hash method is not supported for lightning.".into(),

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -3559,9 +3559,9 @@ pub trait MmCoin: SwapOps + WatcherOps + MarketCoinOps + Send + Sync + 'static {
 
     fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut;
 
-    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut;
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut<'_>;
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut;
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_>;
 
     /// Maximum number of digits after decimal point used to denominate integer coin units (satoshis, wei, etc.)
     fn decimals(&self) -> u8;
@@ -4294,7 +4294,7 @@ impl CoinsContext {
     }
 
     #[inline(always)]
-    pub async fn lock_coins(&self) -> AsyncMutexGuard<HashMap<String, MmCoinStruct>> {
+    pub async fn lock_coins(&self) -> AsyncMutexGuard<'_, HashMap<String, MmCoinStruct>> {
         self.coins.lock().await
     }
 }

--- a/mm2src/coins/nft/storage/sql_storage.rs
+++ b/mm2src/coins/nft/storage/sql_storage.rs
@@ -538,20 +538,22 @@ fn block_number_from_row(row: &Row<'_>) -> Result<i64, SqlError> {
     row.get::<_, i64>(0)
 }
 
+#[allow(dead_code)]
 fn nft_amount_from_row(row: &Row<'_>) -> Result<String, SqlError> {
     row.get(0)
 }
 
+#[allow(dead_code)]
 fn get_nfts_by_token_address_statement(
     conn: &Connection,
     safe_table_name: SafeTableName,
-) -> Result<Statement, SqlError> {
+) -> Result<Statement<'_>, SqlError> {
     let sql_query = format!("SELECT * FROM {} WHERE token_address = ?", safe_table_name.inner());
     let stmt = conn.prepare(&sql_query)?;
     Ok(stmt)
 }
 
-fn get_token_addresses_statement(conn: &Connection, safe_table_name: SafeTableName) -> Result<Statement, SqlError> {
+fn get_token_addresses_statement(conn: &Connection, safe_table_name: SafeTableName) -> Result<Statement<'_>, SqlError> {
     let sql_query = format!("SELECT DISTINCT token_address FROM {}", safe_table_name.inner());
     let stmt = conn.prepare(&sql_query)?;
     Ok(stmt)
@@ -567,7 +569,8 @@ fn get_transfers_from_block_statement<'a>(conn: &'a Connection, chain: &'a Chain
     Ok(stmt)
 }
 
-fn get_transfers_by_token_addr_id_statement(conn: &Connection, chain: Chain) -> Result<Statement, SqlError> {
+#[allow(dead_code)]
+fn get_transfers_by_token_addr_id_statement(conn: &Connection, chain: Chain) -> Result<Statement<'_>, SqlError> {
     let safe_table_name = chain.transfer_history_table_name()?;
     let sql_query = format!(
         "SELECT * FROM {} WHERE token_address = ? AND token_id = ?",
@@ -594,7 +597,7 @@ fn get_transfers_with_empty_meta_builder<'a>(conn: &'a Connection, chain: &'a Ch
     Ok(sql_builder)
 }
 
-fn get_schema_version_stmt(conn: &Connection) -> Result<Statement, SqlError> {
+fn get_schema_version_stmt(conn: &Connection) -> Result<Statement<'_>, SqlError> {
     let table_name = schema_versions_table_name()?;
     let sql = format!("SELECT version FROM {} WHERE table_name = ?1;", table_name.inner());
     let stmt = conn.prepare(&sql)?;

--- a/mm2src/coins/qrc20.rs
+++ b/mm2src/coins/qrc20.rs
@@ -1245,11 +1245,11 @@ impl MmCoin for Qrc20Coin {
         Box::new(qrc20_withdraw(self.clone(), req).boxed().compat())
     }
 
-    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut<'_> {
         Box::new(utxo_common::get_raw_transaction(&self.utxo, req).boxed().compat())
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         Box::new(utxo_common::get_tx_hex_by_hash(&self.utxo, tx_hash).boxed().compat())
     }
 

--- a/mm2src/coins/siacoin.rs
+++ b/mm2src/coins/siacoin.rs
@@ -243,11 +243,11 @@ impl MmCoin for SiaCoin {
         unimplemented!()
     }
 
-    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut<'_> {
         unimplemented!()
     }
 
-    fn get_tx_hex_by_hash(&self, _tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, _tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         unimplemented!()
     }
 

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -3464,7 +3464,7 @@ impl MmCoin for TendermintCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn get_raw_transaction(&self, mut req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, mut req: RawTransactionRequest) -> RawTransactionFut<'_> {
         let coin = self.clone();
         let fut = async move {
             req.tx_hash.make_ascii_uppercase();
@@ -3476,7 +3476,7 @@ impl MmCoin for TendermintCoin {
         Box::new(fut.boxed().compat())
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         let coin = self.clone();
         let fut = async move {
             let len = tx_hash.len();

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -573,11 +573,11 @@ impl MmCoin for TendermintToken {
         Box::new(fut.boxed().compat())
     }
 
-    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut<'_> {
         self.platform_coin.get_raw_transaction(req)
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         unimplemented!()
     }
 

--- a/mm2src/coins/tendermint/wallet_connect.rs
+++ b/mm2src/coins/tendermint/wallet_connect.rs
@@ -217,9 +217,10 @@ where
 }
 
 fn decode_data(encoded: &str) -> Result<Vec<u8>, &'static str> {
-    if encoded.chars().all(|c| c.is_ascii_hexdigit()) && encoded.len() % 2 == 0 {
+    if encoded.chars().all(|c| c.is_ascii_hexdigit()) && encoded.len().is_multiple_of(2) {
         hex::decode(encoded).map_err(|_| "Invalid hex encoding")
-    } else if encoded.contains('=') || encoded.contains('/') || encoded.contains('+') || encoded.len() % 4 == 0 {
+    } else if encoded.contains('=') || encoded.contains('/') || encoded.contains('+') || encoded.len().is_multiple_of(4)
+    {
         general_purpose::STANDARD
             .decode(encoded)
             .map_err(|_| "Invalid base64 encoding")

--- a/mm2src/coins/test_coin.rs
+++ b/mm2src/coins/test_coin.rs
@@ -415,11 +415,11 @@ impl MmCoin for TestCoin {
         unimplemented!()
     }
 
-    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, _req: RawTransactionRequest) -> RawTransactionFut<'_> {
         unimplemented!()
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         unimplemented!()
     }
 

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -23,7 +23,7 @@
 
 pub mod bch;
 pub(crate) mod bchd_grpc;
-#[allow(clippy::all)]
+#[allow(dead_code, clippy::all)]
 #[rustfmt::skip]
 #[path = "utxo/pb.rs"]
 mod bchd_pb;
@@ -315,7 +315,7 @@ impl ActualFeeRate {
             ActualFeeRate::FixedPerKb(fee_rate) => (fee_rate * tx_size) / KILO_BYTE,
             ActualFeeRate::FixedPerKbDingo(fee_rate) => {
                 // Implement rounding mechanism (earlier used in DOGE, now in DINGO coin)
-                let tx_size_kb = if tx_size % KILO_BYTE == 0 {
+                let tx_size_kb = if tx_size.is_multiple_of(KILO_BYTE) {
                     tx_size / KILO_BYTE
                 } else {
                     tx_size / KILO_BYTE + 1

--- a/mm2src/coins/utxo/bch.rs
+++ b/mm2src/coins/utxo/bch.rs
@@ -1291,11 +1291,11 @@ impl MmCoin for BchCoin {
         self.as_ref().abortable_system.weak_spawner()
     }
 
-    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut<'_> {
         Box::new(utxo_common::get_raw_transaction(&self.utxo_arc, req).boxed().compat())
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         Box::new(
             utxo_common::get_tx_hex_by_hash(&self.utxo_arc, tx_hash)
                 .boxed()

--- a/mm2src/coins/utxo/qtum.rs
+++ b/mm2src/coins/utxo/qtum.rs
@@ -908,11 +908,11 @@ impl MmCoin for QtumCoin {
         self.as_ref().abortable_system.weak_spawner()
     }
 
-    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut<'_> {
         Box::new(utxo_common::get_raw_transaction(&self.utxo_arc, req).boxed().compat())
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         Box::new(
             utxo_common::get_tx_hex_by_hash(&self.utxo_arc, tx_hash)
                 .boxed()

--- a/mm2src/coins/utxo/rpc_clients/electrum_rpc/connection_manager/manager.rs
+++ b/mm2src/coins/utxo/rpc_clients/electrum_rpc/connection_manager/manager.rs
@@ -379,7 +379,7 @@ impl ConnectionManager {
         // The connections that we can consider (all connections - candidate connections).
         let all_candidate_connections: Vec<_> = all_connections
             .iter()
-            .filter(|&(_, conn_ctx)| (!maintained_connections.contains_key(&conn_ctx.id)))
+            .filter(|&(_, conn_ctx)| !maintained_connections.contains_key(&conn_ctx.id))
             .map(|(_, conn_ctx)| (conn_ctx.connection.clone(), conn_ctx.id))
             .collect();
         // The candidate connections from above, but further filtered by whether they are suspended or not.
@@ -465,12 +465,12 @@ impl ConnectionManager {
     }
 
     #[inline]
-    fn read_connections(&self) -> RwLockReadGuard<HashMap<String, ConnectionContext>> {
+    fn read_connections(&self) -> RwLockReadGuard<'_, HashMap<String, ConnectionContext>> {
         self.0.connections.read().unwrap()
     }
 
     #[inline]
-    fn write_connections(&self) -> RwLockWriteGuard<HashMap<String, ConnectionContext>> {
+    fn write_connections(&self) -> RwLockWriteGuard<'_, HashMap<String, ConnectionContext>> {
         self.0.connections.write().unwrap()
     }
 
@@ -482,7 +482,7 @@ impl ConnectionManager {
     }
 
     #[inline]
-    fn read_maintained_connections(&self) -> RwLockReadGuard<BTreeMap<ID, String>> {
+    fn read_maintained_connections(&self) -> RwLockReadGuard<'_, BTreeMap<ID, String>> {
         self.0.maintained_connections.read().unwrap()
     }
 

--- a/mm2src/coins/utxo/slp.rs
+++ b/mm2src/coins/utxo/slp.rs
@@ -1570,7 +1570,7 @@ impl MmCoin for SlpToken {
         self.conf.abortable_system.weak_spawner()
     }
 
-    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut<'_> {
         Box::new(
             utxo_common::get_raw_transaction(self.platform_coin.as_ref(), req)
                 .boxed()
@@ -1578,7 +1578,7 @@ impl MmCoin for SlpToken {
         )
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         Box::new(
             utxo_common::get_tx_hex_by_hash(self.platform_coin.as_ref(), tx_hash)
                 .boxed()

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -983,11 +983,11 @@ impl MmCoin for UtxoStandardCoin {
         self.as_ref().abortable_system.weak_spawner()
     }
 
-    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut<'_> {
         Box::new(utxo_common::get_raw_transaction(&self.utxo_arc, req).boxed().compat())
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         Box::new(
             utxo_common::get_tx_hex_by_hash(&self.utxo_arc, tx_hash)
                 .boxed()

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -1763,11 +1763,11 @@ impl MmCoin for ZCoin {
         ))))
     }
 
-    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut<'_> {
         Box::new(utxo_common::get_raw_transaction(&self.utxo_arc, req).boxed().compat())
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         Box::new(
             utxo_common::get_tx_hex_by_hash(&self.utxo_arc, tx_hash)
                 .boxed()

--- a/mm2src/coins/z_coin/storage/z_locked_notes/wasm.rs
+++ b/mm2src/coins/z_coin/storage/z_locked_notes/wasm.rs
@@ -69,7 +69,7 @@ impl LockedNoteDbInner {
 }
 
 impl LockedNotesStorage {
-    async fn lockdb(&self) -> MmResult<LockedNotesDbInnerLocked, LockedNotesStorageError> {
+    async fn lockdb(&self) -> MmResult<LockedNotesDbInnerLocked<'_>, LockedNotesStorageError> {
         self.db.get_or_initialize().await.map_mm_err()
     }
 }

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -1048,7 +1048,7 @@ pub fn median<T: Add<Output = T> + Div<Output = T> + Copy + From<u8> + Ord>(inpu
     }
     input.sort();
     let median_index = input.len() / 2;
-    if input.len() % 2 == 0 {
+    if input.len().is_multiple_of(2) {
         Some((input[median_index - 1] + input[median_index]) / T::from(2u8))
     } else {
         Some(input[median_index])
@@ -1078,7 +1078,7 @@ pub fn calc_total_pages(entries_len: usize, limit: usize) -> usize {
         return 0;
     }
     let pages_num = entries_len / limit;
-    if entries_len % limit == 0 {
+    if entries_len.is_multiple_of(limit) {
         pages_num
     } else {
         pages_num + 1

--- a/mm2src/kdf_walletconnect/src/session/mod.rs
+++ b/mm2src/kdf_walletconnect/src/session/mod.rs
@@ -247,11 +247,11 @@ impl SessionManager {
         )
     }
 
-    pub(crate) fn read(&self) -> RwLockReadGuard<HashMap<Topic, Session>> {
+    pub(crate) fn read(&self) -> RwLockReadGuard<'_, HashMap<Topic, Session>> {
         self.0.sessions.read().expect("read shouldn't fail")
     }
 
-    pub(crate) fn write(&self) -> RwLockWriteGuard<HashMap<Topic, Session>> {
+    pub(crate) fn write(&self) -> RwLockWriteGuard<'_, HashMap<Topic, Session>> {
         self.0.sessions.write().expect("read shouldn't fail")
     }
 

--- a/mm2src/mm2_bitcoin/script/src/script.rs
+++ b/mm2src/mm2_bitcoin/script/src/script.rs
@@ -261,13 +261,13 @@ impl Script {
         Opcode::from_u8(self.data[position]).ok_or(Error::BadOpcode)
     }
 
-    pub fn get_instruction(&self, index: usize) -> Option<Result<Instruction, Error>> {
+    pub fn get_instruction(&self, index: usize) -> Option<Result<Instruction<'_>, Error>> {
         self.iter()
             .enumerate()
             .find_map(|(idx, instr)| if idx == index { Some(instr) } else { None })
     }
 
-    pub fn get_instruction_at(&self, position: usize) -> Result<Instruction, Error> {
+    pub fn get_instruction_at(&self, position: usize) -> Result<Instruction<'_>, Error> {
         let opcode = self.get_opcode(position)?;
         let instruction = match opcode {
             Opcode::OP_PUSHDATA1 | Opcode::OP_PUSHDATA2 | Opcode::OP_PUSHDATA4 => {
@@ -376,14 +376,14 @@ impl Script {
         }
     }
 
-    pub fn iter(&self) -> Instructions {
+    pub fn iter(&self) -> Instructions<'_> {
         Instructions {
             position: 0,
             script: self,
         }
     }
 
-    pub fn opcodes(&self) -> Opcodes {
+    pub fn opcodes(&self) -> Opcodes<'_> {
         Opcodes {
             position: 0,
             script: self,

--- a/mm2src/mm2_bitcoin/spv_validation/src/helpers_validation.rs
+++ b/mm2src/mm2_bitcoin/spv_validation/src/helpers_validation.rs
@@ -90,7 +90,7 @@ struct MerkleArray<'a>(&'a [u8]);
 impl<'a> MerkleArray<'a> {
     /// Return a new merkle array from a slice
     pub fn new(slice: &'a [u8]) -> Result<MerkleArray<'a>, SPVError> {
-        if slice.len() % 32 == 0 {
+        if slice.len().is_multiple_of(32) {
             Ok(Self(slice))
         } else {
             Err(SPVError::BadMerkleProof)

--- a/mm2src/mm2_bitcoin/spv_validation/src/work.rs
+++ b/mm2src/mm2_bitcoin/spv_validation/src/work.rs
@@ -22,7 +22,7 @@ const MAX_TIMESPAN: u32 = TARGET_TIMESPAN_SECONDS * RETARGETING_FACTOR;
 pub const MAX_BITS_BTC: u32 = 486604799;
 
 fn is_retarget_height(height: u64) -> bool {
-    height % RETARGETING_INTERVAL as u64 == 0
+    height.is_multiple_of(RETARGETING_INTERVAL as u64)
 }
 
 #[derive(Clone, Debug, Display, Eq, PartialEq)]

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -402,7 +402,7 @@ impl MmCtx {
 
     /// Returns a SQL connection to the global database.
     #[cfg(all(feature = "new-db-arch", not(target_arch = "wasm32")))]
-    pub fn global_db(&self) -> MutexGuard<Connection> {
+    pub fn global_db(&self) -> MutexGuard<'_, Connection> {
         self.global_db_conn.get().unwrap().lock().unwrap()
     }
 
@@ -410,7 +410,7 @@ impl MmCtx {
     ///
     /// For new implementations, use `self.async_wallet_db()` instead.
     #[cfg(all(feature = "new-db-arch", not(target_arch = "wasm32")))]
-    pub fn wallet_db(&self) -> MutexGuard<Connection> {
+    pub fn wallet_db(&self) -> MutexGuard<'_, Connection> {
         self.wallet_db_conn.get().unwrap().lock().unwrap()
     }
 
@@ -564,12 +564,12 @@ impl MmCtx {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn sqlite_conn_opt(&self) -> Option<MutexGuard<Connection>> {
+    pub fn sqlite_conn_opt(&self) -> Option<MutexGuard<'_, Connection>> {
         self.sqlite_connection.get().map(|conn| conn.lock().unwrap())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn sqlite_connection(&self) -> MutexGuard<Connection> {
+    pub fn sqlite_connection(&self) -> MutexGuard<'_, Connection> {
         self.sqlite_connection
             .get()
             .expect("sqlite_connection is not initialized")
@@ -578,7 +578,7 @@ impl MmCtx {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn shared_sqlite_conn(&self) -> MutexGuard<Connection> {
+    pub fn shared_sqlite_conn(&self) -> MutexGuard<'_, Connection> {
         self.shared_sqlite_conn
             .get()
             .expect("shared_sqlite_conn is not initialized")

--- a/mm2src/mm2_event_stream/src/manager.rs
+++ b/mm2src/mm2_event_stream/src/manager.rs
@@ -119,12 +119,12 @@ pub struct StreamingManager(Arc<RwLock<StreamingManagerInner>>);
 
 impl StreamingManager {
     /// Returns a read guard over the streaming manager.
-    fn read(&self) -> RwLockReadGuard<StreamingManagerInner> {
+    fn read(&self) -> RwLockReadGuard<'_, StreamingManagerInner> {
         self.0.read()
     }
 
     /// Returns a write guard over the streaming manager.
-    fn write(&self) -> RwLockWriteGuard<StreamingManagerInner> {
+    fn write(&self) -> RwLockWriteGuard<'_, StreamingManagerInner> {
         self.0.write()
     }
 

--- a/mm2src/mm2_gui_storage/src/account/storage/sqlite_storage.rs
+++ b/mm2src/mm2_gui_storage/src/account/storage/sqlite_storage.rs
@@ -126,7 +126,7 @@ impl SqliteAccountStorage {
         })
     }
 
-    fn lock_conn_mutex(&self) -> AccountStorageResult<MutexGuard<Connection>> {
+    fn lock_conn_mutex(&self) -> AccountStorageResult<MutexGuard<'_, Connection>> {
         self.conn
             .lock()
             .map_to_mm(|e| AccountStorageError::Internal(format!("Error locking sqlite connection: {e}")))

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -256,12 +256,12 @@ pub struct MakerSwap {
 
 impl MakerSwap {
     #[inline]
-    fn w(&self) -> RwLockWriteGuard<MakerSwapMut> {
+    fn w(&self) -> RwLockWriteGuard<'_, MakerSwapMut> {
         self.mutable.write().unwrap()
     }
 
     #[inline]
-    fn r(&self) -> RwLockReadGuard<MakerSwapMut> {
+    fn r(&self) -> RwLockReadGuard<'_, MakerSwapMut> {
         self.mutable.read().unwrap()
     }
 

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -825,12 +825,12 @@ pub enum TakerSwapCommand {
 
 impl TakerSwap {
     #[inline]
-    fn w(&self) -> RwLockWriteGuard<TakerSwapMut> {
+    fn w(&self) -> RwLockWriteGuard<'_, TakerSwapMut> {
         self.mutable.write().unwrap()
     }
 
     #[inline]
-    pub fn r(&self) -> RwLockReadGuard<TakerSwapMut> {
+    pub fn r(&self) -> RwLockReadGuard<'_, TakerSwapMut> {
         self.mutable.read().unwrap()
     }
 

--- a/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
@@ -51,8 +51,8 @@ use mm2_test_helpers::structs::{
 use serde_json::Value as Json;
 #[cfg(any(feature = "sepolia-maker-swap-v2-tests", feature = "sepolia-taker-swap-v2-tests"))]
 use std::str::FromStr;
-use std::thread;
 use std::time::Duration;
+use std::{slice, thread};
 use uuid::Uuid;
 use web3::contract::{Contract, Options};
 use web3::ethabi::Token;
@@ -2833,7 +2833,7 @@ fn test_v2_eth_eth_kickstart() {
                     &swap_contract_address,
                     contracts.clone(),
                     None,
-                    &[node.clone()]
+                    slice::from_ref(&node)
                 ))
             );
         }

--- a/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
@@ -89,7 +89,7 @@ impl QtumDockerOps {
     }
 }
 
-pub fn qtum_docker_node(docker: &Cli, port: u16) -> DockerNode {
+pub fn qtum_docker_node(docker: &Cli, port: u16) -> DockerNode<'_> {
     let image = GenericImage::new(QTUM_REGTEST_DOCKER_IMAGE, "latest")
         .with_env_var("CLIENTS", "2")
         .with_env_var("COIN_RPC_PORT", port.to_string())

--- a/mm2src/trezor/src/proto/messages_bitcoin.rs
+++ b/mm2src/trezor/src/proto/messages_bitcoin.rs
@@ -1,3 +1,5 @@
+// Generated protocol messages; many types are not instantiated in our build.
+#![allow(dead_code)]
 ///*
 /// Type of redeem script used in input
 /// @embed

--- a/mm2src/trezor/src/proto/messages_common.rs
+++ b/mm2src/trezor/src/proto/messages_common.rs
@@ -1,3 +1,5 @@
+// Generated protocol messages; many types are not instantiated in our build.
+#![allow(dead_code)]
 ///*
 /// Response: Success of the previous request
 /// @end

--- a/mm2src/trezor/src/proto/messages_ethereum_definitions.rs
+++ b/mm2src/trezor/src/proto/messages_ethereum_definitions.rs
@@ -1,3 +1,5 @@
+// Generated protocol messages; many types are not instantiated in our build.
+#![allow(dead_code)]
 ///*
 /// Ethereum network definition. Used to (de)serialize the definition.
 /// Must be signed by vendor signatures and could be found on the trezor web site

--- a/mm2src/trezor/src/proto/messages_management.rs
+++ b/mm2src/trezor/src/proto/messages_management.rs
@@ -1,3 +1,5 @@
+// Generated protocol messages; many types are not instantiated in our build.
+#![allow(dead_code)]
 ///*
 /// Request: Reset device to default state and ask for device details
 /// @start


### PR DESCRIPTION
Align with CI using Rust 1.89.0 stable: fix clippy warnings (wasm32 + all-targets) and apply rustfmt across the workspace. No functional changes.