### PR TITLE
feat(protocol): [0] solana support

### DIFF
--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -10,6 +10,7 @@ enable-sia = [
 	"dep:blake2b_simd",
 	"dep:sia-rust"
 ]
+enable-solana = []
 default = []
 run-docker-tests = []
 for-tests = ["dep:mocktopus"]

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -301,6 +301,8 @@ use crate::coin_balance::{BalanceObjectOps, HDWalletBalanceObject};
 use crate::hd_wallet::{AddrToString, DisplayAddress};
 use z_coin::{ZCoin, ZcoinProtocolInfo};
 
+pub mod solana;
+
 pub type TransactionFut = Box<dyn Future<Item = TransactionEnum, Error = TransactionErr> + Send>;
 pub type TransactionResult = Result<TransactionEnum, TransactionErr>;
 pub type BalanceResult<T> = Result<T, MmError<BalanceError>>;

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -3723,6 +3723,7 @@ pub enum MmCoinEnum {
     TendermintToken(TendermintToken),
     #[cfg(not(target_arch = "wasm32"))]
     LightningCoin(LightningCoin),
+    Solana(solana::SolanaCoin),
     #[cfg(feature = "enable-sia")]
     SiaCoin(SiaCoin),
     #[cfg(any(test, feature = "for-tests"))]
@@ -3791,6 +3792,12 @@ impl From<LightningCoin> for MmCoinEnum {
     }
 }
 
+impl From<solana::SolanaCoin> for MmCoinEnum {
+    fn from(c: solana::SolanaCoin) -> MmCoinEnum {
+        MmCoinEnum::Solana(c)
+    }
+}
+
 impl From<ZCoin> for MmCoinEnum {
     fn from(c: ZCoin) -> MmCoinEnum {
         MmCoinEnum::ZCoin(c)
@@ -3820,6 +3827,7 @@ impl Deref for MmCoinEnum {
             #[cfg(not(target_arch = "wasm32"))]
             MmCoinEnum::LightningCoin(ref c) => c,
             MmCoinEnum::ZCoin(ref c) => c,
+            MmCoinEnum::Solana(ref c) => c,
             #[cfg(feature = "enable-sia")]
             MmCoinEnum::SiaCoin(ref c) => c,
             #[cfg(any(test, feature = "for-tests"))]

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -301,6 +301,7 @@ use crate::coin_balance::{BalanceObjectOps, HDWalletBalanceObject};
 use crate::hd_wallet::{AddrToString, DisplayAddress};
 use z_coin::{ZCoin, ZcoinProtocolInfo};
 
+#[cfg(feature = "enable-solana")]
 pub mod solana;
 
 pub type TransactionFut = Box<dyn Future<Item = TransactionEnum, Error = TransactionErr> + Send>;
@@ -3723,9 +3724,10 @@ pub enum MmCoinEnum {
     TendermintToken(TendermintToken),
     #[cfg(not(target_arch = "wasm32"))]
     LightningCoin(LightningCoin),
-    Solana(solana::SolanaCoin),
     #[cfg(feature = "enable-sia")]
     SiaCoin(SiaCoin),
+    #[cfg(feature = "enable-solana")]
+    Solana(solana::SolanaCoin),
     #[cfg(any(test, feature = "for-tests"))]
     Test(TestCoin),
 }
@@ -3792,6 +3794,7 @@ impl From<LightningCoin> for MmCoinEnum {
     }
 }
 
+#[cfg(feature = "enable-solana")]
 impl From<solana::SolanaCoin> for MmCoinEnum {
     fn from(c: solana::SolanaCoin) -> MmCoinEnum {
         MmCoinEnum::Solana(c)
@@ -3827,9 +3830,10 @@ impl Deref for MmCoinEnum {
             #[cfg(not(target_arch = "wasm32"))]
             MmCoinEnum::LightningCoin(ref c) => c,
             MmCoinEnum::ZCoin(ref c) => c,
-            MmCoinEnum::Solana(ref c) => c,
             #[cfg(feature = "enable-sia")]
             MmCoinEnum::SiaCoin(ref c) => c,
+            #[cfg(feature = "enable-solana")]
+            MmCoinEnum::Solana(ref c) => c,
             #[cfg(any(test, feature = "for-tests"))]
             MmCoinEnum::Test(ref c) => c,
         }

--- a/mm2src/coins/solana/mod.rs
+++ b/mm2src/coins/solana/mod.rs
@@ -1,1 +1,3 @@
 mod solana_coin;
+
+pub use solana_coin::SolanaCoin;

--- a/mm2src/coins/solana/mod.rs
+++ b/mm2src/coins/solana/mod.rs
@@ -1,3 +1,5 @@
 mod solana_coin;
 
 pub use solana_coin::SolanaCoin;
+pub use solana_coin::SolanaInitError;
+pub use solana_coin::SolanaProtocolInfo;

--- a/mm2src/coins/solana/mod.rs
+++ b/mm2src/coins/solana/mod.rs
@@ -1,0 +1,1 @@
+mod solana_coin;

--- a/mm2src/coins/solana/solana_coin.rs
+++ b/mm2src/coins/solana/solana_coin.rs
@@ -1,22 +1,33 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
+use async_trait::async_trait;
 use common::executor::{abortable_queue::WeakSpawner, AbortedError};
 use futures01::Future;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::{MmError, MmResult};
 use mm2_number::{BigDecimal, MmNumber};
 use rpc::v1::types::{Bytes as RpcBytes, H264 as RpcH264};
-use async_trait::async_trait;
 
 use crate::{
-    coin_errors::{AddressFromPubkeyError, MyAddressError, ValidatePaymentResult}, hd_wallet::HDAddressSelector, BalanceFut, CheckIfMyPaymentSentArgs, CoinBalance, ConfirmPaymentInput, DexFee, FeeApproxStage, FoundSwapTxSpend, HistorySyncState, MarketCoinOps, MmCoin, NegotiateSwapContractAddrErr, RawTransactionFut, RawTransactionRequest, RawTransactionResult, RefundPaymentArgs, SearchForSwapTxSpendInput, SendPaymentArgs, SignRawTransactionRequest, SignatureResult, SpendPaymentArgs, SwapOps, TradeFee, TradePreimageFut, TradePreimageResult, TradePreimageValue, TransactionEnum, TransactionResult, TxMarshalingErr, UnexpectedDerivationMethod, ValidateAddressResult, ValidateFeeArgs, ValidateOtherPubKeyErr, ValidatePaymentInput, VerificationResult, WaitForHTLCTxSpendArgs, WatcherOps, WithdrawFut, WithdrawRequest
+    coin_errors::{AddressFromPubkeyError, MyAddressError, ValidatePaymentResult},
+    hd_wallet::HDAddressSelector,
+    BalanceFut, CheckIfMyPaymentSentArgs, CoinBalance, ConfirmPaymentInput, DexFee, FeeApproxStage, FoundSwapTxSpend,
+    HistorySyncState, MarketCoinOps, MmCoin, NegotiateSwapContractAddrErr, RawTransactionFut, RawTransactionRequest,
+    RawTransactionResult, RefundPaymentArgs, SearchForSwapTxSpendInput, SendPaymentArgs, SignRawTransactionRequest,
+    SignatureResult, SpendPaymentArgs, SwapOps, TradeFee, TradePreimageFut, TradePreimageResult, TradePreimageValue,
+    TransactionEnum, TransactionResult, TxMarshalingErr, UnexpectedDerivationMethod, ValidateAddressResult,
+    ValidateFeeArgs, ValidateOtherPubKeyErr, ValidatePaymentInput, VerificationResult, WaitForHTLCTxSpendArgs,
+    WatcherOps, WithdrawFut, WithdrawRequest,
 };
 
 #[derive(Clone)]
 pub struct SolanaCoin(Arc<SolanaCoinFields>);
 
 pub struct SolanaCoinFields {}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SolanaProtocolInfo {}
 
 impl Deref for SolanaCoin {
     type Target = SolanaCoinFields;
@@ -25,6 +36,9 @@ impl Deref for SolanaCoin {
         &self.0
     }
 }
+
+#[derive(Clone, Debug)]
+pub struct SolanaInitError {}
 
 #[async_trait]
 impl MmCoin for SolanaCoin {

--- a/mm2src/coins/solana/solana_coin.rs
+++ b/mm2src/coins/solana/solana_coin.rs
@@ -1,3 +1,5 @@
+#![allow(unused_variables)]
+
 use std::ops::Deref;
 use std::sync::Arc;
 

--- a/mm2src/coins/solana/solana_coin.rs
+++ b/mm2src/coins/solana/solana_coin.rs
@@ -1,6 +1,18 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
+use common::executor::{abortable_queue::WeakSpawner, AbortedError};
+use futures01::Future;
+use mm2_core::mm_ctx::MmArc;
+use mm2_number::MmNumber;
+use rpc::v1::types::Bytes as RpcBytes;
+use async_trait::async_trait;
+
+use crate::{
+    DexFee, FeeApproxStage, HistorySyncState, MmCoin, RawTransactionFut, RawTransactionRequest, TradeFee,
+    TradePreimageResult, TradePreimageValue, ValidateAddressResult, WithdrawFut, WithdrawRequest,
+};
+
 #[derive(Clone)]
 pub struct SolanaCoin(Arc<SolanaCoinFields>);
 
@@ -11,5 +23,126 @@ impl Deref for SolanaCoin {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+#[async_trait]
+impl MmCoin for SolanaCoin {
+    fn is_asset_chain(&self) -> bool {
+        todo!()
+    }
+
+    fn wallet_only(&self, ctx: &MmArc) -> bool {
+        todo!()
+    }
+
+    fn spawner(&self) -> WeakSpawner {
+        todo!()
+    }
+
+    fn withdraw(&self, req: WithdrawRequest) -> WithdrawFut {
+        todo!()
+    }
+
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+        todo!()
+    }
+
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+        todo!()
+    }
+
+    fn decimals(&self) -> u8 {
+        todo!()
+    }
+
+    fn convert_to_address(&self, from: &str, to_address_format: serde_json::Value) -> Result<String, String> {
+        todo!()
+    }
+
+    fn validate_address(&self, address: &str) -> ValidateAddressResult {
+        todo!()
+    }
+
+    fn process_history_loop(&self, ctx: MmArc) -> Box<dyn Future<Item = (), Error = ()> + Send> {
+        todo!()
+    }
+
+    fn history_sync_status(&self) -> HistorySyncState {
+        todo!()
+    }
+
+    fn get_trade_fee(&self) -> Box<dyn Future<Item = TradeFee, Error = String> + Send> {
+        todo!()
+    }
+
+    async fn get_sender_trade_fee(
+        &self,
+        value: TradePreimageValue,
+        _stage: FeeApproxStage,
+    ) -> TradePreimageResult<TradeFee> {
+        todo!()
+    }
+
+    fn get_receiver_trade_fee(&self, stage: FeeApproxStage) -> TradePreimageFut<TradeFee> {
+        todo!()
+    }
+
+    async fn get_fee_to_send_taker_fee(
+        &self,
+        dex_fee_amount: DexFee,
+        _stage: FeeApproxStage,
+    ) -> TradePreimageResult<TradeFee> {
+        todo!()
+    }
+
+    fn required_confirmations(&self) -> u64 {
+        todo!()
+    }
+
+    fn requires_notarization(&self) -> bool {
+        todo!()
+    }
+
+    fn set_required_confirmations(&self, confirmations: u64) {
+        todo!()
+    }
+
+    fn set_requires_notarization(&self, requires_nota: bool) {
+        todo!()
+    }
+
+    fn swap_contract_address(&self) -> Option<RpcBytes> {
+        todo!()
+    }
+
+    fn fallback_swap_contract(&self) -> Option<RpcBytes> {
+        todo!()
+    }
+
+    fn mature_confirmations(&self) -> Option<u32> {
+        todo!()
+    }
+
+    fn coin_protocol_info(&self, amount_to_receive: Option<MmNumber>) -> Vec<u8> {
+        todo!()
+    }
+
+    fn is_coin_protocol_supported(
+        &self,
+        info: &Option<Vec<u8>>,
+        amount_to_send: Option<MmNumber>,
+        locktime: u64,
+        is_maker: bool,
+    ) -> bool {
+        todo!()
+    }
+
+    fn on_disabled(&self) -> Result<(), AbortedError> {
+        todo!()
+    }
+
+    fn on_token_deactivated(&self, ticker: &str) {
+        todo!()
     }
 }

--- a/mm2src/coins/solana/solana_coin.rs
+++ b/mm2src/coins/solana/solana_coin.rs
@@ -4,13 +4,13 @@ use std::sync::Arc;
 use common::executor::{abortable_queue::WeakSpawner, AbortedError};
 use futures01::Future;
 use mm2_core::mm_ctx::MmArc;
-use mm2_number::MmNumber;
-use rpc::v1::types::Bytes as RpcBytes;
+use mm2_err_handle::prelude::{MmError, MmResult};
+use mm2_number::{BigDecimal, MmNumber};
+use rpc::v1::types::{Bytes as RpcBytes, H264 as RpcH264};
 use async_trait::async_trait;
 
 use crate::{
-    DexFee, FeeApproxStage, HistorySyncState, MmCoin, RawTransactionFut, RawTransactionRequest, TradeFee,
-    TradePreimageResult, TradePreimageValue, ValidateAddressResult, WithdrawFut, WithdrawRequest,
+    coin_errors::{AddressFromPubkeyError, MyAddressError, ValidatePaymentResult}, hd_wallet::HDAddressSelector, BalanceFut, CheckIfMyPaymentSentArgs, CoinBalance, ConfirmPaymentInput, DexFee, FeeApproxStage, FoundSwapTxSpend, HistorySyncState, MarketCoinOps, MmCoin, NegotiateSwapContractAddrErr, RawTransactionFut, RawTransactionRequest, RawTransactionResult, RefundPaymentArgs, SearchForSwapTxSpendInput, SendPaymentArgs, SignRawTransactionRequest, SignatureResult, SpendPaymentArgs, SwapOps, TradeFee, TradePreimageFut, TradePreimageResult, TradePreimageValue, TransactionEnum, TransactionResult, TxMarshalingErr, UnexpectedDerivationMethod, ValidateAddressResult, ValidateFeeArgs, ValidateOtherPubKeyErr, ValidatePaymentInput, VerificationResult, WaitForHTLCTxSpendArgs, WatcherOps, WithdrawFut, WithdrawRequest
 };
 
 #[derive(Clone)]
@@ -146,3 +146,201 @@ impl MmCoin for SolanaCoin {
         todo!()
     }
 }
+
+#[async_trait]
+impl MarketCoinOps for SolanaCoin {
+    fn ticker(&self) -> &str {
+        todo!()
+    }
+
+    fn my_address(&self) -> MmResult<String, MyAddressError> {
+        todo!()
+    }
+
+    fn address_from_pubkey(&self, pubkey: &RpcH264) -> MmResult<String, AddressFromPubkeyError> {
+        todo!()
+    }
+
+    async fn get_public_key(&self) -> Result<String, MmError<UnexpectedDerivationMethod>> {
+        todo!()
+    }
+
+    fn sign_message_hash(&self, _message: &str) -> Option<[u8; 32]> {
+        todo!()
+    }
+
+    fn sign_message(&self, _message: &str, _address: Option<HDAddressSelector>) -> SignatureResult<String> {
+        todo!()
+    }
+
+    fn verify_message(&self, _signature: &str, _message: &str, _address: &str) -> VerificationResult<bool> {
+        todo!()
+    }
+
+    fn my_balance(&self) -> BalanceFut<CoinBalance> {
+        todo!()
+    }
+
+    fn base_coin_balance(&self) -> BalanceFut<BigDecimal> {
+        todo!()
+    }
+
+    fn platform_ticker(&self) -> &str {
+        todo!()
+    }
+
+    fn send_raw_tx(&self, tx: &str) -> Box<dyn Future<Item = String, Error = String> + Send> {
+        todo!()
+    }
+
+    fn send_raw_tx_bytes(&self, tx: &[u8]) -> Box<dyn Future<Item = String, Error = String> + Send> {
+        todo!()
+    }
+
+    #[inline(always)]
+    async fn sign_raw_tx(&self, _args: &SignRawTransactionRequest) -> RawTransactionResult {
+        todo!()
+    }
+
+    fn wait_for_confirmations(&self, input: ConfirmPaymentInput) -> Box<dyn Future<Item = (), Error = String> + Send> {
+        todo!()
+    }
+
+    async fn wait_for_htlc_tx_spend(&self, args: WaitForHTLCTxSpendArgs<'_>) -> TransactionResult {
+        todo!()
+    }
+
+    fn tx_enum_from_bytes(&self, bytes: &[u8]) -> Result<TransactionEnum, MmError<TxMarshalingErr>> {
+        todo!()
+    }
+
+    fn current_block(&self) -> Box<dyn Future<Item = u64, Error = String> + Send> {
+        todo!()
+    }
+
+    fn display_priv_key(&self) -> Result<String, String> {
+        todo!()
+    }
+
+    #[inline]
+    fn min_tx_amount(&self) -> BigDecimal {
+        todo!()
+    }
+
+    #[inline]
+    fn min_trading_vol(&self) -> MmNumber {
+        todo!()
+    }
+
+    #[inline]
+    fn should_burn_dex_fee(&self) -> bool {
+        todo!()
+    }
+
+    fn is_trezor(&self) -> bool {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl SwapOps for SolanaCoin {
+    async fn send_taker_fee(&self, dex_fee: DexFee, uuid: &[u8], expire_at: u64) -> TransactionResult {
+        todo!()
+    }
+
+    async fn send_maker_payment(&self, maker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
+        todo!()
+    }
+
+    async fn send_taker_payment(&self, taker_payment_args: SendPaymentArgs<'_>) -> TransactionResult {
+        todo!()
+    }
+
+    async fn send_maker_spends_taker_payment(
+        &self,
+        maker_spends_payment_args: SpendPaymentArgs<'_>,
+    ) -> TransactionResult {
+        todo!()
+    }
+
+    async fn send_taker_spends_maker_payment(
+        &self,
+        taker_spends_payment_args: SpendPaymentArgs<'_>,
+    ) -> TransactionResult {
+        todo!()
+    }
+
+    async fn send_taker_refunds_payment(&self, taker_refunds_payment_args: RefundPaymentArgs<'_>) -> TransactionResult {
+        todo!()
+    }
+
+    async fn send_maker_refunds_payment(&self, maker_refunds_payment_args: RefundPaymentArgs<'_>) -> TransactionResult {
+        todo!()
+    }
+
+    async fn validate_fee(&self, validate_fee_args: ValidateFeeArgs<'_>) -> ValidatePaymentResult<()> {
+        todo!()
+    }
+
+    async fn validate_maker_payment(&self, input: ValidatePaymentInput) -> ValidatePaymentResult<()> {
+        todo!()
+    }
+
+    async fn validate_taker_payment(&self, input: ValidatePaymentInput) -> ValidatePaymentResult<()> {
+        todo!()
+    }
+
+    async fn check_if_my_payment_sent(
+        &self,
+        if_my_payment_sent_args: CheckIfMyPaymentSentArgs<'_>,
+    ) -> Result<Option<TransactionEnum>, String> {
+        todo!()
+    }
+
+    async fn search_for_swap_tx_spend_my(
+        &self,
+        input: SearchForSwapTxSpendInput<'_>,
+    ) -> Result<Option<FoundSwapTxSpend>, String> {
+        todo!()
+    }
+
+    async fn search_for_swap_tx_spend_other(
+        &self,
+        input: SearchForSwapTxSpendInput<'_>,
+    ) -> Result<Option<FoundSwapTxSpend>, String> {
+        todo!()
+    }
+
+    async fn extract_secret(
+        &self,
+        secret_hash: &[u8],
+        spend_tx: &[u8],
+        watcher_reward: bool,
+    ) -> Result<[u8; 32], String> {
+        todo!()
+    }
+
+    fn negotiate_swap_contract_addr(
+        &self,
+        other_side_address: Option<&[u8]>,
+    ) -> Result<Option<RpcBytes>, MmError<NegotiateSwapContractAddrErr>> {
+        todo!()
+    }
+
+    #[inline]
+    fn derive_htlc_key_pair(&self, _swap_unique_data: &[u8]) -> keys::KeyPair {
+        todo!()
+    }
+
+    #[inline]
+    fn derive_htlc_pubkey(&self, _swap_unique_data: &[u8]) -> [u8; 33] {
+        todo!()
+    }
+
+    fn validate_other_pubkey(&self, raw_pubkey: &[u8]) -> MmResult<(), ValidateOtherPubKeyErr> {
+        todo!()
+    }
+}
+
+#[async_trait]
+impl WatcherOps for SolanaCoin {}

--- a/mm2src/coins/solana/solana_coin.rs
+++ b/mm2src/coins/solana/solana_coin.rs
@@ -1,0 +1,15 @@
+use std::ops::Deref;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct SolanaCoin(Arc<SolanaCoinFields>);
+
+pub struct SolanaCoinFields {}
+
+impl Deref for SolanaCoin {
+    type Target = SolanaCoinFields;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/mm2src/coins/solana/solana_coin.rs
+++ b/mm2src/coins/solana/solana_coin.rs
@@ -60,11 +60,11 @@ impl MmCoin for SolanaCoin {
         todo!()
     }
 
-    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut {
+    fn get_raw_transaction(&self, req: RawTransactionRequest) -> RawTransactionFut<'_> {
         todo!()
     }
 
-    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut {
+    fn get_tx_hex_by_hash(&self, tx_hash: Vec<u8>) -> RawTransactionFut<'_> {
         todo!()
     }
 

--- a/mm2src/coins_activation/Cargo.toml
+++ b/mm2src/coins_activation/Cargo.toml
@@ -8,6 +8,7 @@ doctest = false
 
 [features]
 enable-sia = []
+enable-solana = []
 default = []
 for-tests = []
 

--- a/mm2src/coins_activation/src/lib.rs
+++ b/mm2src/coins_activation/src/lib.rs
@@ -12,10 +12,10 @@ mod prelude;
 #[cfg(feature = "enable-sia")]
 mod sia_coin_activation;
 mod slp_token_activation;
+mod solana_with_assets;
 mod standalone_coin;
 mod tendermint_token_activation;
 mod tendermint_with_assets_activation;
-mod solana_with_assets;
 mod token;
 mod utxo_activation;
 #[cfg(not(target_arch = "wasm32"))]

--- a/mm2src/coins_activation/src/lib.rs
+++ b/mm2src/coins_activation/src/lib.rs
@@ -12,6 +12,7 @@ mod prelude;
 #[cfg(feature = "enable-sia")]
 mod sia_coin_activation;
 mod slp_token_activation;
+#[cfg(feature = "enable-solana")]
 mod solana_with_assets;
 mod standalone_coin;
 mod tendermint_token_activation;

--- a/mm2src/coins_activation/src/lib.rs
+++ b/mm2src/coins_activation/src/lib.rs
@@ -15,6 +15,7 @@ mod slp_token_activation;
 mod standalone_coin;
 mod tendermint_token_activation;
 mod tendermint_with_assets_activation;
+mod solana_with_assets;
 mod token;
 mod utxo_activation;
 #[cfg(not(target_arch = "wasm32"))]

--- a/mm2src/coins_activation/src/solana_with_assets.rs
+++ b/mm2src/coins_activation/src/solana_with_assets.rs
@@ -1,28 +1,78 @@
 use async_trait::async_trait;
-use coins::{my_tx_history_v2::TxHistoryStorage, solana::SolanaCoin, MmCoinEnum};
+use coins::{
+    my_tx_history_v2::TxHistoryStorage,
+    solana::{SolanaCoin, SolanaInitError, SolanaProtocolInfo},
+    CoinProtocol, MmCoinEnum,
+};
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::MmError;
 use mm2_number::BigDecimal;
 use rpc_task::RpcTaskHandleShared;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     context::CoinsActivationContext,
     platform_coin_with_tokens::{
-        InitPlatformCoinWithTokensTask, InitPlatformCoinWithTokensTaskManagerShared,
+        EnablePlatformCoinWithTokensError, GetPlatformBalance, InitPlatformCoinWithTokensAwaitingStatus,
+        InitPlatformCoinWithTokensInProgressStatus, InitPlatformCoinWithTokensTask,
+        InitPlatformCoinWithTokensTaskManagerShared, InitPlatformCoinWithTokensUserAction,
         PlatformCoinWithTokensActivationOps, TokenAsMmCoinInitializer,
     },
+    prelude::{ActivationRequestInfo, CurrentBlock, TryFromCoinProtocol, TxHistory},
 };
+
+#[derive(Clone, Deserialize)]
+pub struct SolanaActivationRequest {}
+
+impl TxHistory for SolanaActivationRequest {
+    fn tx_history(&self) -> bool {
+        todo!()
+    }
+}
+
+impl ActivationRequestInfo for SolanaActivationRequest {
+    fn is_hw_policy(&self) -> bool {
+        todo!()
+    }
+}
+
+impl TryFromCoinProtocol for SolanaProtocolInfo {
+    fn try_from_coin_protocol(proto: CoinProtocol) -> Result<Self, MmError<CoinProtocol>> {
+        todo!()
+    }
+}
+
+#[derive(Clone, Serialize)]
+pub struct SolanaActivationResult {}
+
+impl CurrentBlock for SolanaActivationResult {
+    fn current_block(&self) -> u64 {
+        todo!()
+    }
+}
+
+impl GetPlatformBalance for SolanaActivationResult {
+    fn get_platform_balance(&self) -> Option<BigDecimal> {
+        todo!()
+    }
+}
+
+impl From<SolanaInitError> for EnablePlatformCoinWithTokensError {
+    fn from(err: SolanaInitError) -> Self {
+        todo!()
+    }
+}
 
 #[async_trait]
 impl PlatformCoinWithTokensActivationOps for SolanaCoin {
-    type ActivationRequest;
-    type PlatformProtocolInfo;
-    type ActivationResult;
-    type ActivationError;
+    type ActivationRequest = SolanaActivationRequest;
+    type PlatformProtocolInfo = SolanaProtocolInfo;
+    type ActivationResult = SolanaActivationResult;
+    type ActivationError = SolanaInitError;
 
-    type InProgressStatus;
-    type AwaitingStatus;
-    type UserAction;
+    type InProgressStatus = InitPlatformCoinWithTokensInProgressStatus;
+    type AwaitingStatus = InitPlatformCoinWithTokensAwaitingStatus;
+    type UserAction = InitPlatformCoinWithTokensUserAction;
 
     async fn enable_platform_coin(
         ctx: MmArc,

--- a/mm2src/coins_activation/src/solana_with_assets.rs
+++ b/mm2src/coins_activation/src/solana_with_assets.rs
@@ -1,0 +1,79 @@
+use coins::{my_tx_history_v2::TxHistoryStorage, solana::SolanaCoin, MmCoinEnum};
+use mm2_core::mm_ctx::MmArc;
+use mm2_err_handle::prelude::MmError;
+use mm2_number::BigDecimal;
+use rpc_task::RpcTaskHandleShared;
+
+use crate::{
+    context::CoinsActivationContext,
+    platform_coin_with_tokens::{
+        InitPlatformCoinWithTokensTask, InitPlatformCoinWithTokensTaskManagerShared,
+        PlatformCoinWithTokensActivationOps, TokenAsMmCoinInitializer,
+    },
+};
+
+#[async_trait]
+impl PlatformCoinWithTokensActivationOps for SolanaCoin {
+    type ActivationRequest;
+    type PlatformProtocolInfo;
+    type ActivationResult;
+    type ActivationError;
+
+    type InProgressStatus;
+    type AwaitingStatus;
+    type UserAction;
+
+    async fn enable_platform_coin(
+        ctx: MmArc,
+        ticker: String,
+        coin_conf: &Json,
+        activation_request: Self::ActivationRequest,
+        protocol_conf: Self::PlatformProtocolInfo,
+    ) -> Result<Self, MmError<Self::ActivationError>> {
+        todo!()
+    }
+
+    async fn enable_global_nft(
+        &self,
+        _activation_request: &Self::ActivationRequest,
+    ) -> Result<Option<MmCoinEnum>, MmError<Self::ActivationError>> {
+        todo!()
+    }
+
+    fn try_from_mm_coin(coin: MmCoinEnum) -> Option<Self>
+    where
+        Self: Sized,
+    {
+        todo!()
+    }
+
+    fn token_initializers(
+        &self,
+    ) -> Vec<Box<dyn TokenAsMmCoinInitializer<PlatformCoin = Self, ActivationRequest = Self::ActivationRequest>>> {
+        todo!()
+    }
+
+    async fn get_activation_result(
+        &self,
+        _task_handle: Option<RpcTaskHandleShared<InitPlatformCoinWithTokensTask<SolanaCoin>>>,
+        activation_request: &Self::ActivationRequest,
+        _nft_global: &Option<MmCoinEnum>,
+    ) -> Result<Self::ActivationResult, MmError<Self::ActivationError>> {
+        todo!()
+    }
+
+    fn start_history_background_fetching(
+        &self,
+        ctx: MmArc,
+        storage: impl TxHistoryStorage,
+        initial_balance: Option<BigDecimal>,
+    ) {
+        todo!()
+    }
+
+    fn rpc_task_manager(
+        activation_ctx: &CoinsActivationContext,
+    ) -> &InitPlatformCoinWithTokensTaskManagerShared<SolanaCoin> {
+        todo!()
+    }
+}

--- a/mm2src/coins_activation/src/solana_with_assets.rs
+++ b/mm2src/coins_activation/src/solana_with_assets.rs
@@ -1,3 +1,5 @@
+#![allow(unused_variables)]
+
 use async_trait::async_trait;
 use coins::{
     my_tx_history_v2::TxHistoryStorage,

--- a/mm2src/coins_activation/src/solana_with_assets.rs
+++ b/mm2src/coins_activation/src/solana_with_assets.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use coins::{my_tx_history_v2::TxHistoryStorage, solana::SolanaCoin, MmCoinEnum};
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::MmError;
@@ -26,7 +27,7 @@ impl PlatformCoinWithTokensActivationOps for SolanaCoin {
     async fn enable_platform_coin(
         ctx: MmArc,
         ticker: String,
-        coin_conf: &Json,
+        coin_conf: &serde_json::Value,
         activation_request: Self::ActivationRequest,
         protocol_conf: Self::PlatformProtocolInfo,
     ) -> Result<Self, MmError<Self::ActivationError>> {


### PR DESCRIPTION
The infra layer of the Solana implementation, this alone brings +500 lines of change so it's better to merge this first before proceeding with further implementations.

Has zero impact on binaries as the `enable-solana` feature is disabled by default.