### PR TITLE
feat(utxo): introduce a utxo consolidation rpc

### DIFF
--- a/mm2src/coins/rpc_command/consolidate_utxos.rs
+++ b/mm2src/coins/rpc_command/consolidate_utxos.rs
@@ -1,0 +1,103 @@
+use common::HttpStatusCode;
+use derive_more::Display;
+use http::StatusCode;
+use mm2_core::mm_ctx::MmArc;
+use mm2_err_handle::prelude::{MapMmError, MmResult, MmResultExt};
+
+use crate::{
+    hd_wallet::HDWalletOps,
+    lp_coinfind_or_err,
+    utxo::{output_script, utxo_builder::merge_utxos, utxo_common::checked_address_from_str},
+    CoinFindError, DerivationMethod, MmCoinEnum,
+};
+
+#[derive(Deserialize)]
+pub struct ConsolidateUtxoRequest {
+    coin: String,
+    from_address: Option<String>,
+    to_address: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct ConsolidateUtxoResponse {
+    tx_hash: String,
+}
+
+#[derive(Serialize, Display, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum ConsolidateUtxoError {
+    NoSuchCoin(String),
+    NotSupportedCoin(String),
+    InvalidAddress(String),
+    MergeError(String),
+}
+
+impl HttpStatusCode for ConsolidateUtxoError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            ConsolidateUtxoError::NoSuchCoin(_) => StatusCode::NOT_FOUND,
+            ConsolidateUtxoError::NotSupportedCoin(_) => StatusCode::BAD_REQUEST,
+            ConsolidateUtxoError::InvalidAddress(_) => StatusCode::BAD_REQUEST,
+            ConsolidateUtxoError::MergeError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl From<CoinFindError> for ConsolidateUtxoError {
+    fn from(err: CoinFindError) -> Self {
+        ConsolidateUtxoError::NoSuchCoin(err.to_string())
+    }
+}
+
+pub async fn consolidate_utxos_rpc(
+    ctx: MmArc,
+    request: ConsolidateUtxoRequest,
+) -> MmResult<ConsolidateUtxoResponse, ConsolidateUtxoError> {
+    let coin = lp_coinfind_or_err(&ctx, &request.coin).await.map_mm_err()?;
+    match coin {
+        MmCoinEnum::UtxoCoin(coin) => {
+            let from_address = request
+                .from_address
+                .map(|addr| {
+                    checked_address_from_str(&coin, &addr).map_err(|e| {
+                        ConsolidateUtxoError::InvalidAddress(format!("Failed to parse `from_address`: {e}"))
+                    })
+                })
+                .transpose()?;
+            let from_address = match from_address {
+                Some(address) => address,
+                None => match &coin.as_ref().derivation_method {
+                    DerivationMethod::SingleAddress(my_address) => my_address.clone(),
+                    DerivationMethod::HDWallet(wallet) => {
+                        let hd_address = wallet.get_enabled_address().await.ok_or_else(|| {
+                            ConsolidateUtxoError::InvalidAddress("No enabled address found in HD wallet".to_string())
+                        })?;
+                        hd_address.address
+                    },
+                },
+            };
+
+            // Use the `to_address` if it exists, otherwise, use the `from_address` as the destination.
+            let to_address = request
+                .to_address
+                .map(|addr| {
+                    checked_address_from_str(&coin, &addr)
+                        .mm_err(|e| ConsolidateUtxoError::InvalidAddress(format!("Failed to parse `to_address`: {e}")))
+                })
+                .unwrap_or_else(|| Ok(from_address.clone()))?;
+
+            let to_script_pubkey = output_script(&to_address).map_err(|e| {
+                ConsolidateUtxoError::InvalidAddress(format!("Failed to convert `to_address` to a script_pubkey: {e}"))
+            })?;
+
+            let transaction = merge_utxos(&coin, &from_address, &to_script_pubkey, None)
+                .await
+                .map_err(|e| ConsolidateUtxoError::MergeError(format!("Failed to merge UTXOs: {e}")))?;
+
+            Ok(ConsolidateUtxoResponse {
+                tx_hash: format!("{:?}", transaction.hash().reversed()),
+            })
+        },
+        _ => Err(ConsolidateUtxoError::NotSupportedCoin(request.coin).into()),
+    }
+}

--- a/mm2src/coins/rpc_command/consolidate_utxos.rs
+++ b/mm2src/coins/rpc_command/consolidate_utxos.rs
@@ -21,6 +21,7 @@ use crate::{
 #[derive(Deserialize)]
 pub struct ConsolidateUtxoRequest {
     coin: String,
+    #[serde(default)]
     merge_conditions: MergeConditions,
 }
 

--- a/mm2src/coins/rpc_command/consolidate_utxos.rs
+++ b/mm2src/coins/rpc_command/consolidate_utxos.rs
@@ -72,7 +72,7 @@ pub async fn consolidate_utxos_rpc(
                 .map_err(|e| ConsolidateUtxoError::MergeError(format!("Failed to merge UTXOs: {e}")))?;
 
             Ok(ConsolidateUtxoResponse {
-                tx_hash: format!("{:?}", transaction.hash().reversed()),
+                tx_hash: transaction.hash().reversed().to_string(),
             })
         },
         _ => Err(ConsolidateUtxoError::NotSupportedCoin(request.coin).into()),

--- a/mm2src/coins/rpc_command/consolidate_utxos.rs
+++ b/mm2src/coins/rpc_command/consolidate_utxos.rs
@@ -63,7 +63,8 @@ impl From<CoinFindError> for ConsolidateUtxoError {
 
 #[derive(Serialize)]
 struct SpentUtxo {
-    outpoint: String,
+    txid: String,
+    vout: u32,
     value: BigDecimal,
 }
 
@@ -129,7 +130,8 @@ pub async fn consolidate_utxos_rpc(
                 consolidated_utxos: spent_utxos
                     .into_iter()
                     .map(|spent| SpentUtxo {
-                        outpoint: format!("{}:{}", spent.outpoint.hash, spent.outpoint.index),
+                        txid: spent.outpoint.hash.reversed().to_string(),
+                        vout: spent.outpoint.index,
                         value: big_decimal_from_sat_unsigned(spent.value, coin.as_ref().decimals),
                     })
                     .collect(),

--- a/mm2src/coins/rpc_command/consolidate_utxos.rs
+++ b/mm2src/coins/rpc_command/consolidate_utxos.rs
@@ -23,6 +23,8 @@ pub struct ConsolidateUtxoRequest {
     coin: String,
     #[serde(default)]
     merge_conditions: MergeConditions,
+    #[serde(default)]
+    broadcast: bool,
 }
 
 #[derive(Serialize)]
@@ -85,10 +87,15 @@ pub async fn consolidate_utxos_rpc(
                 ConsolidateUtxoError::InvalidAddress(format!("Failed to convert `to_address` to a script_pubkey: {e}"))
             })?;
 
-            let (transaction, spent_utxos) =
-                merge_utxos(&coin, &from_address, &to_script_pubkey, &request.merge_conditions)
-                    .await
-                    .map_err(|e| ConsolidateUtxoError::MergeError(format!("Failed to merge UTXOs: {e}")))?;
+            let (transaction, spent_utxos) = merge_utxos(
+                &coin,
+                &from_address,
+                &to_script_pubkey,
+                &request.merge_conditions,
+                request.broadcast,
+            )
+            .await
+            .map_err(|e| ConsolidateUtxoError::MergeError(format!("Failed to merge UTXOs: {e}")))?;
 
             let received_by_me = transaction.outputs.iter().map(|o| o.value).sum();
             let spent_by_me = spent_utxos.iter().map(|i| i.value).sum();

--- a/mm2src/coins/rpc_command/consolidate_utxos.rs
+++ b/mm2src/coins/rpc_command/consolidate_utxos.rs
@@ -99,8 +99,9 @@ pub async fn consolidate_utxos_rpc(
             .map_err(|e| ConsolidateUtxoError::MergeError(format!("Failed to merge UTXOs: {e}")))?;
 
             let received_by_me = transaction.outputs.iter().map(|o| o.value).sum();
-            let spent_by_me = spent_utxos.iter().map(|i| i.value).sum();
             let received_by_me = big_decimal_from_sat_unsigned(received_by_me, coin.as_ref().decimals);
+
+            let spent_by_me = spent_utxos.iter().map(|i| i.value).sum();
             let spent_by_me = big_decimal_from_sat_unsigned(spent_by_me, coin.as_ref().decimals);
 
             Ok(ConsolidateUtxoResponse {

--- a/mm2src/coins/rpc_command/consolidate_utxos.rs
+++ b/mm2src/coins/rpc_command/consolidate_utxos.rs
@@ -1,4 +1,4 @@
-use common::HttpStatusCode;
+use common::{now_sec, HttpStatusCode};
 use derive_more::Display;
 use http::StatusCode;
 use mm2_core::mm_ctx::MmArc;
@@ -122,7 +122,7 @@ pub async fn consolidate_utxos_rpc(
                         amount: spent_by_me - received_by_me,
                     })),
                     block_height: 0,
-                    timestamp: 0,
+                    timestamp: now_sec(),
                     kmd_rewards: None,
                     transaction_type: Default::default(),
                     memo: None,

--- a/mm2src/coins/rpc_command/consolidate_utxos.rs
+++ b/mm2src/coins/rpc_command/consolidate_utxos.rs
@@ -11,7 +11,7 @@ use crate::{
     lp_coinfind_or_err,
     utxo::{
         output_script,
-        utxo_builder::{merge_utxos, MergeConditions},
+        utxo_builder::{merge_utxos, MergeConditions, UtxoMergeError},
         utxo_common::big_decimal_from_sat_unsigned,
         UtxoFeeDetails,
     },
@@ -39,7 +39,8 @@ pub enum ConsolidateUtxoError {
     NoSuchCoin,
     CoinNotSupported,
     InvalidAddress(String),
-    MergeError(String),
+    BadMergeConditions(String),
+    InternalError(String),
 }
 
 impl HttpStatusCode for ConsolidateUtxoError {
@@ -48,7 +49,8 @@ impl HttpStatusCode for ConsolidateUtxoError {
             ConsolidateUtxoError::NoSuchCoin => StatusCode::NOT_FOUND,
             ConsolidateUtxoError::CoinNotSupported => StatusCode::BAD_REQUEST,
             ConsolidateUtxoError::InvalidAddress(_) => StatusCode::BAD_REQUEST,
-            ConsolidateUtxoError::MergeError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            ConsolidateUtxoError::BadMergeConditions(_) => StatusCode::BAD_REQUEST,
+            ConsolidateUtxoError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }
@@ -57,6 +59,15 @@ impl From<CoinFindError> for ConsolidateUtxoError {
     fn from(err: CoinFindError) -> Self {
         match err {
             CoinFindError::NoSuchCoin { .. } => ConsolidateUtxoError::NoSuchCoin,
+        }
+    }
+}
+
+impl From<UtxoMergeError> for ConsolidateUtxoError {
+    fn from(err: UtxoMergeError) -> Self {
+        match err {
+            UtxoMergeError::BadMergeConditions(e) => ConsolidateUtxoError::BadMergeConditions(e),
+            UtxoMergeError::InternalError(e) => ConsolidateUtxoError::InternalError(e),
         }
     }
 }
@@ -96,7 +107,7 @@ pub async fn consolidate_utxos_rpc(
                 request.broadcast,
             )
             .await
-            .map_err(|e| ConsolidateUtxoError::MergeError(format!("Failed to merge UTXOs: {e}")))?;
+            .map_mm_err()?;
 
             let received_by_me = transaction.outputs.iter().map(|o| o.value).sum();
             let received_by_me = big_decimal_from_sat_unsigned(received_by_me, coin.as_ref().decimals);

--- a/mm2src/coins/rpc_command/consolidate_utxos.rs
+++ b/mm2src/coins/rpc_command/consolidate_utxos.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
+
 use common::{now_sec, HttpStatusCode};
 use derive_more::Display;
 use http::StatusCode;
 use mm2_core::mm_ctx::MmArc;
-use mm2_err_handle::prelude::{MmResult, MmResultExt};
+use mm2_err_handle::prelude::{MapMmError, MmResult, MmResultExt};
 use mm2_number::BigDecimal;
 use rpc::v1::types::ToTxHash;
 
@@ -13,7 +15,7 @@ use crate::{
         output_script,
         utxo_builder::{merge_utxos, MergeConditions, UtxoMergeError},
         utxo_common::big_decimal_from_sat_unsigned,
-        UtxoFeeDetails,
+        UtxoFeeDetails, UtxoStandardOps,
     },
     CoinFindError, DerivationMethod, MmCoinEnum, Transaction, TransactionData, TransactionDetails,
 };
@@ -115,30 +117,38 @@ pub async fn consolidate_utxos_rpc(
             let spent_by_me = spent_utxos.iter().map(|i| i.value).sum();
             let spent_by_me = big_decimal_from_sat_unsigned(spent_by_me, coin.as_ref().decimals);
 
+            let mut tx = TransactionDetails {
+                from: vec![from_address.addr_to_string()],
+                to: vec![from_address.addr_to_string()],
+                received_by_me: received_by_me.clone(),
+                spent_by_me: spent_by_me.clone(),
+                total_amount: spent_by_me.clone(),
+                my_balance_change: &received_by_me - &spent_by_me,
+                tx: TransactionData::new_signed(
+                    transaction.tx_hex().into(),
+                    transaction.hash().reversed().to_vec().to_tx_hash(),
+                ),
+                coin: coin.as_ref().conf.ticker.clone(),
+                internal_id: transaction.hash().reversed().to_vec().into(),
+                fee_details: Some(crate::TxFeeDetails::Utxo(UtxoFeeDetails {
+                    coin: Some(coin.as_ref().conf.ticker.clone()),
+                    amount: spent_by_me - received_by_me,
+                })),
+                block_height: 0,
+                timestamp: now_sec(),
+                kmd_rewards: None,
+                transaction_type: Default::default(),
+                memo: None,
+            };
+
+            if tx.should_update_kmd_rewards() {
+                coin.update_kmd_rewards(&mut tx, &mut HashMap::new())
+                    .await
+                    .mm_err(|e| ConsolidateUtxoError::InternalError(format!("Failed to update KMD rewards: {e}")))?;
+            }
+
             Ok(ConsolidateUtxoResponse {
-                tx: TransactionDetails {
-                    from: vec![from_address.addr_to_string()],
-                    to: vec![from_address.addr_to_string()],
-                    received_by_me: received_by_me.clone(),
-                    spent_by_me: spent_by_me.clone(),
-                    total_amount: spent_by_me.clone(),
-                    my_balance_change: &received_by_me - &spent_by_me,
-                    tx: TransactionData::new_signed(
-                        transaction.tx_hex().into(),
-                        transaction.hash().reversed().to_vec().to_tx_hash(),
-                    ),
-                    coin: coin.as_ref().conf.ticker.clone(),
-                    internal_id: transaction.hash().reversed().to_vec().into(),
-                    fee_details: Some(crate::TxFeeDetails::Utxo(UtxoFeeDetails {
-                        coin: Some(coin.as_ref().conf.ticker.clone()),
-                        amount: spent_by_me - received_by_me,
-                    })),
-                    block_height: 0,
-                    timestamp: now_sec(),
-                    kmd_rewards: None,
-                    transaction_type: Default::default(),
-                    memo: None,
-                },
+                tx,
                 consolidated_utxos: spent_utxos
                     .into_iter()
                     .map(|spent| SpentUtxo {

--- a/mm2src/coins/rpc_command/fetch_utxos.rs
+++ b/mm2src/coins/rpc_command/fetch_utxos.rs
@@ -63,7 +63,8 @@ impl From<CoinFindError> for FetchUtxosError {
 
 #[derive(Serialize)]
 pub struct UnspentOutputs {
-    outpoint: String,
+    txid: String,
+    vout: u32,
     value: BigDecimal,
 }
 
@@ -114,7 +115,8 @@ async fn get_utxos(coin: &UtxoStandardCoin, from_address: &Address) -> MmResult<
         utxos: unspents
             .into_iter()
             .map(|unspent| UnspentOutputs {
-                outpoint: format!("{}:{}", unspent.outpoint.hash, unspent.outpoint.index),
+                txid: unspent.outpoint.hash.reversed().to_string(),
+                vout: unspent.outpoint.index,
                 value: big_decimal_from_sat_unsigned(unspent.value, coin.as_ref().decimals),
             })
             .collect(),

--- a/mm2src/coins/rpc_command/fetch_utxos.rs
+++ b/mm2src/coins/rpc_command/fetch_utxos.rs
@@ -20,6 +20,7 @@ pub struct FetchUtxosRequest {
 #[derive(Serialize)]
 pub struct FetchUtxosResponse {
     pub address: String,
+    pub count: usize,
     pub utxos: Vec<UnspentOutputs>,
 }
 
@@ -79,6 +80,7 @@ pub async fn fetch_utxos_rpc(ctx: MmArc, req: FetchUtxosRequest) -> MmResult<Fet
 
             Ok(FetchUtxosResponse {
                 address: from_address.addr_to_string(),
+                count: unspents.len(),
                 utxos: unspents
                     .into_iter()
                     .map(|unspent| UnspentOutputs {

--- a/mm2src/coins/rpc_command/fetch_utxos.rs
+++ b/mm2src/coins/rpc_command/fetch_utxos.rs
@@ -1,15 +1,18 @@
 use common::HttpStatusCode;
 use derive_more::Display;
 use http::StatusCode;
-use keys::Address;
+use keys::{Address, Public};
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::{MapMmError, MmResult, MmResultExt};
 use mm2_number::BigDecimal;
+use std::collections::HashMap;
 
 use crate::{
-    hd_wallet::{AddrToString, HDWalletOps},
+    hd_wallet::{AddrToString, HDAddress, HDWalletOps},
     lp_coinfind_or_err,
-    utxo::{utxo_common::big_decimal_from_sat_unsigned, utxo_standard::UtxoStandardCoin, GetUtxoListOps},
+    utxo::{
+        utxo_common::big_decimal_from_sat_unsigned, utxo_standard::UtxoStandardCoin, GetUtxoListOps, GetUtxoMapOps,
+    },
     CoinFindError, DerivationMethod, MmCoinEnum,
 };
 
@@ -74,52 +77,88 @@ pub async fn fetch_utxos_rpc(ctx: MmArc, req: FetchUtxosRequest) -> MmResult<Fet
     match coin {
         MmCoinEnum::UtxoCoin(coin) => match &coin.as_ref().derivation_method {
             DerivationMethod::SingleAddress(my_address) => {
-                let utxos = get_utxos(&coin, my_address).await?;
+                let addresses_utxos = get_utxos(&coin, UtxosFrom::Single(my_address.clone())).await?;
+                let total_count = addresses_utxos.iter().map(|addr| addr.count).sum();
                 Ok(FetchUtxosResponse {
-                    total_count: utxos.count,
-                    addresses: vec![utxos],
+                    total_count,
+                    addresses: addresses_utxos,
                 })
             },
             DerivationMethod::HDWallet(wallet) => {
                 let accounts = wallet.get_accounts().await;
-                let mut total_count = 0;
                 let mut addresses = Vec::new();
                 for (_, account) in accounts {
                     let addresses_in_account = account.derived_addresses.lock().await.clone();
-                    for (_, address) in addresses_in_account {
-                        let mut utxos = get_utxos(&coin, &address.address).await?;
-                        // Set the derivation path since this is an HD wallet address.
-                        utxos.derivation_path = Some(address.derivation_path.to_string());
-                        if utxos.count > 0 {
-                            total_count += utxos.count;
-                            addresses.push(utxos);
-                        }
-                    }
+                    addresses.extend(addresses_in_account.into_values());
                 }
-                Ok(FetchUtxosResponse { total_count, addresses })
+                let addresses_utxos = get_utxos(&coin, UtxosFrom::HDWallet(addresses)).await?;
+                let total_count = addresses_utxos.iter().map(|addr| addr.count).sum();
+                Ok(FetchUtxosResponse {
+                    total_count,
+                    addresses: addresses_utxos,
+                })
             },
         },
         _ => Err(FetchUtxosError::CoinNotSupported.into()),
     }
 }
 
-async fn get_utxos(coin: &UtxoStandardCoin, from_address: &Address) -> MmResult<AddressUtxos, FetchUtxosError> {
-    let (unspents, _) = coin
-        .get_unspent_ordered_list(from_address)
-        .await
-        .mm_err(|e| FetchUtxosError::Internal(format!("Couldn't fetch unspent UTXOs (address={from_address}): {e}")))?;
+enum UtxosFrom {
+    Single(Address),
+    HDWallet(Vec<HDAddress<Address, Public>>),
+}
 
-    Ok(AddressUtxos {
-        address: from_address.addr_to_string(),
-        count: unspents.len(),
-        utxos: unspents
-            .into_iter()
-            .map(|unspent| UnspentOutputs {
-                txid: unspent.outpoint.hash.reversed().to_string(),
-                vout: unspent.outpoint.index,
-                value: big_decimal_from_sat_unsigned(unspent.value, coin.as_ref().decimals),
-            })
-            .collect(),
-        derivation_path: None,
-    })
+async fn get_utxos(coin: &UtxoStandardCoin, from: UtxosFrom) -> MmResult<Vec<AddressUtxos>, FetchUtxosError> {
+    let unspents = match from {
+        UtxosFrom::Single(address) => {
+            let (unspents, _) = coin.get_unspent_ordered_list(&address).await.mm_err(|e| {
+                FetchUtxosError::Internal(format!("Couldn't fetch unspent UTXOs (address={address}): {e}"))
+            })?;
+            // In a single address mode, the address doesn't have a derivation path.
+            vec![(address, unspents, None)]
+        },
+        UtxosFrom::HDWallet(addresses) => {
+            // From an HDAddress, we only care about the address itself and the derivation path.
+            let mut addresses: HashMap<_, _> = addresses
+                .into_iter()
+                .map(|addr| (addr.address, addr.derivation_path))
+                .collect();
+
+            let (unspent_map, _) = coin
+                .get_unspent_ordered_map(addresses.keys().cloned().collect())
+                .await
+                .mm_err(|e| {
+                    FetchUtxosError::Internal(format!("Couldn't fetch unspent UTXOs (addresses={addresses:?}): {e}"))
+                })?;
+
+            // Essentially, convert the (address -> unspents) map to (address -> unspents + derivation_path) map/vector.
+            unspent_map
+                .into_iter()
+                .map(|(addr, unspent)| match addresses.remove(&addr) {
+                    Some(derivation_path) => Ok((addr, unspent, Some(derivation_path))),
+                    None => Err(FetchUtxosError::Internal(format!(
+                        "Unknown address={addr} returned by electrum"
+                    ))),
+                })
+                .collect::<Result<_, _>>()?
+        },
+    };
+
+    Ok(unspents
+        .into_iter()
+        .filter(|(_, unspents, _)| !unspents.is_empty())
+        .map(|(addr, unspents, derivation_path)| AddressUtxos {
+            address: addr.addr_to_string(),
+            count: unspents.len(),
+            utxos: unspents
+                .into_iter()
+                .map(|unspent| UnspentOutputs {
+                    txid: unspent.outpoint.hash.reversed().to_string(),
+                    vout: unspent.outpoint.index,
+                    value: big_decimal_from_sat_unsigned(unspent.value, coin.as_ref().decimals),
+                })
+                .collect(),
+            derivation_path: derivation_path.map(|d| d.to_string()),
+        })
+        .collect())
 }

--- a/mm2src/coins/rpc_command/mod.rs
+++ b/mm2src/coins/rpc_command/mod.rs
@@ -1,4 +1,5 @@
 pub mod account_balance;
+pub mod consolidate_utxos;
 pub mod get_current_mtp;
 pub mod get_enabled_coins;
 pub mod get_new_address;

--- a/mm2src/coins/rpc_command/mod.rs
+++ b/mm2src/coins/rpc_command/mod.rs
@@ -1,5 +1,6 @@
 pub mod account_balance;
 pub mod consolidate_utxos;
+pub mod fetch_utxos;
 pub mod get_current_mtp;
 pub mod get_enabled_coins;
 pub mod get_new_address;
@@ -10,7 +11,6 @@ pub mod init_scan_for_new_addresses;
 pub mod init_withdraw;
 pub mod offline_keys;
 pub mod tendermint;
-pub mod utxo_count;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod lightning;

--- a/mm2src/coins/rpc_command/mod.rs
+++ b/mm2src/coins/rpc_command/mod.rs
@@ -10,6 +10,7 @@ pub mod init_scan_for_new_addresses;
 pub mod init_withdraw;
 pub mod offline_keys;
 pub mod tendermint;
+pub mod utxo_count;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod lightning;

--- a/mm2src/coins/rpc_command/utxo_count.rs
+++ b/mm2src/coins/rpc_command/utxo_count.rs
@@ -1,0 +1,93 @@
+use common::HttpStatusCode;
+use derive_more::Display;
+use http::StatusCode;
+use mm2_core::mm_ctx::MmArc;
+use mm2_err_handle::prelude::{MapMmError, MmResult, MmResultExt};
+use mm2_number::BigDecimal;
+
+use crate::{
+    hd_wallet::{AddrToString, HDWalletOps},
+    lp_coinfind_or_err,
+    utxo::{utxo_common::big_decimal_from_sat_unsigned, GetUtxoListOps},
+    CoinFindError, DerivationMethod, MmCoinEnum,
+};
+
+#[derive(Deserialize)]
+pub struct UtxoCountRequest {
+    pub coin: String,
+}
+
+#[derive(Serialize)]
+pub struct UtxoCountResponse {
+    pub address: String,
+    pub utxos: Vec<UnspentOutputs>,
+}
+
+#[derive(Display, Serialize, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum UtxoCountError {
+    NoSuchCoin,
+    CoinNotSupported,
+    InvalidAddress(String),
+    Internal(String),
+}
+
+impl HttpStatusCode for UtxoCountError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            UtxoCountError::NoSuchCoin => StatusCode::NOT_FOUND,
+            UtxoCountError::CoinNotSupported => StatusCode::BAD_REQUEST,
+            UtxoCountError::InvalidAddress(_) => StatusCode::BAD_REQUEST,
+            UtxoCountError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl From<CoinFindError> for UtxoCountError {
+    fn from(e: CoinFindError) -> Self {
+        match e {
+            CoinFindError::NoSuchCoin { .. } => UtxoCountError::NoSuchCoin,
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub struct UnspentOutputs {
+    outpoint: String,
+    value: BigDecimal,
+}
+
+pub async fn utxo_count_rpc(ctx: MmArc, req: UtxoCountRequest) -> MmResult<UtxoCountResponse, UtxoCountError> {
+    let coin = lp_coinfind_or_err(&ctx, &req.coin).await.map_mm_err()?;
+
+    match coin {
+        MmCoinEnum::UtxoCoin(coin) => {
+            let from_address = match &coin.as_ref().derivation_method {
+                DerivationMethod::SingleAddress(my_address) => my_address.clone(),
+                DerivationMethod::HDWallet(wallet) => {
+                    let hd_address = wallet.get_enabled_address().await.ok_or_else(|| {
+                        UtxoCountError::InvalidAddress("No enabled address found in HD wallet".to_string())
+                    })?;
+                    hd_address.address
+                },
+            };
+
+            let (unspents, _) = coin
+                .get_unspent_ordered_list(&from_address)
+                .await
+                .mm_err(|e| UtxoCountError::Internal(format!("Couldn't fetch unspent UTXOs: {e}")))?;
+
+            Ok(UtxoCountResponse {
+                address: from_address.addr_to_string(),
+                utxos: unspents
+                    .into_iter()
+                    .map(|unspent| UnspentOutputs {
+                        outpoint: format!("{}:{}", unspent.outpoint.hash, unspent.outpoint.index),
+                        value: big_decimal_from_sat_unsigned(unspent.value, coin.as_ref().decimals),
+                    })
+                    .collect(),
+            })
+        },
+        _ => Err(UtxoCountError::CoinNotSupported.into()),
+    }
+}

--- a/mm2src/coins/utxo.rs
+++ b/mm2src/coins/utxo.rs
@@ -1855,6 +1855,26 @@ async fn generate_and_send_tx<T>(
 where
     T: AsRef<UtxoCoinFields> + UtxoTxGenerationOps + UtxoTxBroadcastOps,
 {
+    let (signed, spent_unspents) = generate_tx(coin, unspents, required_inputs, fee_policy, outputs).await?;
+
+    try_tx_s!(coin.broadcast_tx(&signed).await, signed);
+
+    recently_spent.add_spent(spent_unspents, signed.hash(), signed.outputs.clone());
+
+    Ok(signed)
+}
+
+/// Generates tx using unspents and outputs. Returns the signed transaction and spent unspents.
+async fn generate_tx<T>(
+    coin: &T,
+    unspents: Vec<UnspentInfo>,
+    required_inputs: Option<Vec<UnspentInfo>>,
+    fee_policy: FeePolicy,
+    outputs: Vec<TransactionOutput>,
+) -> Result<(UtxoTx, Vec<UnspentInfo>), TransactionErr>
+where
+    T: AsRef<UtxoCoinFields> + UtxoTxGenerationOps + UtxoTxBroadcastOps,
+{
     let my_address = try_tx_s!(coin.as_ref().derivation_method.single_addr_or_err().await);
     let key_pair = try_tx_s!(coin.as_ref().priv_key_policy.activated_key_or_err());
     let mut builder = UtxoTxBuilder::new(coin)
@@ -1890,11 +1910,7 @@ where
         coin.as_ref().conf.fork_id
     ));
 
-    try_tx_s!(coin.broadcast_tx(&signed).await, signed);
-
-    recently_spent.add_spent(spent_unspents, signed.hash(), signed.outputs.clone());
-
-    Ok(signed)
+    Ok((signed, spent_unspents))
 }
 
 /// Builds transaction output script for an Address struct

--- a/mm2src/coins/utxo/utxo_builder/mod.rs
+++ b/mm2src/coins/utxo/utxo_builder/mod.rs
@@ -2,7 +2,7 @@ mod utxo_arc_builder;
 mod utxo_coin_builder;
 mod utxo_conf_builder;
 
-pub use utxo_arc_builder::{MergeUtxoArcOps, UtxoArcBuilder};
+pub use utxo_arc_builder::{merge_utxos, MergeUtxoArcOps, UtxoArcBuilder};
 pub use utxo_coin_builder::{
     build_utxo_fields_with_global_hd, build_utxo_fields_with_iguana_priv_key, UtxoCoinBuildError, UtxoCoinBuildResult,
     UtxoCoinBuilder, UtxoCoinBuilderCommonOps, DAY_IN_SECONDS,

--- a/mm2src/coins/utxo/utxo_builder/mod.rs
+++ b/mm2src/coins/utxo/utxo_builder/mod.rs
@@ -2,7 +2,7 @@ mod utxo_arc_builder;
 mod utxo_coin_builder;
 mod utxo_conf_builder;
 
-pub use utxo_arc_builder::{merge_utxos, MergeUtxoArcOps, UtxoArcBuilder};
+pub use utxo_arc_builder::{merge_utxos, MergeConditions, MergeUtxoArcOps, UtxoArcBuilder};
 pub use utxo_coin_builder::{
     build_utxo_fields_with_global_hd, build_utxo_fields_with_iguana_priv_key, UtxoCoinBuildError, UtxoCoinBuildResult,
     UtxoCoinBuilder, UtxoCoinBuilderCommonOps, DAY_IN_SECONDS,

--- a/mm2src/coins/utxo/utxo_builder/mod.rs
+++ b/mm2src/coins/utxo/utxo_builder/mod.rs
@@ -2,7 +2,7 @@ mod utxo_arc_builder;
 mod utxo_coin_builder;
 mod utxo_conf_builder;
 
-pub use utxo_arc_builder::{merge_utxos, MergeConditions, MergeUtxoArcOps, UtxoArcBuilder};
+pub use utxo_arc_builder::{merge_utxos, MergeConditions, MergeUtxoArcOps, UtxoArcBuilder, UtxoMergeError};
 pub use utxo_coin_builder::{
     build_utxo_fields_with_global_hd, build_utxo_fields_with_iguana_priv_key, UtxoCoinBuildError, UtxoCoinBuildResult,
     UtxoCoinBuilder, UtxoCoinBuilderCommonOps, DAY_IN_SECONDS,

--- a/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
@@ -133,8 +133,10 @@ where
 
 #[derive(Deserialize)]
 pub struct MergeConditions {
+    #[serde(default)]
     /// The minimum number of UTXOs to merge. If the number of UTXOs is less than this, the merge will not be performed.
     pub merge_at: usize,
+    #[serde(default)]
     /// The maximum number of UTXOs to merge at once in a single transaction.
     pub max_merge_at_once: usize,
 }

--- a/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
@@ -175,6 +175,9 @@ where
         .into());
     }
     let unspents: Vec<_> = unspents.into_iter().take(merge_conditions.max_merge_at_once).collect();
+    if unspents.len() < 2 {
+        return Err(format!("No point of merging only a single UTXO (coin={ticker})").into());
+    }
 
     let value = unspents.iter().fold(0, |sum, unspent| sum + unspent.value);
     let output = TransactionOutput {

--- a/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
@@ -132,11 +132,10 @@ where
 }
 
 #[derive(Deserialize)]
+#[serde(default)]
 pub struct MergeConditions {
-    #[serde(default)]
     /// The minimum number of UTXOs to merge. If the number of UTXOs is less than this, the merge will not be performed.
     pub merge_at: usize,
-    #[serde(default)]
     /// The maximum number of UTXOs to merge at once in a single transaction.
     pub max_merge_at_once: usize,
 }

--- a/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
@@ -268,8 +268,9 @@ async fn merge_utxo_loop<T>(
 
         let ticker = &coin.as_ref().conf.ticker;
         match merge_utxos(&coin, &my_address, &script_pubkey, &merge_conditions, true).await {
-            Ok((tx, _)) => info!(
-                "UTXO merge successful for coin={ticker}, tx_hash {:?}",
+            Ok((tx, spents)) => info!(
+                "UTXO merge of {} outputs successful for coin={ticker}, tx_hash {:?}",
+                spents.len(),
                 tx.hash().reversed()
             ),
             Err(e) => error!("Error on UTXO merge attempt for coin={ticker}: {e}"),

--- a/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
@@ -189,7 +189,7 @@ async fn merge_utxo_loop<T>(
                         // When this happens, this might be due to using HW wallet that its addresses hasn't been polled yet.
                         // Anyway we don't really need a consolidation loop for HW wallets since they can't swap and
                         // such a loop will keep asking for consolidation signatures every now and then.
-                        error!(
+                        covered_error!(
                             "No enabled address found in HD wallet for coin {}",
                             coin.as_ref().conf.ticker
                         );
@@ -200,7 +200,7 @@ async fn merge_utxo_loop<T>(
             let script_pubkey = match output_script(&my_address) {
                 Ok(script) => script,
                 Err(e) => {
-                    error!("Error {} on output_script for coin {}", e, coin.as_ref().conf.ticker);
+                    covered_error!("Error {} on output_script for coin {}", e, coin.as_ref().conf.ticker);
                     return;
                 },
             };

--- a/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
@@ -14,7 +14,6 @@ use async_trait::async_trait;
 use chain::{BlockHeader, Transaction, TransactionOutput};
 use common::executor::{AbortSettings, SpawnAbortable, Timer};
 use common::log::{debug, error, info};
-use common::{fifty, one_hundred};
 use derive_more::Display;
 use futures::compat::Future01CompatExt;
 use keys::Address;
@@ -135,11 +134,18 @@ where
 #[derive(Deserialize)]
 pub struct MergeConditions {
     /// The minimum number of UTXOs to merge. If the number of UTXOs is less than this, the merge will not be performed.
-    #[serde(default = "one_hundred")]
     pub merge_at: usize,
     /// The maximum number of UTXOs to merge at once in a single transaction.
-    #[serde(default = "fifty")]
     pub max_merge_at_once: usize,
+}
+
+impl Default for MergeConditions {
+    fn default() -> Self {
+        MergeConditions {
+            merge_at: 50,
+            max_merge_at_once: 50,
+        }
+    }
 }
 
 /// Merges unspent UTXOs from `from_address` address to `to_script_pubkey` script.

--- a/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
@@ -269,7 +269,7 @@ async fn merge_utxo_loop<T>(
         let ticker = &coin.as_ref().conf.ticker;
         match merge_utxos(&coin, &my_address, &script_pubkey, &merge_conditions, true).await {
             Ok((tx, spents)) => info!(
-                "UTXO merge of {} outputs successful for coin={ticker}, tx_hash {:?}",
+                "UTXO merge of {} outputs successful for coin={ticker}, tx_hash={}",
                 spents.len(),
                 tx.hash().reversed()
             ),

--- a/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
@@ -132,7 +132,7 @@ where
 
 /// Merges unspent UTXOs from `from_address` address to `to_script_pubkey` script.
 /// If `custom_unspents` is provided, it will be used instead of fetching the `from_address` UTXOs from the coin.
-async fn merge_utxos<Coin>(
+pub async fn merge_utxos<Coin>(
     coin: &Coin,
     from_address: &Address,
     to_script_pubkey: &Script,

--- a/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
+++ b/mm2src/coins/utxo/utxo_builder/utxo_arc_builder.rs
@@ -149,6 +149,11 @@ impl Default for MergeConditions {
     }
 }
 
+pub enum UtxoMergeError {
+    BadMergeConditions(String),
+    InternalError(String),
+}
+
 /// Merges unspent UTXOs from `from_address` address to `to_script_pubkey` script.
 pub async fn merge_utxos<Coin>(
     coin: &Coin,
@@ -156,27 +161,29 @@ pub async fn merge_utxos<Coin>(
     to_script_pubkey: &Script,
     merge_conditions: &MergeConditions,
     broadcast: bool,
-) -> MmResult<(Transaction, Vec<UnspentInfo>), String>
+) -> MmResult<(Transaction, Vec<UnspentInfo>), UtxoMergeError>
 where
     Coin: UtxoCommonOps + GetUtxoListOps,
 {
     let ticker = &coin.as_ref().conf.ticker;
-    let (unspents, recently_spent) = coin
-        .get_unspent_ordered_list(from_address)
-        .await
-        .mm_err(|e| format!("Error in get_unspent_ordered_list for coin={ticker}: {e}"))?;
+    let (unspents, recently_spent) = coin.get_unspent_ordered_list(from_address).await.mm_err(|e| {
+        UtxoMergeError::InternalError(format!("Error in get_unspent_ordered_list for coin={ticker}: {e}"))
+    })?;
 
     if unspents.len() < merge_conditions.merge_at {
-        return Err(format!(
+        return Err(UtxoMergeError::BadMergeConditions(format!(
             "Not enough unspent UTXOs to merge for coin={ticker}, found={}, required={}",
             unspents.len(),
             merge_conditions.merge_at
-        )
+        ))
         .into());
     }
     let unspents: Vec<_> = unspents.into_iter().take(merge_conditions.max_merge_at_once).collect();
     if unspents.len() < 2 {
-        return Err(format!("No point of merging only a single UTXO (coin={ticker})").into());
+        return Err(UtxoMergeError::BadMergeConditions(format!(
+            "No point of merging only a single UTXO (coin={ticker})"
+        ))
+        .into());
     }
 
     let value = unspents.iter().fold(0, |sum, unspent| sum + unspent.value);
@@ -195,9 +202,9 @@ where
             vec![output],
         )
         .await
-        .map_to_mm(|e| format!("Error in generate_and_send_tx for coin={ticker}: {e}"))?
+        .map_to_mm(|e| UtxoMergeError::InternalError(format!("Error in generate_and_send_tx for coin={ticker}: {e}")))?
     } else {
-        generate_tx(
+        let (tx, _) = generate_tx(
             coin,
             unspents.clone(),
             None,
@@ -205,8 +212,8 @@ where
             vec![output],
         )
         .await
-        .map_to_mm(|e| format!("Error in generate_tx for coin={ticker}: {e}"))?
-        .0
+        .map_to_mm(|e| UtxoMergeError::InternalError(format!("Error in generate_tx for coin={ticker}: {e}")))?;
+        tx
     };
 
     Ok((tx, unspents))
@@ -272,7 +279,10 @@ async fn merge_utxo_loop<T>(
                 spents.len(),
                 tx.hash().reversed()
             ),
-            Err(e) => error!("Error on UTXO merge attempt for coin={ticker}: {e}"),
+            Err(e) => match e.into_inner() {
+                UtxoMergeError::BadMergeConditions(_) => (), // We don't gotta log any errors here since we provided a bad merge conditions.ƒ
+                UtxoMergeError::InternalError(e) => error!("Error on UTXO merge attempt for coin={ticker}: {e}"),
+            },
         }
     }
 }

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -4059,6 +4059,8 @@ where
 /// `actual_fee = input_amount - actual_output_amount` or `actual_fee = input_amount - output_amount + kmd_rewards`.
 /// Substitute [`TransactionDetails::fee`] to the last equation:
 /// `actual_fee = TransactionDetails::fee + kmd_rewards`
+///
+/// Note: This assumes that the KMD rewards is always claimed by us and thus sets the `claimed_by_me` field to true.
 pub async fn update_kmd_rewards<T>(
     coin: &T,
     tx_details: &mut TransactionDetails,
@@ -4089,14 +4091,7 @@ where
         }));
     }
 
-    // Todo: https://github.com/KomodoPlatform/komodo-defi-framework/issues/1625
-    let my_address = &coin.my_address().map_mm_err()?;
-    let claimed_by_me = tx_details.from.iter().all(|from| from == my_address) && tx_details.to.contains(my_address);
-
-    tx_details.kmd_rewards = Some(KmdRewardsDetails {
-        amount: kmd_rewards,
-        claimed_by_me,
-    });
+    tx_details.kmd_rewards = Some(KmdRewardsDetails::claimed_by_me(kmd_rewards));
     Ok(())
 }
 

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -982,6 +982,10 @@ pub const fn ten_f64() -> f64 {
     10.
 }
 
+pub const fn fifty() -> usize {
+    50
+}
+
 pub const fn one_hundred() -> usize {
     100
 }

--- a/mm2src/common/log.rs
+++ b/mm2src/common/log.rs
@@ -178,8 +178,8 @@ macro_rules! covered_warn {
     };
 }
 
-#[macro_export]
 /// A macro to log errors in production environment and panic in tests.
+#[macro_export]
 macro_rules! covered_error {
     ($($arg:tt)+) => {
         if cfg!(not(test)) {

--- a/mm2src/common/log.rs
+++ b/mm2src/common/log.rs
@@ -178,6 +178,18 @@ macro_rules! covered_warn {
     };
 }
 
+#[macro_export]
+/// A macro to log errors in production environment and panic in tests.
+macro_rules! covered_error {
+    ($($arg:tt)+) => {
+        if cfg!(not(test)) {
+            common::log::error!($($arg)+)
+        } else {
+            panic!($($arg)+)
+        }
+    };
+}
+
 /// Debug logging.
 ///
 /// This logging SHOULD be human-readable but it is not intended for the end users specifically.

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -37,6 +37,7 @@ use coins::my_tx_history_v2::my_tx_history_v2_rpc;
 use coins::rpc_command::{
     account_balance::account_balance,
     consolidate_utxos::consolidate_utxos_rpc,
+    fetch_utxos::fetch_utxos_rpc,
     get_current_mtp::get_current_mtp_rpc,
     get_enabled_coins::get_enabled_coins_rpc,
     get_new_address::{
@@ -53,7 +54,6 @@ use coins::rpc_command::{
     },
     init_withdraw::{cancel_withdraw, init_withdraw, withdraw_status, withdraw_user_action},
     offline_keys::get_private_keys,
-    utxo_count::utxo_count_rpc,
 };
 #[cfg(feature = "enable-sia")]
 use coins::siacoin::SiaCoin;
@@ -237,6 +237,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
             handle_mmrpc(ctx, request, enable_platform_coin_with_tokens::<TendermintCoin>).await
         },
         "enable_tendermint_token" => handle_mmrpc(ctx, request, enable_token::<TendermintToken>).await,
+        "fetch_utxos" => handle_mmrpc(ctx, request, fetch_utxos_rpc).await,
         "get_current_mtp" => handle_mmrpc(ctx, request, get_current_mtp_rpc).await,
         "get_enabled_coins" => handle_mmrpc(ctx, request, get_enabled_coins_rpc).await,
         "get_locked_amount" => handle_mmrpc(ctx, request, get_locked_amount_rpc).await,
@@ -270,7 +271,6 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "trade_preimage" => handle_mmrpc(ctx, request, trade_preimage_rpc).await,
         "trezor_connection_status" => handle_mmrpc(ctx, request, trezor_connection_status).await,
         "update_nft" => handle_mmrpc(ctx, request, update_nft).await,
-        "utxo_count" => handle_mmrpc(ctx, request, utxo_count_rpc).await,
         "change_mnemonic_password" => handle_mmrpc(ctx, request, change_mnemonic_password).await,
         "update_version_stat_collection" => handle_mmrpc(ctx, request, update_version_stat_collection).await,
         "verify_message" => handle_mmrpc(ctx, request, verify_message).await,

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -53,6 +53,7 @@ use coins::rpc_command::{
     },
     init_withdraw::{cancel_withdraw, init_withdraw, withdraw_status, withdraw_user_action},
     offline_keys::get_private_keys,
+    utxo_count::utxo_count_rpc,
 };
 #[cfg(feature = "enable-sia")]
 use coins::siacoin::SiaCoin;
@@ -225,6 +226,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "get_token_allowance" => handle_mmrpc(ctx, request, get_token_allowance_rpc).await,
         "best_orders" => handle_mmrpc(ctx, request, best_orders_rpc_v2).await,
         "clear_nft_db" => handle_mmrpc(ctx, request, clear_nft_db).await,
+        "consolidate_utxos" => handle_mmrpc(ctx, request, consolidate_utxos_rpc).await,
         "delete_wallet" => handle_mmrpc(ctx, request, delete_wallet_rpc).await,
         "enable_bch_with_tokens" => handle_mmrpc(ctx, request, enable_platform_coin_with_tokens::<BchCoin>).await,
         "enable_slp" => handle_mmrpc(ctx, request, enable_token::<SlpToken>).await,
@@ -252,7 +254,6 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "get_token_info" => handle_mmrpc(ctx, request, get_token_info).await,
         "get_wallet_names" => handle_mmrpc(ctx, request, get_wallet_names_rpc).await,
         "max_maker_vol" => handle_mmrpc(ctx, request, max_maker_vol).await,
-        "consolidate_utxos" => handle_mmrpc(ctx, request, consolidate_utxos_rpc).await,
         "my_recent_swaps" => handle_mmrpc(ctx, request, my_recent_swaps_rpc).await,
         "my_swap_status" => handle_mmrpc(ctx, request, my_swap_status_rpc).await,
         "my_tx_history" => handle_mmrpc(ctx, request, my_tx_history_v2_rpc).await,
@@ -269,6 +270,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "trade_preimage" => handle_mmrpc(ctx, request, trade_preimage_rpc).await,
         "trezor_connection_status" => handle_mmrpc(ctx, request, trezor_connection_status).await,
         "update_nft" => handle_mmrpc(ctx, request, update_nft).await,
+        "utxo_count" => handle_mmrpc(ctx, request, utxo_count_rpc).await,
         "change_mnemonic_password" => handle_mmrpc(ctx, request, change_mnemonic_password).await,
         "update_version_stat_collection" => handle_mmrpc(ctx, request, update_version_stat_collection).await,
         "verify_message" => handle_mmrpc(ctx, request, verify_message).await,

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -36,6 +36,7 @@ use coins::eth::EthCoin;
 use coins::my_tx_history_v2::my_tx_history_v2_rpc;
 use coins::rpc_command::{
     account_balance::account_balance,
+    consolidate_utxos::consolidate_utxos_rpc,
     get_current_mtp::get_current_mtp_rpc,
     get_enabled_coins::get_enabled_coins_rpc,
     get_new_address::{
@@ -251,6 +252,7 @@ async fn dispatcher_v2(request: MmRpcRequest, ctx: MmArc) -> DispatcherResult<Re
         "get_token_info" => handle_mmrpc(ctx, request, get_token_info).await,
         "get_wallet_names" => handle_mmrpc(ctx, request, get_wallet_names_rpc).await,
         "max_maker_vol" => handle_mmrpc(ctx, request, max_maker_vol).await,
+        "consolidate_utxos" => handle_mmrpc(ctx, request, consolidate_utxos_rpc).await,
         "my_recent_swaps" => handle_mmrpc(ctx, request, my_recent_swaps_rpc).await,
         "my_swap_status" => handle_mmrpc(ctx, request, my_swap_status_rpc).await,
         "my_tx_history" => handle_mmrpc(ctx, request, my_tx_history_v2_rpc).await,

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -3065,7 +3065,7 @@ fn test_utxo_merge_max_merge_at_once() {
 fn test_consolidate_utxos_rpc() {
     let timeout = 30; // timeout if test takes more than 30 seconds to run
     let utxos = 50;
-    let (_ctx, coin, privkey) = generate_utxo_coin_with_random_privkey("MYCOIN", 0.into());
+    let (_ctx, coin, privkey) = generate_utxo_coin_with_random_privkey("MYCOIN", 1000.into());
 
     // fill several times to have more UTXOs on address
     for i in 1..=utxos {
@@ -3094,9 +3094,9 @@ fn test_consolidate_utxos_rpc() {
 
     let consolidate_rpc = |merge_at: u32, merge_at_once: u32| {
         block_on(mm_bob.rpc(&json!({
+            "mmrpc": "2.0",
             "userpass": mm_bob.userpass,
             "method": "consolidate_utxos",
-            "mm2": 1,
             "params": {
                 "coin": "MYCOIN",
                 "merge_conditions": {
@@ -3108,7 +3108,7 @@ fn test_consolidate_utxos_rpc() {
         .unwrap()
     };
 
-    let res = consolidate_rpc(51, 4);
+    let res = consolidate_rpc(52, 4);
     assert!(!res.0.is_success(), "Expected error for merge_at > utxos: {}", res.1);
 
     let res = consolidate_rpc(30, 4);
@@ -3126,14 +3126,14 @@ fn test_consolidate_utxos_rpc() {
     thread::sleep(Duration::from_secs(2));
     let address = block_on(coin.as_ref().derivation_method.unwrap_single_addr());
     let (unspents, _) = block_on(coin.get_unspent_ordered_list(&address)).unwrap();
-    // We have 50 utxos and merged 4 of them which resulted in an extra one.
-    assert_eq!(unspents.len(), 50 - 4 + 1);
+    // We have 51 utxos and merged 4 of them which resulted in an extra one.
+    assert_eq!(unspents.len(), 51 - 4 + 1);
 }
 
 #[test]
 fn test_fetch_utxos_rpc() {
     let timeout = 30; // timeout if test takes more than 30 seconds to run
-    let (_ctx, coin, privkey) = generate_utxo_coin_with_random_privkey("MYCOIN", 0.into());
+    let (_ctx, coin, privkey) = generate_utxo_coin_with_random_privkey("MYCOIN", 1000.into());
 
     // fill several times to have more UTXOs on address
     for i in 1..=10 {
@@ -3162,9 +3162,9 @@ fn test_fetch_utxos_rpc() {
 
     let fetch_utxo_rpc = || {
         let res = block_on(mm_bob.rpc(&json!({
+            "mmrpc": "2.0",
             "userpass": mm_bob.userpass,
             "method": "fetch_utxos",
-            "mm2": 1,
             "params": {
                 "coin": "MYCOIN"
             }
@@ -3177,13 +3177,13 @@ fn test_fetch_utxos_rpc() {
     };
 
     let res = fetch_utxo_rpc();
-    assert!(res.utxos.len() == 10);
+    assert!(res.utxos.len() == 11);
 
     fill_address(&coin, &coin.my_address().unwrap(), 100.into(), timeout);
     thread::sleep(Duration::from_secs(2));
 
     let res = fetch_utxo_rpc();
-    assert!(res.utxos.len() == 11);
+    assert!(res.utxos.len() == 12);
     assert!(res.utxos.iter().any(|utxo| utxo.value == 100.into()));
 }
 

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -3102,7 +3102,8 @@ fn test_consolidate_utxos_rpc() {
                 "merge_conditions": {
                     "merge_at": merge_at,
                     "max_merge_at_once": merge_at_once,
-                }
+                },
+                "broadcast": true
             }
         })))
         .unwrap()

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -2996,7 +2996,7 @@ fn test_utxo_merge() {
     block_on(mm_bob.wait_for_log(4., |log| log.contains("Starting UTXO merge loop for coin MYCOIN"))).unwrap();
 
     block_on(mm_bob.wait_for_log(4., |log| {
-        log.contains("UTXO merge of 5 outputs successful for coin MYCOIN, tx_hash")
+        log.contains("UTXO merge of 5 outputs successful for coin=MYCOIN, tx_hash")
     }))
     .unwrap();
 
@@ -3052,7 +3052,7 @@ fn test_utxo_merge_max_merge_at_once() {
     block_on(mm_bob.wait_for_log(4., |log| log.contains("Starting UTXO merge loop for coin MYCOIN"))).unwrap();
 
     block_on(mm_bob.wait_for_log(4., |log| {
-        log.contains("UTXO merge of 4 outputs successful for coin MYCOIN, tx_hash")
+        log.contains("UTXO merge of 4 outputs successful for coin=MYCOIN, tx_hash")
     }))
     .unwrap();
 

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -2995,9 +2995,10 @@ fn test_utxo_merge() {
 
     block_on(mm_bob.wait_for_log(4., |log| log.contains("Starting UTXO merge loop for coin MYCOIN"))).unwrap();
 
-    block_on(mm_bob.wait_for_log(4., |log| log.contains("Trying to merge 5 UTXOs of coin MYCOIN"))).unwrap();
-
-    block_on(mm_bob.wait_for_log(4., |log| log.contains("UTXO merge successful for coin MYCOIN, tx_hash"))).unwrap();
+    block_on(mm_bob.wait_for_log(4., |log| {
+        log.contains("UTXO merge of 5 outputs successful for coin MYCOIN, tx_hash")
+    }))
+    .unwrap();
 
     thread::sleep(Duration::from_secs(2));
     let address = block_on(coin.as_ref().derivation_method.unwrap_single_addr());
@@ -3050,9 +3051,10 @@ fn test_utxo_merge_max_merge_at_once() {
 
     block_on(mm_bob.wait_for_log(4., |log| log.contains("Starting UTXO merge loop for coin MYCOIN"))).unwrap();
 
-    block_on(mm_bob.wait_for_log(4., |log| log.contains("Trying to merge 4 UTXOs of coin MYCOIN"))).unwrap();
-
-    block_on(mm_bob.wait_for_log(4., |log| log.contains("UTXO merge successful for coin MYCOIN, tx_hash"))).unwrap();
+    block_on(mm_bob.wait_for_log(4., |log| {
+        log.contains("UTXO merge of 4 outputs successful for coin MYCOIN, tx_hash")
+    }))
+    .unwrap();
 
     thread::sleep(Duration::from_secs(2));
     let address = block_on(coin.as_ref().derivation_method.unwrap_single_addr());

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -3062,6 +3062,132 @@ fn test_utxo_merge_max_merge_at_once() {
 }
 
 #[test]
+fn test_consolidate_utxos_rpc() {
+    let timeout = 30; // timeout if test takes more than 30 seconds to run
+    let utxos = 50;
+    let (_ctx, coin, privkey) = generate_utxo_coin_with_random_privkey("MYCOIN", 0.into());
+
+    // fill several times to have more UTXOs on address
+    for i in 1..=utxos {
+        fill_address(&coin, &coin.my_address().unwrap(), i.into(), timeout);
+    }
+
+    let coins = json!([mycoin_conf(1000)]);
+    let mm_bob = MarketMakerIt::start(
+        json!({
+            "gui": "nogui",
+            "netid": 9000,
+            "dht": "on",  // Enable DHT without delay.
+            "passphrase": format!("0x{}", hex::encode(privkey)),
+            "coins": coins,
+            "rpc_password": "pass",
+            "i_am_seed": true,
+            "is_bootstrap_node": true
+        }),
+        "pass".to_string(),
+        None,
+    )
+    .unwrap();
+    let (_bob_dump_log, _bob_dump_dashboard) = mm_dump(&mm_bob.log_path);
+
+    log!("{:?}", block_on(enable_native(&mm_bob, "MYCOIN", &[], None)));
+
+    let consolidate_rpc = |merge_at: u32, merge_at_once: u32| {
+        block_on(mm_bob.rpc(&json!({
+            "userpass": mm_bob.userpass,
+            "method": "consolidate_utxos",
+            "mm2": 1,
+            "params": {
+                "coin": "MYCOIN",
+                "merge_conditions": {
+                    "merge_at": merge_at,
+                    "max_merge_at_once": merge_at_once,
+                }
+            }
+        })))
+        .unwrap()
+    };
+
+    let res = consolidate_rpc(51, 4);
+    assert!(!res.0.is_success(), "Expected error for merge_at > utxos: {}", res.1);
+
+    let res = consolidate_rpc(30, 4);
+    assert!(res.0.is_success(), "Consolidate utxos failed: {}", res.1);
+
+    let res: RpcSuccessResponse<ConsolidateUtxoResponse> =
+        serde_json::from_str(&res.1).expect("Expected 'RpcSuccessResponse<ConsolidateUtxoResponse>'");
+    // Assert that we respected `max_merge_at_once` and merged only 4 UTXOs.
+    assert_eq!(res.result.consolidated_utxos.len(), 4);
+    // Assert that we merged the smallest 4 UTXOs.
+    for i in 1..=4 {
+        assert_eq!(res.result.consolidated_utxos[i - 1].value, (i as u32).into());
+    }
+
+    thread::sleep(Duration::from_secs(2));
+    let address = block_on(coin.as_ref().derivation_method.unwrap_single_addr());
+    let (unspents, _) = block_on(coin.get_unspent_ordered_list(&address)).unwrap();
+    // We have 50 utxos and merged 4 of them which resulted in an extra one.
+    assert_eq!(unspents.len(), 50 - 4 + 1);
+}
+
+#[test]
+fn test_fetch_utxos_rpc() {
+    let timeout = 30; // timeout if test takes more than 30 seconds to run
+    let (_ctx, coin, privkey) = generate_utxo_coin_with_random_privkey("MYCOIN", 0.into());
+
+    // fill several times to have more UTXOs on address
+    for i in 1..=10 {
+        fill_address(&coin, &coin.my_address().unwrap(), i.into(), timeout);
+    }
+
+    let coins = json!([mycoin_conf(1000)]);
+    let mm_bob = MarketMakerIt::start(
+        json!({
+            "gui": "nogui",
+            "netid": 9000,
+            "dht": "on",  // Enable DHT without delay.
+            "passphrase": format!("0x{}", hex::encode(privkey)),
+            "coins": coins,
+            "rpc_password": "pass",
+            "i_am_seed": true,
+            "is_bootstrap_node": true
+        }),
+        "pass".to_string(),
+        None,
+    )
+    .unwrap();
+    let (_bob_dump_log, _bob_dump_dashboard) = mm_dump(&mm_bob.log_path);
+
+    log!("{:?}", block_on(enable_native(&mm_bob, "MYCOIN", &[], None)));
+
+    let fetch_utxo_rpc = || {
+        let res = block_on(mm_bob.rpc(&json!({
+            "userpass": mm_bob.userpass,
+            "method": "fetch_utxos",
+            "mm2": 1,
+            "params": {
+                "coin": "MYCOIN"
+            }
+        })))
+        .unwrap();
+        assert!(res.0.is_success(), "Fetch UTXOs failed: {}", res.1);
+        let res: RpcSuccessResponse<FetchUtxosResponse> =
+            serde_json::from_str(&res.1).expect("Expected 'RpcSuccessResponse<FetchUtxosResponse>'");
+        res.result
+    };
+
+    let res = fetch_utxo_rpc();
+    assert!(res.utxos.len() == 10);
+
+    fill_address(&coin, &coin.my_address().unwrap(), 100.into(), timeout);
+    thread::sleep(Duration::from_secs(2));
+
+    let res = fetch_utxo_rpc();
+    assert!(res.utxos.len() == 11);
+    assert!(res.utxos.iter().any(|utxo| utxo.value == 100.into()));
+}
+
+#[test]
 fn test_withdraw_not_sufficient_balance() {
     let privkey = random_secp256k1_secret();
     let coins = json!([mycoin_conf(1000), mycoin1_conf(1000)]);

--- a/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
+++ b/mm2src/mm2_main/tests/docker_tests/docker_tests_inner.rs
@@ -3177,14 +3177,14 @@ fn test_fetch_utxos_rpc() {
     };
 
     let res = fetch_utxo_rpc();
-    assert!(res.utxos.len() == 11);
+    assert!(res.total_count == 11);
 
     fill_address(&coin, &coin.my_address().unwrap(), 100.into(), timeout);
     thread::sleep(Duration::from_secs(2));
 
     let res = fetch_utxo_rpc();
-    assert!(res.utxos.len() == 12);
-    assert!(res.utxos.iter().any(|utxo| utxo.value == 100.into()));
+    assert!(res.total_count == 12);
+    assert!(res.addresses[0].utxos.iter().any(|utxo| utxo.value == 100.into()));
 }
 
 #[test]

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -1229,3 +1229,21 @@ pub struct TokenInfoResponse {
     #[serde(flatten)]
     pub info: TokenInfo,
 }
+
+#[derive(Debug, Deserialize)]
+pub struct SpentUtxo {
+    pub outpoint: String,
+    pub value: BigDecimal,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ConsolidateUtxoResponse {
+    pub tx: TransactionDetails,
+    pub consolidated_utxos: Vec<SpentUtxo>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FetchUtxosResponse {
+    pub address: String,
+    pub utxos: Vec<SpentUtxo>,
+}

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -1232,7 +1232,8 @@ pub struct TokenInfoResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct SpentUtxo {
-    pub outpoint: String,
+    pub txid: String,
+    pub vout: u32,
     pub value: BigDecimal,
 }
 

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -1243,7 +1243,15 @@ pub struct ConsolidateUtxoResponse {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct FetchUtxosResponse {
+pub struct AddressUtxos {
     pub address: String,
+    pub count: usize,
     pub utxos: Vec<SpentUtxo>,
+    pub derivation_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FetchUtxosResponse {
+    pub total_count: usize,
+    pub addresses: Vec<AddressUtxos>,
 }


### PR DESCRIPTION
This PR introduces a `consolidate_utxos` RPC that sends all the utxos of the utxo coin's address to itself for the sake of consolidation.

sample request

```json
{
    "method": "consolidate_utxos",
    "userpass": "{{userpass}}",
    "mmrpc": "2.0",
    "params": {
        "coin": "BTC"
        "merge_conditions": {
            "merge_at": 20, // will only perform the merge if we have 20 lone utxos (defaults to 100)
            "max_merge_at_once": 40, // will only merge the smallest 40 utxos (defaults to 50)
        },
        "broadcast": true, // whether to broadcast the consolidation tx or not (false by default)
    }
}
```

the transaction details should be returned upon succeeding.