### PR TITLE
fix(clippy): fix clippy warnings for #2565

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5111,7 +5111,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote 1.0.37",
- "syn 2.0.77",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/mm2src/trezor/src/proto/messages_ethereum.rs
+++ b/mm2src/trezor/src/proto/messages_ethereum.rs
@@ -1,3 +1,5 @@
+// Generated protocol messages; many types are not instantiated in our build.
+#![allow(dead_code)]
 ///*
 /// Request: Ask device for Ethereum address corresponding to address_n path
 /// @start


### PR DESCRIPTION
Fix failing lint and fmt job in dev. Also fixes cargo.lock