### PR TITLE
improvement(`static mut`s): `static mut` removal

### DIFF
--- a/mm2src/common/executor/abortable_system/simple_map.rs
+++ b/mm2src/common/executor/abortable_system/simple_map.rs
@@ -147,14 +147,16 @@ impl<FutureId: FutureIdTrait> SimpleMapInnerState<FutureId> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use super::*;
     use crate::block_on;
     use crate::executor::Timer;
 
     #[test]
     fn test_abort_all() {
-        static mut F1_FINISHED: bool = false;
-        static mut F2_FINISHED: bool = false;
+        static F1_FINISHED: AtomicBool = AtomicBool::new(false);
+        static F2_FINISHED: AtomicBool = AtomicBool::new(false);
 
         let abortable_system = AbortableSimpleMap::default();
         let mut guard = abortable_system.lock();
@@ -162,7 +164,7 @@ mod tests {
         guard
             .spawn_or_ignore("F1".to_string(), async move {
                 Timer::sleep(0.1).await;
-                unsafe { F1_FINISHED = true };
+                F1_FINISHED.store(true, Ordering::Relaxed);
             })
             .unwrap();
         assert_eq!(guard.contains("F1"), Ok(true));
@@ -170,7 +172,7 @@ mod tests {
         guard
             .spawn_or_ignore("F2".to_string(), async move {
                 Timer::sleep(0.5).await;
-                unsafe { F2_FINISHED = true };
+                F2_FINISHED.store(true, Ordering::Relaxed);
             })
             .unwrap();
 
@@ -179,15 +181,13 @@ mod tests {
         abortable_system.abort_all().unwrap();
         block_on(Timer::sleep(0.4));
 
-        unsafe {
-            assert!(F1_FINISHED);
-            assert!(!F2_FINISHED);
-        }
+        assert!(F1_FINISHED.load(Ordering::Relaxed));
+        assert!(!F2_FINISHED.load(Ordering::Relaxed));
     }
 
     #[test]
     fn test_abort_future() {
-        static mut F1_FINISHED: bool = false;
+        static F1_FINISHED: AtomicBool = AtomicBool::new(false);
 
         let abortable_system = AbortableSimpleMap::default();
         let mut guard = abortable_system.lock();
@@ -195,7 +195,7 @@ mod tests {
         guard
             .spawn_or_ignore("F1".to_string(), async move {
                 Timer::sleep(0.2).await;
-                unsafe { F1_FINISHED = true };
+                F1_FINISHED.store(true, Ordering::Relaxed);
             })
             .unwrap();
 
@@ -208,35 +208,31 @@ mod tests {
 
         block_on(Timer::sleep(0.3));
 
-        unsafe {
-            assert!(!F1_FINISHED);
-        }
+        assert!(!F1_FINISHED.load(Ordering::Relaxed));
     }
 
     #[test]
     fn test_spawn_twice() {
-        static mut F1_FINISHED: bool = false;
-        static mut F1_COPY_FINISHED: bool = false;
+        static F1_FINISHED: AtomicBool = AtomicBool::new(false);
+        static F1_COPY_FINISHED: AtomicBool = AtomicBool::new(false);
 
         let abortable_system = AbortableSimpleMap::default();
         let mut guard = abortable_system.lock();
 
         let fut_1 = async move {
-            unsafe { F1_FINISHED = true };
+            F1_FINISHED.store(true, Ordering::Relaxed);
         };
         guard.spawn_or_ignore("F1".to_string(), fut_1).unwrap();
 
         let fut_2 = async move {
-            unsafe { F1_COPY_FINISHED = true };
+            F1_COPY_FINISHED.store(true, Ordering::Relaxed);
         };
         guard.spawn_or_ignore("F1".to_string(), fut_2).unwrap();
 
         drop(guard);
         block_on(Timer::sleep(0.1));
 
-        unsafe {
-            assert!(F1_FINISHED);
-            assert!(!F1_COPY_FINISHED);
-        }
+        assert!(F1_FINISHED.load(Ordering::Relaxed));
+        assert!(!F1_COPY_FINISHED.load(Ordering::Relaxed));
     }
 }

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -2978,6 +2978,8 @@ pub fn max_taker_vol_from_available(
 
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod taker_swap_tests {
+    use std::sync::atomic::AtomicUsize;
+
     use super::*;
     use crate::lp_swap::get_locked_amount_by_other_swaps;
     use coins::eth::{addr_from_str, signed_eth_tx_from_bytes, SignedEthTx};
@@ -3017,9 +3019,9 @@ mod taker_swap_tests {
         TestCoin::ticker.mock_safe(|_| MockResult::Return("ticker"));
         TestCoin::swap_contract_address.mock_safe(|_| MockResult::Return(None));
 
-        static mut MAKER_PAYMENT_SPEND_CALLED: bool = false;
+        static MAKER_PAYMENT_SPEND_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::send_taker_spends_maker_payment.mock_safe(|_, _| {
-            unsafe { MAKER_PAYMENT_SPEND_CALLED = true };
+            MAKER_PAYMENT_SPEND_CALLED.store(true, Ordering::Relaxed);
             MockResult::Return(Box::pin(futures::future::ready(Ok(eth_tx_for_test().into()))))
         });
         TestCoin::search_for_swap_tx_spend_other
@@ -3040,7 +3042,7 @@ mod taker_swap_tests {
             transaction: eth_tx_for_test().into(),
         };
         assert_eq!(expected, actual);
-        assert!(unsafe { MAKER_PAYMENT_SPEND_CALLED });
+        assert!(MAKER_PAYMENT_SPEND_CALLED.load(Ordering::Relaxed));
     }
 
     #[test]
@@ -3055,21 +3057,21 @@ mod taker_swap_tests {
         TestCoin::can_refund_htlc
             .mock_safe(|_, _| MockResult::Return(Box::pin(futures::future::ok(CanRefundHtlc::CanRefundNow))));
 
-        static mut MY_PAYMENT_SENT_CALLED: bool = false;
+        static MY_PAYMENT_SENT_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::check_if_my_payment_sent.mock_safe(|_, _| {
-            unsafe { MY_PAYMENT_SENT_CALLED = true };
+            MY_PAYMENT_SENT_CALLED.store(true, Ordering::Relaxed);
             MockResult::Return(Box::pin(futures::future::ok(Some(eth_tx_for_test().into()))))
         });
 
-        static mut TX_SPEND_CALLED: bool = false;
+        static TX_SPEND_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::search_for_swap_tx_spend_my.mock_safe(|_, _| {
-            unsafe { TX_SPEND_CALLED = true };
+            TX_SPEND_CALLED.store(true, Ordering::Relaxed);
             MockResult::Return(Box::pin(futures::future::ready(Ok(None))))
         });
 
-        static mut TAKER_PAYMENT_REFUND_CALLED: bool = false;
+        static TAKER_PAYMENT_REFUND_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::send_taker_refunds_payment.mock_safe(|_, _| {
-            unsafe { TAKER_PAYMENT_REFUND_CALLED = true };
+            TAKER_PAYMENT_REFUND_CALLED.store(true, Ordering::Relaxed);
             MockResult::Return(Box::pin(futures::future::ok(eth_tx_for_test().into())))
         });
         let maker_coin = MmCoinEnum::Test(TestCoin::default());
@@ -3088,9 +3090,9 @@ mod taker_swap_tests {
             transaction: eth_tx_for_test().into(),
         };
         assert_eq!(expected, actual);
-        assert!(unsafe { MY_PAYMENT_SENT_CALLED });
-        assert!(unsafe { TX_SPEND_CALLED });
-        assert!(unsafe { TAKER_PAYMENT_REFUND_CALLED });
+        assert!(MY_PAYMENT_SENT_CALLED.load(Ordering::Relaxed));
+        assert!(TX_SPEND_CALLED.load(Ordering::Relaxed));
+        assert!(TAKER_PAYMENT_REFUND_CALLED.load(Ordering::Relaxed));
     }
 
     #[test]
@@ -3104,15 +3106,15 @@ mod taker_swap_tests {
         TestCoin::swap_contract_address.mock_safe(|_| MockResult::Return(None));
         TestCoin::extract_secret.mock_safe(|_, _, _, _| MockResult::Return(Box::pin(async move { Ok([0; 32]) })));
 
-        static mut MY_PAYMENT_SENT_CALLED: bool = false;
+        static MY_PAYMENT_SENT_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::check_if_my_payment_sent.mock_safe(|_, _| {
-            unsafe { MY_PAYMENT_SENT_CALLED = true };
+            MY_PAYMENT_SENT_CALLED.store(true, Ordering::Relaxed);
             MockResult::Return(Box::pin(futures::future::ok(Some(eth_tx_for_test().into()))))
         });
 
-        static mut SEARCH_TX_SPEND_CALLED: bool = false;
+        static SEARCH_TX_SPEND_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::search_for_swap_tx_spend_my.mock_safe(|_, _| {
-            unsafe { SEARCH_TX_SPEND_CALLED = true };
+            SEARCH_TX_SPEND_CALLED.store(true, Ordering::Relaxed);
             let tx: UtxoTx = "0100000001de7aa8d29524906b2b54ee2e0281f3607f75662cbc9080df81d1047b78e21dbc00000000d7473044022079b6c50820040b1fbbe9251ced32ab334d33830f6f8d0bf0a40c7f1336b67d5b0220142ccf723ddabb34e542ed65c395abc1fbf5b6c3e730396f15d25c49b668a1a401209da937e5609680cb30bff4a7661364ca1d1851c2506fa80c443f00a3d3bf7365004c6b6304f62b0e5cb175210270e75970bb20029b3879ec76c4acd320a8d0589e003636264d01a7d566504bfbac6782012088a9142fb610d856c19fd57f2d0cffe8dff689074b3d8a882103f368228456c940ac113e53dad5c104cf209f2f102a409207269383b6ab9b03deac68ffffffff01d0dc9800000000001976a9146d9d2b554d768232320587df75c4338ecc8bf37d88ac40280e5c".into();
             MockResult::Return(Box::pin(futures::future::ready(Ok(Some(FoundSwapTxSpend::Spent(tx.into()))))))
         });
@@ -3120,9 +3122,9 @@ mod taker_swap_tests {
         TestCoin::search_for_swap_tx_spend_other
             .mock_safe(|_, _| MockResult::Return(Box::pin(futures::future::ready(Ok(None)))));
 
-        static mut MAKER_PAYMENT_SPEND_CALLED: bool = false;
+        static MAKER_PAYMENT_SPEND_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::send_taker_spends_maker_payment.mock_safe(|_, _| {
-            unsafe { MAKER_PAYMENT_SPEND_CALLED = true };
+            MAKER_PAYMENT_SPEND_CALLED.store(true, Ordering::Relaxed);
             MockResult::Return(Box::pin(futures::future::ready(Ok(eth_tx_for_test().into()))))
         });
         let maker_coin = MmCoinEnum::Test(TestCoin::default());
@@ -3141,9 +3143,9 @@ mod taker_swap_tests {
             transaction: eth_tx_for_test().into(),
         };
         assert_eq!(expected, actual);
-        assert!(unsafe { MY_PAYMENT_SENT_CALLED });
-        assert!(unsafe { SEARCH_TX_SPEND_CALLED });
-        assert!(unsafe { MAKER_PAYMENT_SPEND_CALLED });
+        assert!(MY_PAYMENT_SENT_CALLED.load(Ordering::Relaxed));
+        assert!(SEARCH_TX_SPEND_CALLED.load(Ordering::Relaxed));
+        assert!(MAKER_PAYMENT_SPEND_CALLED.load(Ordering::Relaxed));
     }
 
     #[test]
@@ -3158,15 +3160,15 @@ mod taker_swap_tests {
         TestCoin::can_refund_htlc
             .mock_safe(|_, _| MockResult::Return(Box::pin(futures::future::ok(CanRefundHtlc::CanRefundNow))));
 
-        static mut SEARCH_TX_SPEND_CALLED: bool = false;
+        static SEARCH_TX_SPEND_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::search_for_swap_tx_spend_my.mock_safe(|_, _| {
-            unsafe { SEARCH_TX_SPEND_CALLED = true };
+            SEARCH_TX_SPEND_CALLED.store(true, Ordering::Relaxed);
             MockResult::Return(Box::pin(futures::future::ready(Ok(None))))
         });
 
-        static mut REFUND_CALLED: bool = false;
+        static REFUND_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::send_taker_refunds_payment.mock_safe(|_, _| {
-            unsafe { REFUND_CALLED = true };
+            REFUND_CALLED.store(true, Ordering::Relaxed);
             MockResult::Return(Box::pin(futures::future::ok(eth_tx_for_test().into())))
         });
         let maker_coin = MmCoinEnum::Test(TestCoin::default());
@@ -3185,8 +3187,8 @@ mod taker_swap_tests {
             transaction: eth_tx_for_test().into(),
         };
         assert_eq!(expected, actual);
-        assert!(unsafe { SEARCH_TX_SPEND_CALLED });
-        assert!(unsafe { REFUND_CALLED });
+        assert!(SEARCH_TX_SPEND_CALLED.load(Ordering::Relaxed));
+        assert!(REFUND_CALLED.load(Ordering::Relaxed));
     }
 
     #[test]
@@ -3201,9 +3203,9 @@ mod taker_swap_tests {
         TestCoin::can_refund_htlc
             .mock_safe(|_, _| MockResult::Return(Box::pin(futures::future::ok(CanRefundHtlc::HaveToWait(1000)))));
 
-        static mut SEARCH_TX_SPEND_CALLED: bool = false;
+        static SEARCH_TX_SPEND_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::search_for_swap_tx_spend_my.mock_safe(|_, _| {
-            unsafe { SEARCH_TX_SPEND_CALLED = true };
+            SEARCH_TX_SPEND_CALLED.store(true, Ordering::Relaxed);
             MockResult::Return(Box::pin(futures::future::ready(Ok(None))))
         });
         let maker_coin = MmCoinEnum::Test(TestCoin::default());
@@ -3217,7 +3219,7 @@ mod taker_swap_tests {
         .unwrap();
         let error = block_on(taker_swap.recover_funds()).unwrap_err();
         assert!(error.contains("Too early to refund"));
-        assert!(unsafe { SEARCH_TX_SPEND_CALLED });
+        assert!(SEARCH_TX_SPEND_CALLED.load(Ordering::Relaxed));
     }
 
     #[test]
@@ -3231,9 +3233,9 @@ mod taker_swap_tests {
         TestCoin::swap_contract_address.mock_safe(|_| MockResult::Return(None));
         TestCoin::extract_secret.mock_safe(|_, _, _, _| MockResult::Return(Box::pin(async move { Ok([0; 32]) })));
 
-        static mut SEARCH_TX_SPEND_CALLED: bool = false;
+        static SEARCH_TX_SPEND_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::search_for_swap_tx_spend_my.mock_safe(|_, _| {
-            unsafe { SEARCH_TX_SPEND_CALLED = true };
+            SEARCH_TX_SPEND_CALLED.store(true, Ordering::Relaxed);
             let tx: UtxoTx = "0100000001de7aa8d29524906b2b54ee2e0281f3607f75662cbc9080df81d1047b78e21dbc00000000d7473044022079b6c50820040b1fbbe9251ced32ab334d33830f6f8d0bf0a40c7f1336b67d5b0220142ccf723ddabb34e542ed65c395abc1fbf5b6c3e730396f15d25c49b668a1a401209da937e5609680cb30bff4a7661364ca1d1851c2506fa80c443f00a3d3bf7365004c6b6304f62b0e5cb175210270e75970bb20029b3879ec76c4acd320a8d0589e003636264d01a7d566504bfbac6782012088a9142fb610d856c19fd57f2d0cffe8dff689074b3d8a882103f368228456c940ac113e53dad5c104cf209f2f102a409207269383b6ab9b03deac68ffffffff01d0dc9800000000001976a9146d9d2b554d768232320587df75c4338ecc8bf37d88ac40280e5c".into();
             MockResult::Return(Box::pin(futures::future::ready(Ok(Some(FoundSwapTxSpend::Spent(tx.into()))))))
         });
@@ -3241,9 +3243,9 @@ mod taker_swap_tests {
         TestCoin::search_for_swap_tx_spend_other
             .mock_safe(|_, _| MockResult::Return(Box::pin(futures::future::ready(Ok(None)))));
 
-        static mut MAKER_PAYMENT_SPEND_CALLED: bool = false;
+        static MAKER_PAYMENT_SPEND_CALLED: AtomicBool = AtomicBool::new(false);
         TestCoin::send_taker_spends_maker_payment.mock_safe(|_, _| {
-            unsafe { MAKER_PAYMENT_SPEND_CALLED = true };
+            MAKER_PAYMENT_SPEND_CALLED.store(true, Ordering::Relaxed);
             MockResult::Return(Box::pin(futures::future::ready(Ok(eth_tx_for_test().into()))))
         });
         let maker_coin = MmCoinEnum::Test(TestCoin::default());
@@ -3262,8 +3264,8 @@ mod taker_swap_tests {
             transaction: eth_tx_for_test().into(),
         };
         assert_eq!(expected, actual);
-        assert!(unsafe { SEARCH_TX_SPEND_CALLED });
-        assert!(unsafe { MAKER_PAYMENT_SPEND_CALLED });
+        assert!(SEARCH_TX_SPEND_CALLED.load(Ordering::Relaxed));
+        assert!(MAKER_PAYMENT_SPEND_CALLED.load(Ordering::Relaxed));
     }
 
     #[test]
@@ -3312,9 +3314,9 @@ mod taker_swap_tests {
         let taker_saved_swap: TakerSavedSwap = json::from_str(taker_saved_json).unwrap();
 
         TestCoin::ticker.mock_safe(|_| MockResult::Return("ticker"));
-        static mut SWAP_CONTRACT_ADDRESS_CALLED: usize = 0;
+        static SWAP_CONTRACT_ADDRESS_CALLED: AtomicUsize = AtomicUsize::new(0);
         TestCoin::swap_contract_address.mock_safe(|_| {
-            unsafe { SWAP_CONTRACT_ADDRESS_CALLED += 1 };
+            SWAP_CONTRACT_ADDRESS_CALLED.fetch_add(1, Ordering::Relaxed);
             MockResult::Return(Some(BytesJson::default()))
         });
         let maker_coin = MmCoinEnum::Test(TestCoin::default());
@@ -3327,7 +3329,7 @@ mod taker_swap_tests {
         ))
         .unwrap();
 
-        assert_eq!(unsafe { SWAP_CONTRACT_ADDRESS_CALLED }, 2);
+        assert_eq!(SWAP_CONTRACT_ADDRESS_CALLED.load(Ordering::Relaxed), 2);
         assert_eq!(
             taker_swap.r().data.maker_coin_swap_contract_address,
             Some(BytesJson::default())
@@ -3347,9 +3349,9 @@ mod taker_swap_tests {
         let taker_saved_swap: TakerSavedSwap = json::from_str(taker_saved_json).unwrap();
 
         TestCoin::ticker.mock_safe(|_| MockResult::Return("ticker"));
-        static mut SWAP_CONTRACT_ADDRESS_CALLED: usize = 0;
+        static SWAP_CONTRACT_ADDRESS_CALLED: AtomicUsize = AtomicUsize::new(0);
         TestCoin::swap_contract_address.mock_safe(|_| {
-            unsafe { SWAP_CONTRACT_ADDRESS_CALLED += 1 };
+            SWAP_CONTRACT_ADDRESS_CALLED.fetch_add(1, Ordering::Relaxed);
             MockResult::Return(Some(BytesJson::default()))
         });
         let maker_coin = MmCoinEnum::Test(TestCoin::default());
@@ -3362,7 +3364,7 @@ mod taker_swap_tests {
         ))
         .unwrap();
 
-        assert_eq!(unsafe { SWAP_CONTRACT_ADDRESS_CALLED }, 1);
+        assert_eq!(SWAP_CONTRACT_ADDRESS_CALLED.load(Ordering::Relaxed), 1);
         let expected_addr = addr_from_str(ETH_SEPOLIA_SWAP_CONTRACT).unwrap();
         let expected = BytesJson::from(expected_addr.0.as_ref());
         assert_eq!(taker_swap.r().data.maker_coin_swap_contract_address, Some(expected));


### PR DESCRIPTION
Removes static mutable variables. Ones in the docker tests are used in so many places and requires a massive change/diff, I skipped them in this PR.

Resolves #2520 mostly (apart from docker tests).