### PR TITLE
fix(orderbook): validate roots before commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Test
         run: |
           wget -O - https://raw.githubusercontent.com/KomodoPlatform/komodo/635112d590618165a152dfa0f31e95a9be39a8f6/zcutil/fetch-params-alt.sh | bash
-          cargo test --test 'mm2_tests_main' --no-fail-fast
+          cargo test --test 'mm2_tests_main' --features for-tests --no-fail-fast
 
   mac-x86-64-kdf-integration:
     timeout-minutes: 90
@@ -155,7 +155,7 @@ jobs:
       - name: Test
         run: |
           wget -O - https://raw.githubusercontent.com/KomodoPlatform/komodo/635112d590618165a152dfa0f31e95a9be39a8f6/zcutil/fetch-params-alt.sh | bash
-          cargo test --test 'mm2_tests_main' --no-fail-fast
+          cargo test --test 'mm2_tests_main' --features for-tests --no-fail-fast
 
   win-x86-64-kdf-integration:
     timeout-minutes: 90
@@ -191,7 +191,7 @@ jobs:
       - name: Test
         run: |
           Invoke-WebRequest -Uri https://raw.githubusercontent.com/KomodoPlatform/komodo/635112d590618165a152dfa0f31e95a9be39a8f6/zcutil/fetch-params-alt.bat -OutFile \cmd.bat && \cmd.bat
-          cargo test --test 'mm2_tests_main' --no-fail-fast
+          cargo test --test 'mm2_tests_main' --features for-tests --no-fail-fast
 
   docker-tests:
     timeout-minutes: 90

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -17,7 +17,7 @@ custom-swap-locktime = [] # only for testing purposes, should never be activated
 native = [] # Deprecated
 track-ctx-pointer = ["common/track-ctx-pointer"]
 zhtlc-native-tests = ["coins/zhtlc-native-tests"]
-run-docker-tests = ["coins/run-docker-tests"]
+run-docker-tests = ["for-tests", "coins/run-docker-tests"]
 default = []
 trezor-udp = ["crypto/trezor-udp"] # use for tests to connect to trezor emulator over udp
 run-device-tests = []
@@ -29,7 +29,12 @@ new-db-arch = ["mm2_core/new-db-arch"] # A temporary feature to integrate the ne
 # Temporary feature for implementing IBC wrap/unwrap mechanism and will be removed
 # once we consider it as stable.
 ibc-routing-for-swaps = []
-for-tests = []
+for-tests = [
+    "coins/for-tests",
+    "coins_activation/for-tests",
+    "common/for-tests",
+    "trading_api/for-tests"
+]
 
 [dependencies]
 async-std = { workspace = true, features = ["unstable"] }
@@ -155,4 +160,14 @@ chrono.workspace = true
 gstuff.workspace = true
 prost-build = { version = "0.12", default-features = false }
 regex.workspace = true
+
+[[test]]
+name = "docker_tests_main"
+path = "tests/docker_tests_main.rs"
+required-features = ["run-docker-tests"]
+
+[[test]]
+name = "mm2_tests_main"
+path = "tests/mm2_tests_main.rs"
+required-features = ["for-tests"]
 

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -3874,7 +3874,6 @@ pub async fn lp_ordermatch_loop(ctx: MmArc) {
         .expect("CryptoCtx not available")
         .mm2_internal_pubkey_hex();
 
-    let maker_order_timeout = ctx.conf["maker_order_timeout"].as_u64().unwrap_or(MAKER_ORDER_TIMEOUT);
     loop {
         if ctx.is_stopping() {
             break;
@@ -3906,7 +3905,7 @@ pub async fn lp_ordermatch_loop(ctx: MmArc) {
             for (pubkey, state) in orderbook.pubkeys_state.iter() {
                 let is_ours = orderbook.my_p2p_pubkeys.contains(pubkey);
                 let to_keep =
-                    pubkey == &my_pubsecp || is_ours || state.last_keep_alive + maker_order_timeout > now_sec();
+                    pubkey == &my_pubsecp || is_ours || state.last_keep_alive + MAKER_ORDER_TIMEOUT > now_sec();
                 if !to_keep {
                     for (uuid, _) in &state.orders_uuids {
                         uuids_to_remove.push(*uuid);

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -494,7 +494,7 @@ async fn process_orders_keep_alive(
     match (fully_synced, state.is_synced) {
         (true, false) => {
             state.is_synced = true;
-            log::debug!("Marked pubkey {} as fully synced", from_pubkey);
+            log::info!("Marked pubkey {} as fully synced", from_pubkey);
         },
         (false, true) => {
             state.is_synced = false;
@@ -3079,14 +3079,14 @@ impl Orderbook {
         {
             let pubkey_state = pubkey_state_mut(&mut self.pubkeys_state, from_pubkey);
             if !pubkey_state.is_synced {
-                log::debug!(
+                log::info!(
                     "KeepAlive received for a not fully synced pubkey {} (propagated_from={})",
                     from_pubkey,
                     propagated_from
                 );
             }
             if message.timestamp <= pubkey_state.latest_maker_timestamp {
-                log::debug!(
+                warn!(
                     "Ignoring PubkeyKeepAlive from {}: message.timestamp={} <= last_processed_timestamp={} (stale/replayed)",
                     from_pubkey,
                     message.timestamp,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -2598,10 +2598,6 @@ fn broadcast_keep_alive_for_pub(ctx: &MmArc, pubkey: &str, orderbook: &Orderbook
     };
 
     for (alb_pair, root) in state.trie_roots.iter() {
-        if *root == H64::default() && *root == hashed_null_node::<Layout>() {
-            continue;
-        }
-
         let message = new_protocol::PubkeyKeepAlive {
             trie_roots: HashMap::from([(alb_pair.clone(), *root)]),
             timestamp: now_sec(),

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -466,7 +466,7 @@ async fn process_orders_keep_alive(
         return Ok(());
     }
 
-    // Query ONLY the origin peer.
+    // Query ONLY the keepalive propagator.
     let mut remaining_pairs: HashSet<AlbOrderedOrderbookPair> = trie_roots_to_request.keys().cloned().collect();
     let _ = request_and_apply_pubkey_state_sync_from_peer(
         &ctx,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -3124,6 +3124,7 @@ impl Orderbook {
         // so this is equivalent to checking that one pair. If multi-pair keep-alives return,
         // demote only stale pairs instead of rejecting the whole message.
         {
+            let pubkey_state = pubkey_state_mut(&mut self.pubkeys_state, from_pubkey);
             for (alb_pair, _) in message.trie_roots.iter() {
                 let subscribed = self
                     .topics_subscribed_to
@@ -3132,16 +3133,13 @@ impl Orderbook {
                     continue;
                 }
 
-                let last_pair_timestamp = {
-                    let pubkey_state = pubkey_state_mut(&mut self.pubkeys_state, from_pubkey);
-                    *pubkey_state.latest_root_timestamp_by_pair.get(alb_pair).unwrap_or(&0)
-                };
+                let last_pair_timestamp = *pubkey_state.latest_root_timestamp_by_pair.get(alb_pair).unwrap_or(&0);
 
                 if message.timestamp <= last_pair_timestamp {
                     log::debug!(
-                    "Ignoring PubkeyKeepAlive from {} due to stale pair {}: message.timestamp={} <= last_pair_timestamp={}",
+                    "Ignoring a stale PubkeyKeepAlive from {} for pair {}: message.timestamp={} <= last_pair_timestamp={}",
                     from_pubkey, alb_pair, message.timestamp, last_pair_timestamp
-                );
+                    );
                     return MmError::err(OrderbookP2PHandlerError::StaleKeepAlive {
                         from_pubkey: from_pubkey.to_owned(),
                         propagated_from: propagated_from.to_owned(),

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -944,7 +944,7 @@ fn process_get_orderbook_request(ctx: MmArc, base: String, rel: String) -> Resul
                 pubkey
             ))?;
 
-            let pubkey_last_seen = pubkey_state.pair_last_seen_local.values().copied().max().unwrap_or(0);
+            let pubkey_last_seen = pubkey_state.pair_last_seen_local.values().max().copied().unwrap_or(0);
 
             let item = GetOrderbookPubkeyItem {
                 last_keep_alive: pubkey_last_seen,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -46,10 +46,8 @@ use mm2_err_handle::prelude::*;
 use mm2_event_stream::{DeriveStreamerId, StreamingManager};
 use mm2_libp2p::application::request_response::ordermatch::OrdermatchRequest;
 use mm2_libp2p::application::request_response::P2PRequest;
-use mm2_libp2p::p2p_ctx::P2PContext;
 use mm2_libp2p::{
-    decode_signed, encode_and_sign, encode_message, get_relay_mesh, pub_sub_topic, PublicKey, TopicHash, TopicPrefix,
-    TOPIC_SEPARATOR,
+    decode_signed, encode_and_sign, encode_message, pub_sub_topic, PublicKey, TopicHash, TopicPrefix, TOPIC_SEPARATOR,
 };
 use mm2_metrics::mm_gauge;
 use mm2_number::{BigDecimal, BigRational, MmNumber, MmNumberMultiRepr};
@@ -186,11 +184,23 @@ pub enum OrderbookP2PHandlerError {
         from_pubkey: String,
         propagated_from: String,
     },
+
+    #[display(
+        fmt = "Sync failure for pubkey '{from_pubkey}' via '{propagated_from}'; unresolved pairs: {unresolved_pairs:?}"
+    )]
+    SyncFailure {
+        from_pubkey: String,
+        propagated_from: String,
+        unresolved_pairs: Vec<String>,
+    },
 }
 
 impl OrderbookP2PHandlerError {
     pub(crate) fn is_warning(&self) -> bool {
-        matches!(self, OrderbookP2PHandlerError::OrderNotFound(_))
+        matches!(
+            self,
+            OrderbookP2PHandlerError::OrderNotFound(_) | OrderbookP2PHandlerError::SyncFailure { .. } // treat SyncFailure as a warning for now due to outdated nodes
+        )
     }
 }
 
@@ -364,6 +374,7 @@ fn apply_and_validate_pubkey_state_sync_response(
     response: SyncPubkeyOrderbookStateRes,
     expected_pair_roots: &HashMap<AlbOrderedOrderbookPair, H64>,
     pending_pairs: &mut HashSet<AlbOrderedOrderbookPair>,
+    keep_alive_timestamp: u64,
 ) {
     let mut orderbook = orderbook_mutex.lock();
     for (pair, diff) in response.pair_orders_diff {
@@ -384,6 +395,12 @@ fn apply_and_validate_pubkey_state_sync_response(
         if let Some(expected) = expected_pair_roots.get(&pair) {
             if &new_root == expected {
                 pending_pairs.remove(&pair);
+                // Mark per-pair maker-published timestamp once accepted
+                let state = pubkey_state_mut(&mut orderbook.pubkeys_state, from_pubkey);
+                state
+                    .latest_root_timestamp_by_pair
+                    .insert(pair.clone(), keep_alive_timestamp);
+                state.pair_last_seen_local.insert(pair.clone(), now_sec());
             } else {
                 warn!(
                     "Sync validation failed for pubkey {} pair {} from {}: expected {:?}, got {:?}. Reverting pair.",
@@ -402,6 +419,7 @@ async fn request_and_apply_pubkey_state_sync_from_peer(
     peer: &str,
     expected_pair_roots: &HashMap<AlbOrderedOrderbookPair, H64>,
     pending_pairs: &mut HashSet<AlbOrderedOrderbookPair>,
+    keep_alive_timestamp: u64,
 ) -> OrderbookP2PHandlerResult {
     if pending_pairs.is_empty() {
         return Ok(());
@@ -424,6 +442,7 @@ async fn request_and_apply_pubkey_state_sync_from_peer(
             resp,
             expected_pair_roots,
             pending_pairs,
+            keep_alive_timestamp,
         );
     }
 
@@ -437,9 +456,10 @@ async fn process_orders_keep_alive(
     keep_alive: new_protocol::PubkeyKeepAlive,
     i_am_relay: bool,
 ) -> OrderbookP2PHandlerResult {
+    let keep_alive_timestamp = keep_alive.timestamp;
     let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).expect("from_ctx failed");
 
-    // Phase 1: Update local timestamps / decide whether to sync.
+    // Phase 1: Update local state and decide whether to sync.
     let to_request =
         ordermatch_ctx
             .orderbook
@@ -452,7 +472,7 @@ async fn process_orders_keep_alive(
         None => return Ok(()),
     };
 
-    // Phase 2: Prepare expected roots and the initial set of pairs to sync.
+    // Phase 2: Prepare expected roots and the set of pairs to sync.
     let OrdermatchRequest::SyncPubkeyOrderbookState {
         trie_roots: expected_roots_by_pair,
         ..
@@ -466,62 +486,26 @@ async fn process_orders_keep_alive(
     };
     let mut remaining_pairs: HashSet<AlbOrderedOrderbookPair> = expected_roots_by_pair.keys().cloned().collect();
 
-    // Build the peer sequence once: origin first, then current mesh (excluding origin).
-    let peers = {
-        let p2p_cmd_tx = P2PContext::fetch_from_mm_arc(&ctx).cmd_tx.lock().clone();
-        let mut mesh = get_relay_mesh(p2p_cmd_tx).await;
-        mesh.retain(|p| p != &propagated_from);
-        std::iter::once(propagated_from.clone())
-            .chain(mesh.into_iter())
-            .collect::<Vec<_>>()
-    };
+    // Phase 3: Query ONLY the origin peer.
+    let _ = request_and_apply_pubkey_state_sync_from_peer(
+        &ctx,
+        &ordermatch_ctx.orderbook,
+        &from_pubkey,
+        &propagated_from,
+        &expected_roots_by_pair,
+        &mut remaining_pairs,
+        keep_alive_timestamp,
+    )
+    .await;
 
-    // Phase 3: Query peers sequentially until all pairs are synced, or we run out of peers.
-    let mut consulted = Vec::with_capacity(peers.len());
-    for peer in peers {
-        if remaining_pairs.is_empty() {
-            break;
-        }
-        if let Err(e) = request_and_apply_pubkey_state_sync_from_peer(
-            &ctx,
-            &ordermatch_ctx.orderbook,
-            &from_pubkey,
-            &peer,
-            &expected_roots_by_pair,
-            &mut remaining_pairs,
-        )
-        .await
-        {
-            error!(
-                "Failed to sync pubkey {} from peer {}: {}. Remaining pairs: {:?}",
-                from_pubkey, peer, e, remaining_pairs
-            );
-        }
-        consulted.push(peer);
-    }
-
-    // Phase 4: Finalize state and report unresolved pairs (if any).
-    let fully_synced = remaining_pairs.is_empty();
-    let mut orderbook = ordermatch_ctx.orderbook.lock();
-    let state = pubkey_state_mut(&mut orderbook.pubkeys_state, &from_pubkey);
-
-    match (fully_synced, state.is_synced) {
-        (true, false) => {
-            state.is_synced = true;
-            log::info!("Marked pubkey {} as fully synced", from_pubkey);
-        },
-        (false, true) => {
-            state.is_synced = false;
-            warn!(
-                "SyncPubkeyOrderbookState unresolved for pubkey {} pairs {:?}. Origin={}, consulted {} peer(s): [{}]",
-                from_pubkey,
-                remaining_pairs,
-                propagated_from,
-                consulted.len(),
-                consulted.join(", ")
-            );
-        },
-        _ => {},
+    // Phase 4: Finalize; if unresolved, mark unsynced and DO NOT FORWARD.
+    if !remaining_pairs.is_empty() {
+        let unresolved_pairs = remaining_pairs.into_iter().collect::<Vec<_>>();
+        return MmError::err(OrderbookP2PHandlerError::SyncFailure {
+            from_pubkey,
+            propagated_from,
+            unresolved_pairs,
+        });
     }
 
     Ok(())
@@ -664,6 +648,9 @@ async fn request_and_fill_orderbook(ctx: &MmArc, base: &str, rel: &str) -> Resul
             conf_infos: &conf_infos,
         };
         let _new_root = process_pubkey_full_trie(&mut orderbook, orders, params);
+
+        let state = pubkey_state_mut(&mut orderbook.pubkeys_state, &pubkey);
+        state.pair_last_seen_local.insert(alb_pair.clone(), now_sec());
     }
 
     let topic = orderbook_topic_from_base_rel(base, rel);
@@ -976,8 +963,10 @@ fn process_get_orderbook_request(ctx: MmArc, base: String, rel: String) -> Resul
                 pubkey
             ))?;
 
+            let pubkey_last_seen = pubkey_state.pair_last_seen_local.values().copied().max().unwrap_or(0);
+
             let item = GetOrderbookPubkeyItem {
-                last_keep_alive: pubkey_state.last_keep_alive,
+                last_keep_alive: pubkey_last_seen,
                 orders,
                 // TODO save last signed payload to pubkey state
                 last_signed_pubkey_payload: vec![],
@@ -1089,10 +1078,9 @@ impl<Key: Clone + Eq + std::hash::Hash + TryFromBytes, Value: Clone> DeltaOrFull
                 return Ok(DeltaOrFullTrie::Delta(total_delta));
             }
 
-            log::warn!(
+            warn!(
                 "History started from {:?} ends with not up-to-date trie root {:?}",
-                from_hash,
-                actual_trie_root
+                from_hash, actual_trie_root
             );
         }
 
@@ -1330,7 +1318,7 @@ impl BalanceTradeFeeUpdatedHandler for BalanceUpdateOrdermatchHandler {
             None => return,
         };
         if coin.wallet_only(&ctx) {
-            log::warn!(
+            warn!(
                 "coin: {} is wallet only, skip BalanceTradeFeeUpdatedHandler",
                 coin.ticker()
             );
@@ -1342,7 +1330,7 @@ impl BalanceTradeFeeUpdatedHandler for BalanceUpdateOrdermatchHandler {
             Ok(vol_info) => vol_info.volume,
             Err(e) if e.get_inner().not_sufficient_balance() => MmNumber::from(0),
             Err(e) => {
-                log::warn!("Couldn't handle the 'balance_updated' event: {}", e);
+                warn!("Couldn't handle the 'balance_updated' event: {}", e);
                 return;
             },
         };
@@ -2746,12 +2734,20 @@ impl<Key, Value> TrieDiffHistory<Key, Value> {
 type TrieOrderHistory = TrieDiffHistory<Uuid, OrderbookItem>;
 
 struct OrderbookPubkeyState {
-    /// Local receive time (seconds) when we last accepted a keep-alive from this pubkey.
-    /// Used by inactivity GC to purge stale pubkeys and their orders.
-    last_keep_alive: u64,
-    /// Monotonic maker-published timestamp of the last processed PubkeyKeepAlive.
-    /// Used to ignore out-of-order or replayed keep-alive messages from this pubkey.
-    latest_maker_timestamp: u64,
+    /// Monotonic maker-published timestamp for the last accepted root per pair.
+    /// Used to ignore out-of-order or replayed keep-alive roots for specific pairs.
+    ///
+    /// Retention policy:
+    /// We intentionally retain entries even after a pair is pruned by inactivity GC to defend against
+    /// stale replays resurrecting old state. These entries are dropped only when the entire pubkey
+    /// state is removed.
+    latest_root_timestamp_by_pair: HashMap<AlbOrderedOrderbookPair, u64>,
+    /// Local receive time (seconds) of the last accepted keep‑alive per alphabetically ordered pair
+    /// owned by this pubkey. This is the authoritative liveness signal used by inactivity GC and
+    /// trie‑state pruning. Pairs not updated within the timeout are purged; if all pairs are stale,
+    /// the entire pubkey state is removed.
+    /// Key: `AlbOrderedOrderbookPair` ("BASE:REL"), Value: local Unix time in seconds.
+    pair_last_seen_local: HashMap<AlbOrderedOrderbookPair, u64>,
     /// The map storing historical data about specific pair subtrie changes
     /// Used to get diffs of orders of pair between specific root hashes
     order_pairs_trie_state_history: TimedMap<AlbOrderedOrderbookPair, TrieOrderHistory>,
@@ -2759,20 +2755,16 @@ struct OrderbookPubkeyState {
     orders_uuids: HashSet<(Uuid, AlbOrderedOrderbookPair)>,
     /// The map storing alphabetically ordered pair with trie root hash of orders owned by pubkey.
     trie_roots: HashMap<AlbOrderedOrderbookPair, H64>,
-    is_synced: bool,
 }
 
 impl OrderbookPubkeyState {
     pub fn new() -> OrderbookPubkeyState {
         OrderbookPubkeyState {
-            // Keep `last_keep_alive` based on local receive time. This is used for cleaning up orders of an inactive pubkey.
-            last_keep_alive: now_sec(),
-            // Start at 0 so the first message from this pubkey always passes the monotonic check.
-            latest_maker_timestamp: 0,
+            latest_root_timestamp_by_pair: HashMap::default(),
+            pair_last_seen_local: HashMap::default(),
             order_pairs_trie_state_history: TimedMap::new_with_map_kind(MapKind::FxHashMap),
             orders_uuids: HashSet::default(),
             trie_roots: HashMap::default(),
-            is_synced: true,
         }
     }
 }
@@ -2904,6 +2896,8 @@ impl Orderbook {
         let alb_ordered = alb_ordered_pair(&order.base, &order.rel);
         let pair_root = order_pair_root_mut(&mut pubkey_state.trie_roots, &alb_ordered);
         let prev_root = *pair_root;
+
+        pubkey_state.pair_last_seen_local.insert(alb_ordered.clone(), now_sec());
 
         pubkey_state.orders_uuids.insert((order.uuid, alb_ordered.clone()));
 
@@ -3083,6 +3077,12 @@ impl Orderbook {
         self.topics_subscribed_to.contains_key(topic)
     }
 
+    // TODO(rate-limit):
+    // Add centralized inbound rate limiting per OrdermatchMessage type.
+    // For keep-alive, enforce a minimum interval per pubkey (e.g., >= 20–30s) or X messages/minute.
+    // When throttled, early-return Ok(None) to avoid sync and propagation.
+    // Prefer implementing this in a shared limiter (e.g., mm2_p2p or a small service in lp_network)
+    // and call it here before any state mutation.
     fn process_keep_alive(
         &mut self,
         from_pubkey: &str,
@@ -3090,29 +3090,35 @@ impl Orderbook {
         i_am_relay: bool,
         propagated_from: &str,
     ) -> Result<Option<OrdermatchRequest>, MmError<OrderbookP2PHandlerError>> {
+        // Pre-scan: if any single pair is stale => treat the whole message as stale.
+        // Note: We currently send keep-alives per pair (trie_roots has a single entry),
+        // so this is equivalent to checking that one pair. If multi-pair keep-alives return,
+        // demote only stale pairs instead of rejecting the whole message.
         {
-            let pubkey_state = pubkey_state_mut(&mut self.pubkeys_state, from_pubkey);
-            if message.timestamp <= pubkey_state.latest_maker_timestamp {
-                log::debug!(
-                    "Ignoring PubkeyKeepAlive from {}: message.timestamp={} <= last_processed_timestamp={} (stale/replayed)",
-                    from_pubkey,
-                    message.timestamp,
-                    pubkey_state.latest_maker_timestamp
+            for (alb_pair, _) in message.trie_roots.iter() {
+                let subscribed = self
+                    .topics_subscribed_to
+                    .contains_key(&orderbook_topic_from_ordered_pair(alb_pair));
+                if !subscribed && !i_am_relay {
+                    continue;
+                }
+
+                let last_pair_timestamp = {
+                    let pubkey_state = pubkey_state_mut(&mut self.pubkeys_state, from_pubkey);
+                    *pubkey_state.latest_root_timestamp_by_pair.get(alb_pair).unwrap_or(&0)
+                };
+
+                if message.timestamp <= last_pair_timestamp {
+                    log::debug!(
+                    "Ignoring PubkeyKeepAlive from {} due to stale pair {}: message.timestamp={} <= last_pair_timestamp={}",
+                    from_pubkey, alb_pair, message.timestamp, last_pair_timestamp
                 );
-                return MmError::err(OrderbookP2PHandlerError::StaleKeepAlive {
-                    from_pubkey: from_pubkey.to_owned(),
-                    propagated_from: propagated_from.to_owned(),
-                });
+                    return MmError::err(OrderbookP2PHandlerError::StaleKeepAlive {
+                        from_pubkey: from_pubkey.to_owned(),
+                        propagated_from: propagated_from.to_owned(),
+                    });
+                }
             }
-            if !pubkey_state.is_synced {
-                log::info!(
-                    "KeepAlive received for a not fully synced pubkey {} (propagated_from={})",
-                    from_pubkey,
-                    propagated_from
-                );
-            }
-            pubkey_state.latest_maker_timestamp = message.timestamp;
-            pubkey_state.last_keep_alive = now_sec();
         }
 
         let mut trie_roots_to_request = HashMap::new();
@@ -3141,6 +3147,10 @@ impl Orderbook {
                 {
                     let pubkey_state = pubkey_state_mut(&mut self.pubkeys_state, from_pubkey);
                     pubkey_state.trie_roots.insert(alb_pair.clone(), trie_root);
+                    pubkey_state
+                        .latest_root_timestamp_by_pair
+                        .insert(alb_pair.clone(), message.timestamp);
+                    pubkey_state.pair_last_seen_local.remove(&alb_pair);
                 }
 
                 continue;
@@ -3153,7 +3163,13 @@ impl Orderbook {
             };
             if current_root != trie_root {
                 trie_roots_to_request.insert(alb_pair, trie_root);
+                continue;
             }
+            let state = pubkey_state_mut(&mut self.pubkeys_state, from_pubkey);
+            state
+                .latest_root_timestamp_by_pair
+                .insert(alb_pair.clone(), message.timestamp);
+            state.pair_last_seen_local.insert(alb_pair, now_sec());
         }
 
         if trie_roots_to_request.is_empty() {
@@ -3915,26 +3931,78 @@ pub async fn lp_ordermatch_loop(ctx: MmArc) {
         }
 
         {
-            // remove "timed out" pubkeys states with their orders from orderbook
             let mut orderbook = ordermatch_ctx.orderbook.lock();
-            let mut uuids_to_remove = vec![];
-            let mut pubkeys_to_remove = vec![];
+
+            let deadline = now_sec().saturating_sub(MAKER_ORDER_TIMEOUT);
+
+            let mut pairs_to_prune = Vec::new();
+            let mut pubkeys_to_remove = Vec::new();
+
             for (pubkey, state) in orderbook.pubkeys_state.iter() {
-                let is_ours = orderbook.my_p2p_pubkeys.contains(pubkey);
-                let to_keep =
-                    pubkey == &my_pubsecp || is_ours || state.last_keep_alive + MAKER_ORDER_TIMEOUT > now_sec();
-                if !to_keep {
-                    for (uuid, _) in &state.orders_uuids {
-                        uuids_to_remove.push(*uuid);
-                    }
+                // Skip our own pubkeys; local order lifecycle manages them.
+                if pubkey == &my_pubsecp || orderbook.my_p2p_pubkeys.contains(pubkey) {
+                    continue;
+                }
+
+                // Remove the pubkey if no pair has been seen recently.
+                let any_recent_pair = state
+                    .trie_roots
+                    .keys()
+                    .any(|pair| state.pair_last_seen_local.get(pair).copied().unwrap_or(0) > deadline);
+
+                if !any_recent_pair {
                     pubkeys_to_remove.push(pubkey.clone());
+                    continue;
+                }
+
+                // Otherwise keep the pubkey and prune only its stale pairs.
+                let stale_pairs: Vec<_> = state
+                    .trie_roots
+                    .keys()
+                    .filter_map(|pair| {
+                        let last_seen = state.pair_last_seen_local.get(pair).copied().unwrap_or(0);
+                        (last_seen <= deadline).then(|| pair.clone())
+                    })
+                    .collect();
+
+                if !stale_pairs.is_empty() {
+                    pairs_to_prune.push((pubkey.clone(), stale_pairs));
                 }
             }
 
-            for uuid in uuids_to_remove {
-                orderbook.remove_order_trie_update(uuid);
+            // Prune stale pairs for pubkeys we keep.
+            for (pubkey, pairs) in pairs_to_prune {
+                for pair in pairs {
+                    remove_pubkey_pair_orders(&mut orderbook, &pubkey, &pair);
+                    if let Some(state) = orderbook.pubkeys_state.get_mut(&pubkey) {
+                        state.pair_last_seen_local.remove(&pair);
+                    }
+                }
+            }
+
+            // Remove fully expired pubkeys: delete their remaining orders first, then the state.
+            // GC: remove orders while the pubkey state still exists to avoid lazy re-creation inside `remove_order_trie_update`.
+            for pubkey in &pubkeys_to_remove {
+                let uuids: Vec<Uuid> = orderbook
+                    .pubkeys_state
+                    .get(pubkey)
+                    .map(|s| s.orders_uuids.iter().map(|(uuid, _)| *uuid).collect())
+                    .unwrap_or_default();
+                for uuid in uuids {
+                    orderbook.remove_order_trie_update(uuid);
+                }
             }
             for pubkey in pubkeys_to_remove {
+                // TODO(pubkey_replay_guard):
+                // Block stale replays after full pubkey timeout (incl. restarts).
+                // - On full pubkey removal: store pubkey -> max maker_ts (write-once HashMap<String,u64>).
+                // - On keep-alive intake: before creating state, drop if maker_ts <= stored floor.
+                // - Restarts: persist this map (and ideally per-pair last_maker_ts); until persisted, enforce
+                //   sanity bounds: maker_ts > now + MAX_MAKER_FUTURE_SKEW or now - maker_ts > MAX_MAKER_PAST_AGE => reject.
+                // - Liveness: keep GC driven by local time; optionally prune when maker_stale || local_stale;
+                //   do not rely solely on maker clock.
+                // - Cleanup: pre-scan without creating state; centralize timestamp checks/logging; never sync
+                //   origin for messages rejected by guards; add unit tests.
                 orderbook.pubkeys_state.remove(&pubkey);
             }
 
@@ -4303,7 +4371,7 @@ async fn process_maker_connected(ctx: MmArc, from_pubkey: PublicKey, connected: 
     let order_match = match my_order_entry.get().matches.get(&connected.maker_order_uuid) {
         Some(o) => o,
         None => {
-            log::warn!(
+            warn!(
                 "Our node doesn't have the match with uuid {}",
                 connected.maker_order_uuid
             );
@@ -4464,7 +4532,7 @@ async fn process_taker_connect(ctx: MmArc, sender_pubkey: PublicKey, connect_msg
     let order_match = match my_order.matches.get_mut(&connect_msg.taker_order_uuid) {
         Some(o) => o,
         None => {
-            log::warn!(
+            warn!(
                 "Our node doesn't have the match with uuid {}",
                 connect_msg.taker_order_uuid
             );
@@ -4472,7 +4540,7 @@ async fn process_taker_connect(ctx: MmArc, sender_pubkey: PublicKey, connect_msg
         },
     };
     if order_match.request.sender_pubkey != sender_pubkey.unprefixed().into() {
-        log::warn!("Connect message sender pubkey != request message sender pubkey");
+        warn!("Connect message sender pubkey != request message sender pubkey");
         return;
     }
 
@@ -5809,7 +5877,7 @@ pub async fn orders_history_by_filter(ctx: MmArc, req: Json) -> Result<Response<
                         "Order details for Uuid {} were skipped because uuid could not be parsed",
                         order.uuid
                     );
-                    log::warn!("{}, error {}", warning, e);
+                    warn!("{}, error {}", warning, e);
                     warnings.push(UuidParseError {
                         uuid: order.uuid.clone(),
                         warning,

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -421,10 +421,6 @@ async fn request_and_apply_pubkey_state_sync_from_peer(
     pending_pairs: &mut HashSet<AlbOrderedOrderbookPair>,
     keep_alive_timestamp: u64,
 ) -> OrderbookP2PHandlerResult {
-    if pending_pairs.is_empty() {
-        return Ok(());
-    }
-
     let current_req = build_pubkey_state_sync_request(from_pubkey, pending_pairs, expected_pair_roots);
 
     if let Some(resp) = request_one_peer::<SyncPubkeyOrderbookStateRes>(
@@ -459,40 +455,26 @@ async fn process_orders_keep_alive(
     let keep_alive_timestamp = keep_alive.timestamp;
     let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).expect("from_ctx failed");
 
-    // Phase 1: Update local state and decide whether to sync.
-    let to_request =
+    // Update local state and decide whether to sync.
+    let trie_roots_to_request =
         ordermatch_ctx
             .orderbook
             .lock()
             .process_keep_alive(&from_pubkey, keep_alive, i_am_relay, &propagated_from)?;
 
-    let req = match to_request {
-        Some(req) => req,
+    if trie_roots_to_request.is_empty() {
         // The message was processed, return Ok to forward it
-        None => return Ok(()),
-    };
-
-    // Phase 2: Prepare expected roots and the set of pairs to sync.
-    let OrdermatchRequest::SyncPubkeyOrderbookState {
-        trie_roots: expected_roots_by_pair,
-        ..
-    } = req
-    else {
-        error!(
-            "`process_keep_alive` returned unexpected `OrdermatchRequest` variant: {:?}",
-            req
-        );
         return Ok(());
-    };
-    let mut remaining_pairs: HashSet<AlbOrderedOrderbookPair> = expected_roots_by_pair.keys().cloned().collect();
+    }
 
-    // Phase 3: Query ONLY the origin peer.
+    // Query ONLY the origin peer.
+    let mut remaining_pairs: HashSet<AlbOrderedOrderbookPair> = trie_roots_to_request.keys().cloned().collect();
     let _ = request_and_apply_pubkey_state_sync_from_peer(
         &ctx,
         &ordermatch_ctx.orderbook,
         &from_pubkey,
         &propagated_from,
-        &expected_roots_by_pair,
+        &trie_roots_to_request,
         &mut remaining_pairs,
         keep_alive_timestamp,
     )
@@ -3077,19 +3059,58 @@ impl Orderbook {
         self.topics_subscribed_to.contains_key(topic)
     }
 
-    // TODO(rate-limit):
-    // Add centralized inbound rate limiting per OrdermatchMessage type.
-    // For keep-alive, enforce a minimum interval per pubkey (e.g., >= 20–30s) or X messages/minute.
-    // When throttled, early-return Ok(None) to avoid sync and propagation.
-    // Prefer implementing this in a shared limiter (e.g., mm2_p2p or a small service in lp_network)
-    // and call it here before any state mutation.
+    /// Processes a [`new_protocol::PubkeyKeepAlive`] for `from_pubkey`, updating per‑pair state and
+    /// deciding whether a state sync is required.
+    ///
+    /// This function performs only local state transitions; it does no I/O.
+    /// It may:
+    /// - Accept the announcement (per pair) and refresh timestamps if the announced root matches the
+    ///   local root.
+    /// - Clear a pair if the announced root is null/empty (remove all orders, remember the null root,
+    ///   update the maker timestamp floor, and drop the local “last seen” so GC can prune it).
+    /// - Detect divergence and return the set of pairs that must be synced to the announced roots.
+    ///
+    /// Invariants and validation:
+    /// - Maker timestamps are checked per pair and must be strictly increasing. If any pair is stale
+    ///   (announced timestamp ≤ the last accepted maker timestamp for that pair), the function returns
+    ///   [`OrderbookP2PHandlerError::StaleKeepAlive`] and no state is advanced for that message. Callers
+    ///   must not propagate such a message.
+    /// - We update `pair_last_seen_local` only for pairs that are accepted/in‑sync. Divergent pairs do
+    ///   not refresh liveness until validated to the expected root.
+    ///
+    /// Subscription policy:
+    /// - Pairs we are not subscribed to are ignored unless this node acts as a relay (`i_am_relay`).
+    ///
+    /// Returns:
+    /// - A map of `"BASE:REL"` to the expected roots (as announced) for which local state diverges and
+    ///   a sync is required. An empty map means no sync is needed and the message may be propagated.
+    ///
+    /// Caller responsibilities:
+    /// - If the returned map is non‑empty, fetch trie diffs from the peer that propagated the keep‑alive
+    ///   (`propagated_from`), validate them to the expected roots, apply, and only then consider forwarding
+    ///   the keep‑alive.
+    ///
+    /// Errors:
+    /// - [`OrderbookP2PHandlerError::StaleKeepAlive`] if any per‑pair maker timestamp regresses or repeats.
+    /// - Other variants for malformed or otherwise invalid data.
+    ///
+    /// Notes:
+    /// - Maker timestamps are used for monotonicity/anti‑replay; GC uses local receive times.
+    /// - The caller must ignore Unsolicited pairs in sync responses when applying the response.
     fn process_keep_alive(
         &mut self,
         from_pubkey: &str,
         message: new_protocol::PubkeyKeepAlive,
         i_am_relay: bool,
         propagated_from: &str,
-    ) -> Result<Option<OrdermatchRequest>, MmError<OrderbookP2PHandlerError>> {
+    ) -> Result<HashMap<AlbOrderedOrderbookPair, H64>, MmError<OrderbookP2PHandlerError>> {
+        // TODO(rate-limit):
+        // Add centralized inbound rate limiting per OrdermatchMessage type.
+        // For keep-alive, enforce a minimum interval per pubkey (e.g., >= 20–30s) or X messages/minute.
+        // When throttled, early-return Ok(None) to avoid sync and propagation.
+        // Prefer implementing this in a shared limiter (e.g., mm2_p2p or a small service in lp_network)
+        // and call it here before any state mutation.
+
         // Pre-scan: if any single pair is stale => treat the whole message as stale.
         // Note: We currently send keep-alives per pair (trie_roots has a single entry),
         // so this is equivalent to checking that one pair. If multi-pair keep-alives return,
@@ -3172,14 +3193,7 @@ impl Orderbook {
             state.pair_last_seen_local.insert(alb_pair, now_sec());
         }
 
-        if trie_roots_to_request.is_empty() {
-            return Ok(None);
-        }
-
-        Ok(Some(OrdermatchRequest::SyncPubkeyOrderbookState {
-            pubkey: from_pubkey.to_owned(),
-            trie_roots: trie_roots_to_request,
-        }))
+        Ok(trie_roots_to_request)
     }
 
     fn orderbook_item_with_proof(&self, order: OrderbookItem) -> OrderbookItemWithProof {

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -3104,11 +3104,10 @@ impl Orderbook {
         propagated_from: &str,
     ) -> Result<HashMap<AlbOrderedOrderbookPair, H64>, MmError<OrderbookP2PHandlerError>> {
         // TODO(rate-limit):
-        // Add centralized inbound rate limiting per OrdermatchMessage type.
-        // For keep-alive, enforce a minimum interval per pubkey (e.g., >= 20–30s) or X messages/minute.
-        // When throttled, early-return Ok(None) to avoid sync and propagation.
-        // Prefer implementing this in a shared limiter (e.g., mm2_p2p or a small service in lp_network)
-        // and call it here before any state mutation.
+        // Add a single, shared in‑process rate limiter for OrdermatchMessage
+        // types (e.g., a module in mm2_p2p or lp_network).
+        // For keep-alive, enforce a minimum interval per pubkey (>= 20–30s) or X messages/minute.
+        // When throttled, early‑return without syncing/propagating, before any state mutation.
 
         // Pre-scan: if any single pair is stale => treat the whole message as stale.
         // Note: We currently send keep-alives per pair (trie_roots has a single entry),

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -3994,17 +3994,17 @@ pub async fn lp_ordermatch_loop(ctx: MmArc) {
 
             // Remove fully expired pubkeys: delete their remaining orders first, then the state.
             // GC: remove orders while the pubkey state still exists to avoid lazy re-creation inside `remove_order_trie_update`.
-            for pubkey in &pubkeys_to_remove {
-                let uuids: Vec<Uuid> = orderbook
-                    .pubkeys_state
-                    .get(pubkey)
-                    .map(|s| s.orders_uuids.iter().map(|(uuid, _)| *uuid).collect())
-                    .unwrap_or_default();
-                for uuid in uuids {
-                    orderbook.remove_order_trie_update(uuid);
-                }
-            }
             for pubkey in pubkeys_to_remove {
+                if let Some(orders) = orderbook
+                    .pubkeys_state
+                    .get_mut(&pubkey)
+                    .map(|state| std::mem::take(&mut state.orders_uuids))
+                {
+                    for (uuid, _) in orders {
+                        orderbook.remove_order_trie_update(uuid);
+                    }
+                }
+
                 // TODO(pubkey_replay_guard):
                 // Block stale replays after full pubkey timeout (incl. restarts).
                 // - On full pubkey removal: store pubkey -> max maker_ts (write-once HashMap<String,u64>).

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -134,9 +134,9 @@ pub mod ordermatch_tests;
 mod ordermatch_wasm_db;
 
 pub const ORDERBOOK_PREFIX: TopicPrefix = "orbk";
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "for-tests")))]
 pub const MIN_ORDER_KEEP_ALIVE_INTERVAL: u64 = 30;
-#[cfg(test)]
+#[cfg(any(test, feature = "for-tests"))]
 pub const MIN_ORDER_KEEP_ALIVE_INTERVAL: u64 = 5;
 const BALANCE_REQUEST_INTERVAL: f64 = 30.;
 const MAKER_ORDER_TIMEOUT: u64 = MIN_ORDER_KEEP_ALIVE_INTERVAL * 3;

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -528,27 +528,37 @@ fn process_maker_order_cancelled(ctx: &MmArc, from_pubkey: String, cancelled_msg
     orderbook
         .recently_cancelled
         .insert_expirable(uuid, from_pubkey.clone(), RECENTLY_CANCELLED_TIMEOUT);
-    if let Some(order) = orderbook.order_set.get(&uuid) {
-        if order.pubkey == from_pubkey {
-            orderbook.remove_order_trie_update(uuid);
+
+    let maybe_pair = orderbook
+        .order_set
+        .get(&uuid)
+        .filter(|o| o.pubkey == from_pubkey)
+        .map(|o| alb_ordered_pair(&o.base, &o.rel));
+
+    if let Some(alb_pair) = maybe_pair {
+        orderbook.remove_order_trie_update(uuid);
+
+        // Advance the per-pair maker timestamp floor to the cancel timestamp
+        // so any earlier keep-alive for this pair will be rejected as stale.
+        //
+        // Note: we do NOT refresh liveness (pair_last_seen_local) here.
+        // Liveness is refreshed only when we accept state-carrying messages
+        // (e.g., a keep-alive that matches the expected root, a validated sync,
+        // a MakerOrderCreated/Updated, or a full-trie fill), not on cancel.
+        let state = pubkey_state_mut(&mut orderbook.pubkeys_state, &from_pubkey);
+        state
+            .latest_root_timestamp_by_pair
+            .insert(alb_pair.clone(), cancelled_msg.timestamp);
+
+        // If this cancel emptied the pair (root is zero/hashed-null), drop liveness for this pair.
+        // This mirrors the zero-root keep-alive path and allows faster GC of empty pairs.
+        if let Some(&pair_root) = state.trie_roots.get(&alb_pair) {
+            if pair_root == H64::default() || pair_root == hashed_null_node::<Layout>() {
+                state.pair_last_seen_local.remove(&alb_pair);
+            }
         }
     }
 }
-
-// fn verify_pubkey_orderbook(orderbook: &GetOrderbookPubkeyItem) -> Result<(), String> {
-//     let keys: Vec<(_, _)> = orderbook
-//         .orders
-//         .iter()
-//         .map(|(uuid, order)| {
-//             let order_bytes = rmp_serde::to_vec(&order).expect("Serialization should never fail");
-//             (uuid.as_bytes(), Some(order_bytes))
-//         })
-//         .collect();
-//     let (orders_root, proof) = &orderbook.pair_orders_trie_root;
-//     verify_trie_proof::<Layout, _, _, _>(orders_root, proof, &keys)
-//         .map_err(|e| ERRL!("Error on pair_orders_trie_root verification: {}", e))?;
-//     Ok(())
-// }
 
 // Some coins, for example ZHTLC, have privacy features like random keypair to sign P2P messages per every order.
 // So, each order of such coin has unique «pubkey» field that doesn’t match node persistent pubkey derived from passphrase.

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -197,9 +197,10 @@ pub enum OrderbookP2PHandlerError {
 
 impl OrderbookP2PHandlerError {
     pub(crate) fn is_warning(&self) -> bool {
+        // treat SyncFailure as a warning for now due to outdated nodes
         matches!(
             self,
-            OrderbookP2PHandlerError::OrderNotFound(_) | OrderbookP2PHandlerError::SyncFailure { .. } // treat SyncFailure as a warning for now due to outdated nodes
+            OrderbookP2PHandlerError::OrderNotFound(_) | OrderbookP2PHandlerError::SyncFailure { .. }
         )
     }
 }
@@ -335,12 +336,10 @@ fn build_pubkey_state_sync_request(
     pending_pairs: &HashSet<AlbOrderedOrderbookPair>,
     expected_pair_roots: &HashMap<AlbOrderedOrderbookPair, H64>,
 ) -> OrdermatchRequest {
-    let mut trie_roots = HashMap::with_capacity(pending_pairs.len());
-    for pair in pending_pairs {
-        if let Some(root) = expected_pair_roots.get(pair) {
-            trie_roots.insert(pair.clone(), *root);
-        }
-    }
+    let trie_roots = pending_pairs
+        .iter()
+        .filter_map(|p| expected_pair_roots.get(p).map(|&root| (p.clone(), root)))
+        .collect();
     OrdermatchRequest::SyncPubkeyOrderbookState {
         pubkey: pubkey.to_owned(),
         trie_roots,

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -2633,6 +2633,7 @@ fn test_orderbook_pubkey_sync_request() {
 
     let request = orderbook
         .process_keep_alive(pubkey, message, false, propagated_from)
+        .unwrap()
         .unwrap();
     match request {
         OrdermatchRequest::SyncPubkeyOrderbookState {
@@ -2667,6 +2668,7 @@ fn test_orderbook_pubkey_sync_request_relay() {
 
     let request = orderbook
         .process_keep_alive(pubkey, message, true, propagated_from)
+        .unwrap()
         .unwrap();
     match request {
         OrdermatchRequest::SyncPubkeyOrderbookState {

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -2620,6 +2620,7 @@ fn test_orderbook_pubkey_sync_request() {
         OrderbookRequestingState::Requested,
     );
     let pubkey = "pubkey";
+    let propagated_from = "propagated_from";
 
     let mut trie_roots = HashMap::new();
     trie_roots.insert("C1:C2".to_owned(), [1; 8]);
@@ -2630,7 +2631,9 @@ fn test_orderbook_pubkey_sync_request() {
         timestamp: now_sec(),
     };
 
-    let request = orderbook.process_keep_alive(pubkey, message, false).unwrap();
+    let request = orderbook
+        .process_keep_alive(pubkey, message, false, propagated_from)
+        .unwrap();
     match request {
         OrdermatchRequest::SyncPubkeyOrderbookState {
             trie_roots: pairs_trie_roots,
@@ -2651,6 +2654,7 @@ fn test_orderbook_pubkey_sync_request_relay() {
         OrderbookRequestingState::Requested,
     );
     let pubkey = "pubkey";
+    let propagated_from = "propagated_from";
 
     let mut trie_roots = HashMap::new();
     trie_roots.insert("C1:C2".to_owned(), [1; 8]);
@@ -2661,7 +2665,9 @@ fn test_orderbook_pubkey_sync_request_relay() {
         timestamp: now_sec(),
     };
 
-    let request = orderbook.process_keep_alive(pubkey, message, true).unwrap();
+    let request = orderbook
+        .process_keep_alive(pubkey, message, true, propagated_from)
+        .unwrap();
     match request {
         OrdermatchRequest::SyncPubkeyOrderbookState {
             trie_roots: pairs_trie_roots,

--- a/mm2src/mm2_main/src/ordermatch_tests.rs
+++ b/mm2src/mm2_main/src/ordermatch_tests.rs
@@ -2631,20 +2631,11 @@ fn test_orderbook_pubkey_sync_request() {
         timestamp: now_sec(),
     };
 
-    let request = orderbook
+    let pairs_trie_roots = orderbook
         .process_keep_alive(pubkey, message, false, propagated_from)
-        .unwrap()
         .unwrap();
-    match request {
-        OrdermatchRequest::SyncPubkeyOrderbookState {
-            trie_roots: pairs_trie_roots,
-            ..
-        } => {
-            assert!(pairs_trie_roots.contains_key("C1:C2"));
-            assert!(!pairs_trie_roots.contains_key("C2:C3"));
-        },
-        _ => panic!("Invalid request {:?}", request),
-    }
+    assert!(pairs_trie_roots.contains_key("C1:C2"));
+    assert!(!pairs_trie_roots.contains_key("C2:C3"));
 }
 
 #[test]
@@ -2666,20 +2657,11 @@ fn test_orderbook_pubkey_sync_request_relay() {
         timestamp: now_sec(),
     };
 
-    let request = orderbook
+    let pairs_trie_roots = orderbook
         .process_keep_alive(pubkey, message, true, propagated_from)
-        .unwrap()
         .unwrap();
-    match request {
-        OrdermatchRequest::SyncPubkeyOrderbookState {
-            trie_roots: pairs_trie_roots,
-            ..
-        } => {
-            assert!(pairs_trie_roots.contains_key("C1:C2"));
-            assert!(pairs_trie_roots.contains_key("C2:C3"));
-        },
-        _ => panic!("Invalid request {:?}", request),
-    }
+    assert!(pairs_trie_roots.contains_key("C1:C2"));
+    assert!(pairs_trie_roots.contains_key("C2:C3"));
 }
 
 #[test]

--- a/mm2src/mm2_main/tests/feature_gate_for_tests.rs
+++ b/mm2src/mm2_main/tests/feature_gate_for_tests.rs
@@ -1,0 +1,8 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+#[cfg(not(any(feature = "for-tests", feature = "run-docker-tests")))]
+compile_error!(concat!(
+    "Integration tests for `",
+    env!("CARGO_PKG_NAME"),
+    "` require either the `for-tests` or the `run-docker-tests` feature."
+));

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -1823,7 +1823,6 @@ fn test_order_should_not_be_displayed_when_node_is_down() {
             "coins": coins,
             "seednodes": [mm_bob.ip.to_string()],
             "rpc_password": "pass",
-            "maker_order_timeout": 5,
         }),
         "pass".into(),
         None,
@@ -1870,7 +1869,7 @@ fn test_order_should_not_be_displayed_when_node_is_down() {
     assert_eq!(asks.len(), 1, "Alice RICK/MORTY orderbook must have exactly 1 ask");
 
     block_on(mm_bob.stop()).unwrap();
-    thread::sleep(Duration::from_secs(6));
+    thread::sleep(Duration::from_secs(16));
 
     let rc = block_on(mm_alice.rpc(&json! ({
         "userpass": mm_alice.userpass,
@@ -1910,7 +1909,6 @@ fn test_own_orders_should_not_be_removed_from_orderbook() {
             "coins": coins,
             "i_am_seed": true,
             "rpc_password": "pass",
-            "maker_order_timeout": 5,
             "is_bootstrap_node": true
         }),
         "pass".into(),

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -2119,7 +2119,7 @@ fn set_price_with_cancel_previous_should_broadcast_cancelled_message() {
     ]);
 
     // start bob and immediately place the order
-    let mm_bob = MarketMakerIt::start(
+    let mut mm_bob = MarketMakerIt::start(
         json! ({
             "gui": "nogui",
             "netid": 9998,
@@ -2157,7 +2157,7 @@ fn set_price_with_cancel_previous_should_broadcast_cancelled_message() {
     let rc = block_on(mm_bob.rpc(&set_price_json)).unwrap();
     assert!(rc.0.is_success(), "!setprice: {}", rc.1);
 
-    let mm_alice = MarketMakerIt::start(
+    let mut mm_alice = MarketMakerIt::start(
         json! ({
             "gui": "nogui",
             "netid": 9998,
@@ -2202,9 +2202,13 @@ fn set_price_with_cancel_previous_should_broadcast_cancelled_message() {
     let rc = block_on(mm_bob.rpc(&set_price_json)).unwrap();
     assert!(rc.0.is_success(), "!setprice: {}", rc.1);
 
-    let pause = 2;
-    log!("Waiting ({} seconds) for Bob to broadcast messages…", pause);
-    thread::sleep(Duration::from_secs(pause));
+    block_on(mm_bob.wait_for_log(10., |log| log.contains("maker_order_cancelled_p2p_notify called")))
+        .expect("Cancel broadcast not seen in Bob’s logs within the expected time");
+
+    block_on(mm_alice.wait_for_log(10., |log| {
+        log.contains("received ordermatch message MakerOrderCancelled")
+    }))
+    .expect("Alice did not log MakerOrderCancelled in time");
 
     // Bob orderbook must show 1 order
     log!("Get RICK/MORTY orderbook on Bob side");

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -1937,7 +1937,7 @@ fn test_own_orders_should_not_be_removed_from_orderbook() {
     .unwrap();
     assert!(rc.0.is_success(), "!setprice: {}", rc.1);
 
-    thread::sleep(Duration::from_secs(6));
+    thread::sleep(Duration::from_secs(16));
 
     let rc = block_on(mm_bob.rpc(&json! ({
         "userpass": mm_bob.userpass,

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -2203,7 +2203,7 @@ fn set_price_with_cancel_previous_should_broadcast_cancelled_message() {
     assert!(rc.0.is_success(), "!setprice: {}", rc.1);
 
     block_on(mm_bob.wait_for_log(10., |log| log.contains("maker_order_cancelled_p2p_notify called")))
-        .expect("Cancel broadcast not seen in Bob’s logs within the expected time");
+        .expect("Cancel broadcast not seen in Bob's logs within the expected time");
 
     block_on(mm_alice.wait_for_log(10., |log| {
         log.contains("received ordermatch message MakerOrderCancelled")

--- a/mm2src/mm2_main/tests/mm2_tests_main.rs
+++ b/mm2src/mm2_main/tests/mm2_tests_main.rs
@@ -1,4 +1,4 @@
-#![cfg(not(target_arch = "wasm32"))]
+#![cfg(all(not(target_arch = "wasm32"), feature = "for-tests"))]
 
 mod integration_tests_common;
 mod mm2_tests;


### PR DESCRIPTION
### Background
- After the P2P upgrade in #1878 (“broadcast one topic at a time”), keep‑alive messages no longer implied deletion when a pair’s root was absent. Combined with a single pubkey‑wide timeout, a seed that missed a cancel could keep an order until the maker went offline.
- After #2580, older nodes still didn't clear local pairs on null roots, leading to bad orderbooks and repeated warnings like “Couldn’t find an order … it will be synced upon pubkey keep alive,” and errors such as `InvalidStateRoot([0,…])` (see #2594).
- This PR finalizes the receiver‑side handling for the #2580 change by:
  - Validating per‑pair diffs strictly against maker‑advertised roots and clearing pairs on mismatch.
  - Tracking per‑pair liveness locally (`pair_last_seen_local`) and pruning stale pairs, removing a pubkey only when all its pairs are stale.

### What this PR changes
- Commit-after-validate (per pair)
  - On `PubkeyKeepAlive`, compute expected roots per pair from the maker.
  - Request diffs/full tries only from the keep‑alive’s origin peer (`propagated_from`).
  - Ignore unsolicited pairs in the sync response.
  - Apply the diff/full trie and recompute the root per pair; commit only if it exactly matches the expected root.
  - On mismatch, reject the data, clear that pair locally, and do not propagate the message.
  - The same “do not propagate” rule applies to stale/replayed keep‑alives handled as `StaleKeepAlive`.
   - Propagation: forward the keep‑alive only if all requested pairs were validated and applied successfully; if any pair is stale, mismatched, or remains unresolved, the message is not propagated.
- Unresolved pairs
  - If any requested pairs remain unresolved after the origin‑peer sync, return a `SyncFailure` (treated as a warning) and do not propagate the message.
- Stale/replay protection (per pair)
  - Introduces a per‑pair monotonic maker timestamp gate (`latest_root_timestamp_by_pair`) and a local per‑pair last‑seen clock (`pair_last_seen_local`).
  - Rejects stale keep‑alives with `OrderbookP2PHandlerError::StaleKeepAlive`.
  - Replay guard: we intentionally retain `latest_root_timestamp_by_pair` entries even after a pair is pruned, to block stale replays of old roots; these entries are dropped only when the entire pubkey state is removed (which is not ideal still).
- Receiver‑side handling of empty roots
  - If a keep‑alive carries a zero or hashed‑null root for a pair, clear local state for that pair and:
    - Store the null root in `trie_roots`,
    - Update the per‑pair maker timestamp (`latest_root_timestamp_by_pair`),
    - Remove the local last‑seen (`pair_last_seen_local`) so the pair becomes eligible for GC if it stays inactive.
  - No sync is attempted for that pair.
- Liveness and GC
  - Track liveness per pair and prune only stale pairs; remove the pubkey when all its pairs are stale.
  - GC now uses the constant `MAKER_ORDER_TIMEOUT`; the loop no longer reads an override from config.
  - `GetOrderbookPubkeyItem.last_keep_alive` reflects the max local last‑seen across the pubkey’s pairs.
  - When the orderbook is filled from relays (`GetOrderbook` response), we now set `pair_last_seen_local` for each imported (pubkey, pair), so `last_keep_alive` and GC behave correctly for imported state.
- Errors and logging
  - Adds `OrderbookP2PHandlerError::StaleKeepAlive` and `::SyncFailure` and treats `SyncFailure` as a warning to accommodate outdated peers.
- Code cleanup:
   - Removed a dead condition in keep‑alive broadcasting where `if (root == H64::default()) && (root == hashed_null_node::<Layout>())` can never be true (no functional change)
      - Maybe we should not broadcast such roots and let them timeout on receiver side instead to reduce network load, will think of that.

### Why this stops “ghost orders”
- We accept per‑pair data only if it reproduces the maker’s expected root.
- We time out inactive pairs locally (per pair) using the node’s clock.

### Out of scope (future work)
- Peer scoring/quarantine for consistently failing relays.

### TODO
- [ ] Maybe we should not broadcast null roots and let them timeout on receiver side instead to reduce network load.
- [ ] Refactor keepalive logic / code to a different file to start reducing the code in `lp_ordermatch.rs`. This will be done after reviews and approvals.

addresses #2594