### PR TITLE
improvement(RPC): make `params` payload flexible for certain RPCs

### DIFF
--- a/mm2src/coins/eth/eth_tests.rs
+++ b/mm2src/coins/eth/eth_tests.rs
@@ -976,7 +976,7 @@ fn test_eth_validate_valid_and_invalid_pubkey() {
 #[test]
 fn test_get_enabled_erc20_by_contract_and_platform() {
     use super::erc20::get_enabled_erc20_by_platform_and_contract;
-    use crate::rpc_command::get_enabled_coins::{get_enabled_coins_rpc, GetEnabledCoinsRequest};
+    use crate::rpc_command::get_enabled_coins::get_enabled_coins_rpc;
     const BNB_TOKEN: &str = "1INCH-BEP20";
     const ETH_TOKEN: &str = "1INCH-ERC20";
 
@@ -1081,7 +1081,7 @@ fn test_get_enabled_erc20_by_contract_and_platform() {
     });
     block_on(lp_coininit(&ctx, ETH_TOKEN, &req_eth_token)).unwrap();
 
-    let coins = block_on(get_enabled_coins_rpc(ctx.clone(), GetEnabledCoinsRequest)).unwrap();
+    let coins = block_on(get_enabled_coins_rpc(ctx.clone(), None)).unwrap();
     assert_eq!(coins.coins.len(), 2);
 
     let contract_address = Address::from_str("0x111111111117dC0aa78b770fA6A738034120C302").unwrap();

--- a/mm2src/coins/rpc_command/get_enabled_coins.rs
+++ b/mm2src/coins/rpc_command/get_enabled_coins.rs
@@ -22,7 +22,7 @@ impl HttpStatusCode for GetEnabledCoinsError {
 }
 
 #[derive(Deserialize)]
-pub struct GetEnabledCoinsRequest;
+pub struct GetEnabledCoinsRequest {}
 
 #[derive(Debug, Serialize)]
 pub struct GetEnabledCoinsResponse {
@@ -36,7 +36,7 @@ pub struct EnabledCoinV2 {
 
 pub async fn get_enabled_coins_rpc(
     ctx: MmArc,
-    _req: GetEnabledCoinsRequest,
+    _req: Option<GetEnabledCoinsRequest>,
 ) -> MmResult<GetEnabledCoinsResponse, GetEnabledCoinsError> {
     let coins_ctx = CoinsContext::from_ctx(&ctx).map_to_mm(GetEnabledCoinsError::Internal)?;
     let coins_map = coins_ctx.coins.lock().await;

--- a/mm2src/mm2_main/src/lp_init/init_hw.rs
+++ b/mm2src/mm2_main/src/lp_init/init_hw.rs
@@ -110,7 +110,7 @@ pub enum InitHwInProgressStatus {
     FollowHwDeviceInstructions,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Default, Deserialize, Clone)]
 pub struct InitHwRequest {
     device_pubkey: Option<HwPubkey>,
 }
@@ -183,7 +183,12 @@ impl RpcTask for InitHwTask {
     }
 }
 
-pub async fn init_trezor(ctx: MmArc, req: RpcInitReq<InitHwRequest>) -> MmResult<InitRpcTaskResponse, InitHwError> {
+pub async fn init_trezor(
+    ctx: MmArc,
+    req: Option<RpcInitReq<InitHwRequest>>,
+) -> MmResult<InitRpcTaskResponse, InitHwError> {
+    let req = req.unwrap_or_default();
+
     let (client_id, req) = (req.client_id, req.inner);
     let init_ctx = MmInitContext::from_ctx(&ctx).map_to_mm(InitHwError::Internal)?;
     let spawner = ctx.spawner();

--- a/mm2src/mm2_main/src/rpc/wc_commands/sessions.rs
+++ b/mm2src/mm2_main/src/rpc/wc_commands/sessions.rs
@@ -20,7 +20,7 @@ pub struct GetSessionsResponse {
 /// `Get all sessions connection` RPC command implementation.
 pub async fn get_all_sessions(
     ctx: MmArc,
-    _req: EmptyRpcRequest,
+    _req: Option<EmptyRpcRequest>,
 ) -> MmResult<GetSessionsResponse, WalletConnectRpcError> {
     let wc_ctx =
         WalletConnectCtx::from_ctx(&ctx).mm_err(|err| WalletConnectRpcError::InitializationError(err.to_string()))?;

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -6725,7 +6725,7 @@ mod trezor_tests {
 
         CryptoCtx::init_with_iguana_passphrase(ctx.clone(), "123456").unwrap(); // for now we need passphrase seed for init
         let req: RpcInitReq<InitHwRequest> = serde_json::from_value(json!({ "device_pubkey": null })).unwrap();
-        let res = match init_trezor(ctx.clone(), req).await {
+        let res = match init_trezor(ctx.clone(), Some(req)).await {
             Ok(res) => res,
             _ => {
                 panic!("cannot start init trezor task");

--- a/mm2src/rpc_task/src/task.rs
+++ b/mm2src/rpc_task/src/task.rs
@@ -25,7 +25,7 @@ pub trait RpcTask: RpcTaskTypes + Sized + Send + 'static {
 ///
 /// `client_id` is used to identify the client to which the task should stream out update events
 /// to and is common in each request. Other data is request-specific.
-#[derive(Deserialize)]
+#[derive(Default, Deserialize)]
 pub struct RpcInitReq<T> {
     // If the client ID isn't included, assume it's 0.
     #[serde(default)]


### PR DESCRIPTION
Makes `get_enabled_coins`, `task::init_trezor::init` and `wc_get_sessions` RPCs to accept empty `params` field without any breaking change on the API.

Closes https://github.com/KomodoPlatform/komodo-defi-framework/issues/2498