### PR TITLE
fix(sec-bug): handle no-login mode extensively

### DIFF
--- a/mm2src/coins/eth/eth_tests.rs
+++ b/mm2src/coins/eth/eth_tests.rs
@@ -991,6 +991,7 @@ fn test_get_enabled_erc20_by_contract_and_platform() {
     const BNB_TOKEN: &str = "1INCH-BEP20";
     const ETH_TOKEN: &str = "1INCH-ERC20";
 
+    let passphrase = "spice describe gravity federal blast come thank unfair canal monkey style afraid";
     let conf = json!({
         "coins": [{
           "coin": "BNB",
@@ -1071,15 +1072,11 @@ fn test_get_enabled_erc20_by_contract_and_platform() {
           },
           "derivation_path": "m/44'/60'"
         }],
-        "passphrase": "spice describe gravity federal blast come thank unfair canal monkey style afraid",
+        "passphrase": passphrase
     });
 
     let ctx = MmCtxBuilder::new().with_conf(conf).into_mm_arc();
-    CryptoCtx::init_with_iguana_passphrase(
-        ctx.clone(),
-        "spice describe gravity federal blast come thank unfair canal monkey style afraid",
-    )
-    .unwrap();
+    CryptoCtx::init_with_iguana_passphrase(ctx.clone(), passphrase).unwrap();
 
     let req_bnb_token = json!({
         "urls":["https://bsc-dataseed1.binance.org","https://bsc-dataseed1.defibit.io"],
@@ -1118,6 +1115,7 @@ fn test_fee_history() {
 fn test_gas_limit_conf() {
     use mm2_test_helpers::for_tests::ETH_SEPOLIA_SWAP_CONTRACT;
 
+    let passphrase = "123456";
     let conf = json!({
         "coins": [{
             "coin": "ETH",
@@ -1137,11 +1135,11 @@ fn test_gas_limit_conf() {
                 "erc20_sender_refund": 110000
             }
         }],
-        "passphrase": "123456"
+        "passphrase": passphrase
     });
 
     let ctx = MmCtxBuilder::new().with_conf(conf).into_mm_arc();
-    CryptoCtx::init_with_iguana_passphrase(ctx.clone(), "123456").unwrap();
+    CryptoCtx::init_with_iguana_passphrase(ctx.clone(), passphrase).unwrap();
 
     let req = json!({
         "urls":ETH_SEPOLIA_NODES,

--- a/mm2src/coins/eth/eth_tests.rs
+++ b/mm2src/coins/eth/eth_tests.rs
@@ -993,84 +993,85 @@ fn test_get_enabled_erc20_by_contract_and_platform() {
 
     let conf = json!({
         "coins": [{
-      "coin": "BNB",
-      "name": "binancesmartchain",
-      "fname": "Binance Coin",
-      "avg_blocktime": 3,
-      "rpcport": 80,
-      "mm2": 1,
-      "use_access_list": true,
-      "max_eth_tx_type": 2,
-      "required_confirmations": 3,
-      "protocol": {
-        "type": "ETH",
-        "protocol_data": {
-            "chain_id": 56
-        }
-      },
-      "derivation_path": "m/44'/60'",
-      "trezor_coin": "Binance Smart Chain",
-      "links": {
-        "homepage": "https://www.binance.org"
-      }
-    },{
-      "coin": BNB_TOKEN,
-      "name": "1inch_bep20",
-      "fname": "1Inch",
-      "rpcport": 80,
-      "mm2": 1,
-      "avg_blocktime": 3,
-      "required_confirmations": 3,
-      "protocol": {
-        "type": "ERC20",
-        "protocol_data": {
-          "platform": "BNB",
-          "contract_address": "0x111111111117dC0aa78b770fA6A738034120C302"
-        }
-      },
-      "derivation_path": "m/44'/60'",
-      "use_access_list": true,
-      "max_eth_tx_type": 2,
-      "gas_limit": {
-          "eth_send_erc20": 60000,
-          "erc20_payment": 110000,
-          "erc20_receiver_spend": 85000,
-          "erc20_sender_refund": 85000
-      }
-    },{
-      "coin": "ETH",
-      "name": "ethereum",
-      "fname": "Ethereum",
-      "rpcport": 80,
-      "mm2": 1,
-      "sign_message_prefix": "Ethereum Signed Message:\n",
-      "required_confirmations": 3,
-      "avg_blocktime": 15,
-      "protocol": {
-        "type": "ETH",
-        "protocol_data": {
-            "chain_id": 1
-        }
-      },
-      "derivation_path": "m/44'/60'"
-    },{
-      "coin": ETH_TOKEN,
-      "name": "1inch_erc20",
-      "fname": "1Inch",
-      "rpcport": 80,
-      "mm2": 1,
-      "avg_blocktime": 15,
-      "required_confirmations": 3,
-      "decimals": 18,
-      "protocol": {
-        "type": "ERC20",
-        "protocol_data": {
-          "platform": "ETH",
-          "contract_address": "0x111111111117dC0aa78b770fA6A738034120C302"
-        }
-      },
-      "derivation_path": "m/44'/60'"
-    }]
+          "coin": "BNB",
+          "name": "binancesmartchain",
+          "fname": "Binance Coin",
+          "avg_blocktime": 3,
+          "rpcport": 80,
+          "mm2": 1,
+          "use_access_list": true,
+          "max_eth_tx_type": 2,
+          "required_confirmations": 3,
+          "protocol": {
+            "type": "ETH",
+            "protocol_data": {
+                "chain_id": 56
+            }
+          },
+          "derivation_path": "m/44'/60'",
+          "trezor_coin": "Binance Smart Chain",
+          "links": {
+            "homepage": "https://www.binance.org"
+          }
+        },{
+          "coin": BNB_TOKEN,
+          "name": "1inch_bep20",
+          "fname": "1Inch",
+          "rpcport": 80,
+          "mm2": 1,
+          "avg_blocktime": 3,
+          "required_confirmations": 3,
+          "protocol": {
+            "type": "ERC20",
+            "protocol_data": {
+              "platform": "BNB",
+              "contract_address": "0x111111111117dC0aa78b770fA6A738034120C302"
+            }
+          },
+          "derivation_path": "m/44'/60'",
+          "use_access_list": true,
+          "max_eth_tx_type": 2,
+          "gas_limit": {
+              "eth_send_erc20": 60000,
+              "erc20_payment": 110000,
+              "erc20_receiver_spend": 85000,
+              "erc20_sender_refund": 85000
+          }
+        },{
+          "coin": "ETH",
+          "name": "ethereum",
+          "fname": "Ethereum",
+          "rpcport": 80,
+          "mm2": 1,
+          "sign_message_prefix": "Ethereum Signed Message:\n",
+          "required_confirmations": 3,
+          "avg_blocktime": 15,
+          "protocol": {
+            "type": "ETH",
+            "protocol_data": {
+                "chain_id": 1
+            }
+          },
+          "derivation_path": "m/44'/60'"
+        },{
+          "coin": ETH_TOKEN,
+          "name": "1inch_erc20",
+          "fname": "1Inch",
+          "rpcport": 80,
+          "mm2": 1,
+          "avg_blocktime": 15,
+          "required_confirmations": 3,
+          "decimals": 18,
+          "protocol": {
+            "type": "ERC20",
+            "protocol_data": {
+              "platform": "ETH",
+              "contract_address": "0x111111111117dC0aa78b770fA6A738034120C302"
+            }
+          },
+          "derivation_path": "m/44'/60'"
+        }],
+        "passphrase": "spice describe gravity federal blast come thank unfair canal monkey style afraid",
     });
 
     let ctx = MmCtxBuilder::new().with_conf(conf).into_mm_arc();
@@ -1135,7 +1136,8 @@ fn test_gas_limit_conf() {
                 "erc20_receiver_spend": 130000,
                 "erc20_sender_refund": 110000
             }
-        }]
+        }],
+        "passphrase": "123456"
     });
 
     let ctx = MmCtxBuilder::new().with_conf(conf).into_mm_arc();

--- a/mm2src/coins/eth/eth_wasm_tests.rs
+++ b/mm2src/coins/eth/eth_wasm_tests.rs
@@ -30,8 +30,8 @@ async fn init_eth_coin_helper() -> Result<(MmArc, MmCoinEnum), String> {
             "rpcport": 80,
             "mm2": 1,
             "max_eth_tx_type": 2,
-            "passphrase": passphrase,
-        }]
+        }],
+        "passphrase": passphrase,
     });
 
     let ctx = MmCtxBuilder::new().with_conf(conf).into_mm_arc();

--- a/mm2src/coins/eth/eth_wasm_tests.rs
+++ b/mm2src/coins/eth/eth_wasm_tests.rs
@@ -15,6 +15,7 @@ fn pass() {
 }
 
 async fn init_eth_coin_helper() -> Result<(MmArc, MmCoinEnum), String> {
+    let passphrase = "spice describe gravity federal blast come thank unfair canal monkey style afraid";
     let conf = json!({
         "coins": [{
             "coin": "ETH",
@@ -28,16 +29,13 @@ async fn init_eth_coin_helper() -> Result<(MmArc, MmCoinEnum), String> {
             },
             "rpcport": 80,
             "mm2": 1,
-            "max_eth_tx_type": 2
+            "max_eth_tx_type": 2,
+            "passphrase": passphrase,
         }]
     });
 
     let ctx = MmCtxBuilder::new().with_conf(conf).into_mm_arc();
-    CryptoCtx::init_with_iguana_passphrase(
-        ctx.clone(),
-        "spice describe gravity federal blast come thank unfair canal monkey style afraid",
-    )
-    .unwrap();
+    CryptoCtx::init_with_iguana_passphrase(ctx.clone(), passphrase).unwrap();
 
     let req = json!({
         "urls":ETH_SEPOLIA_NODES,

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -5137,6 +5137,10 @@ pub fn is_wallet_only_ticker(ctx: &MmArc, ticker: &str) -> bool {
 ///
 /// * `req` - Payload of the corresponding "enable" or "electrum" RPC request.
 pub async fn lp_coininit(ctx: &MmArc, ticker: &str, req: &Json) -> Result<MmCoinEnum, String> {
+    if ctx.is_no_login_mode() {
+        return ERR!("Cannot enable coins in no-login mode.");
+    }
+
     let cctx = try_s!(CoinsContext::from_ctx(ctx));
     {
         let coins = cctx.coins.lock().await;

--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -510,7 +510,9 @@ async fn offline_iguana_keys_export_internal(
 
             let prefix_values = extract_prefix_values(&ctx, &ticker, &coin_conf)?;
 
-            let passphrase = ctx.conf["passphrase"].as_str().unwrap_or("");
+            let passphrase = ctx.conf["passphrase"].as_str().ok_or_else(|| {
+                OfflineKeysError::Internal("Couldn't derive 'passphrase' from the KDF configuration.".to_owned())
+            })?;
 
             let key_pair = {
                 match key_pair_from_seed(passphrase) {

--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -100,6 +100,8 @@ pub enum OfflineKeysError {
     MissingPrefixValue { ticker: String, prefix_type: String },
     #[display(fmt = "Invalid parameters: start_index and end_index are only valid for HD mode")]
     InvalidParametersForMode,
+    #[display(fmt = "Cannot get private key in no-login mode.")]
+    NotAllowedInNoLoginMode,
 }
 
 #[derive(Debug, Clone)]
@@ -116,9 +118,10 @@ impl HttpStatusCode for OfflineKeysError {
             Self::CoinConfigNotFound(_) => StatusCode::BAD_REQUEST,
             Self::KeyDerivationFailed { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             Self::InvalidHdRange { .. } => StatusCode::BAD_REQUEST,
-            Self::HdRangeTooLarge => StatusCode::BAD_REQUEST,
             Self::MissingPrefixValue { .. } => StatusCode::BAD_REQUEST,
-            Self::InvalidParametersForMode => StatusCode::BAD_REQUEST,
+            Self::HdRangeTooLarge | Self::NotAllowedInNoLoginMode | Self::InvalidParametersForMode => {
+                StatusCode::BAD_REQUEST
+            },
             Self::ProtocolParseError { .. } => StatusCode::BAD_REQUEST,
         }
     }
@@ -645,6 +648,10 @@ pub async fn get_private_keys(
     ctx: MmArc,
     req: GetPrivateKeysRequest,
 ) -> Result<GetPrivateKeysResponse, MmError<OfflineKeysError>> {
+    if ctx.is_no_login_mode() {
+        return MmError::err(OfflineKeysError::NotAllowedInNoLoginMode);
+    }
+
     let mode = req.mode.unwrap_or_else(|| {
         if ctx.enable_hd() {
             KeyExportMode::Hd

--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -974,7 +974,8 @@ mod tests {
         let ctx = MmCtxBuilder::new()
             .with_conf(json!({
                 "coins": [btc_conf],
-                "rpc_password": "test123"
+                "rpc_password": "test123",
+                "passphrase": TEST_MNEMONIC,
             }))
             .into_mm_arc();
 
@@ -1008,7 +1009,8 @@ mod tests {
         let ctx = MmCtxBuilder::new()
             .with_conf(json!({
                 "coins": [btc_conf],
-                "rpc_password": "test123"
+                "rpc_password": "test123",
+                "passphrase": TEST_MNEMONIC,
             }))
             .into_mm_arc();
 
@@ -1102,7 +1104,8 @@ mod tests {
         let ctx = MmCtxBuilder::new()
             .with_conf(json!({
                 "coins": [arrr_conf],
-                "rpc_password": "test123"
+                "rpc_password": "test123",
+                "passphrase": TEST_SEED,
             }))
             .into_mm_arc();
 
@@ -1163,15 +1166,17 @@ mod tests {
     async fn test_eth_iguana_eip55_formatting() {
         use mm2_test_helpers::for_tests::eth_dev_conf;
 
+        let passphrase = "test_passphrase_for_eip55";
         let ctx = MmCtxBuilder::new()
             .with_conf(json!({
                 "coins": [eth_dev_conf()],
-                "rpc_password": "test123"
+                "rpc_password": "test123",
+                "passphrase": passphrase,
             }))
             .into_mm_arc();
 
         // Initialize with a test passphrase for Iguana mode
-        CryptoCtx::init_with_iguana_passphrase(ctx.clone(), "test_passphrase_for_eip55").unwrap();
+        CryptoCtx::init_with_iguana_passphrase(ctx.clone(), passphrase).unwrap();
 
         let req = GetPrivateKeysRequest {
             coins: vec!["ETH".to_string()],

--- a/mm2src/coins_activation/src/platform_coin_with_tokens.rs
+++ b/mm2src/coins_activation/src/platform_coin_with_tokens.rs
@@ -296,6 +296,8 @@ pub enum EnablePlatformCoinWithTokensError {
     #[display(fmt = "WalletConnect Error: {_0}")]
     WalletConnectError(String),
     PlatformCoinMismatch,
+    #[display(fmt = "Cannot enable coins in no-login mode.")]
+    CannotEnableInNoLoginMode,
 }
 
 impl From<CoinConfWithProtocolError> for EnablePlatformCoinWithTokensError {
@@ -390,6 +392,7 @@ impl HttpStatusCode for EnablePlatformCoinWithTokensError {
             | EnablePlatformCoinWithTokensError::FailedSpawningBalanceEvents(_)
             | EnablePlatformCoinWithTokensError::WalletConnectError(_)
             | EnablePlatformCoinWithTokensError::PlatformCoinMismatch
+            | EnablePlatformCoinWithTokensError::CannotEnableInNoLoginMode
             | EnablePlatformCoinWithTokensError::UnexpectedTokenProtocol { .. } => StatusCode::BAD_REQUEST,
             EnablePlatformCoinWithTokensError::Transport(_) => StatusCode::BAD_GATEWAY,
         }
@@ -441,6 +444,10 @@ where
     Platform: PlatformCoinWithTokensActivationOps,
     EnablePlatformCoinWithTokensError: From<Platform::ActivationError>,
 {
+    if ctx.is_no_login_mode() {
+        return MmError::err(EnablePlatformCoinWithTokensError::CannotEnableInNoLoginMode);
+    }
+
     if req.request.is_hw_policy() {
         return MmError::err(EnablePlatformCoinWithTokensError::UnexpectedDeviceActivationPolicy);
     }

--- a/mm2src/crypto/src/crypto_ctx.rs
+++ b/mm2src/crypto/src/crypto_ctx.rs
@@ -31,6 +31,8 @@ pub enum CryptoInitError {
     #[display(fmt = "Invalid passphrase: '{_0}'")]
     InvalidPassphrase(PrivKeyError),
     Internal(String),
+    #[display(fmt = "Cannot initialize in no-login mode.")]
+    CannotInitInNoLoginMode,
 }
 
 impl From<PrivKeyError> for CryptoInitError {
@@ -54,6 +56,8 @@ pub enum CryptoCtxError {
     NotInitialized,
     #[display(fmt = "Internal error: {_0}")]
     Internal(String),
+    #[display(fmt = "Cannot use `CryptoCtx` in no-login mode.")]
+    CannotInitInNoLoginMode,
 }
 
 #[derive(Debug)]
@@ -111,11 +115,16 @@ impl CryptoCtx {
         match CryptoCtx::from_ctx(ctx).split_mm() {
             Ok(_) => Ok(true),
             Err((CryptoCtxError::NotInitialized, _trace)) => Ok(false),
+            Err((CryptoCtxError::CannotInitInNoLoginMode, _trace)) => Ok(false),
             Err((other, trace)) => MmError::err_with_trace(InternalError(other.to_string()), trace),
         }
     }
 
     pub fn from_ctx(ctx: &MmArc) -> MmResult<Arc<CryptoCtx>, CryptoCtxError> {
+        if ctx.is_no_login_mode() {
+            return MmError::err(CryptoCtxError::CannotInitInNoLoginMode);
+        }
+
         let ctx_field = ctx
             .crypto_ctx
             .lock()

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -249,6 +249,10 @@ impl MmCtx {
         self.conf["i_am_seed"].as_bool().unwrap_or(false)
     }
 
+    pub fn is_no_login_mode(&self) -> bool {
+        self.conf["passphrase"].is_null()
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     pub fn rpc_ip_port(&self) -> Result<SocketAddr, String> {
         let port = match self.conf.get("rpcport") {

--- a/mm2src/mm2_core/src/mm_ctx.rs
+++ b/mm2src/mm2_core/src/mm_ctx.rs
@@ -250,7 +250,7 @@ impl MmCtx {
     }
 
     pub fn is_no_login_mode(&self) -> bool {
-        self.conf["passphrase"].is_null()
+        self.conf["passphrase"].is_null() && self.conf["wallet_name"].is_null()
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/mm2src/mm2_main/src/lp_native_dex.rs
+++ b/mm2src/mm2_main/src/lp_native_dex.rs
@@ -434,6 +434,10 @@ pub async fn lp_init_continue(ctx: MmArc) -> MmInitResult<()> {
 pub async fn lp_init(ctx: MmArc, version: String, datetime: String) -> MmInitResult<()> {
     info!("Version: {} DT {}", version, datetime);
 
+    if ctx.is_no_login_mode() {
+        info!("Running on no-login mode. Wallet operations will be unavailable.");
+    }
+
     // Ensure the database root directory exists before initializing the wallet passphrase.
     // This is necessary to store the encrypted wallet passphrase if needed.
     #[cfg(not(target_arch = "wasm32"))]

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -541,7 +541,7 @@ where
     match CryptoCtx::from_ctx(ctx).split_mm() {
         Ok(crypto_ctx) => Ok(Some(CryptoCtx::mm2_internal_pubkey_hex(crypto_ctx.as_ref()))),
         Err((CryptoCtxError::NotInitialized, _)) => Ok(None),
-        Err((CryptoCtxError::Internal(error), trace)) => MmError::err_with_trace(err_construct(error), trace),
+        Err((e, trace)) => MmError::err_with_trace(err_construct(e.to_string()), trace),
     }
 }
 

--- a/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/mm2_tests_inner.rs
@@ -5765,6 +5765,33 @@ fn test_no_login() {
 
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
+fn test_no_login_get_private_keys() {
+    let coins = json!([rick_conf(), morty_conf()]);
+    let seednode_passphrase = get_passphrase(&".env.seed", "BOB_PASSPHRASE").unwrap();
+    let seednode_conf = Mm2TestConf::seednode(&seednode_passphrase, &coins);
+    let seednode = MarketMakerIt::start(seednode_conf.conf, seednode_conf.rpc_password, None).unwrap();
+    let (_dump_log, _dump_dashboard) = seednode.mm_dump();
+    log!("log path: {}", seednode.log_path.display());
+
+    let no_login_conf = Mm2TestConf::no_login_node(&coins, &[&seednode.ip.to_string()]);
+    let mm = MarketMakerIt::start(no_login_conf.conf, no_login_conf.rpc_password, None).unwrap();
+
+    let rc = block_on(mm.rpc(&json! ({
+        "userpass": mm.userpass,
+        "method": "get_private_keys",
+        "mmrpc": "2.0",
+        "params": {
+            "coins": []
+        }
+    })))
+    .unwrap();
+
+    assert!(rc.0.is_client_error());
+    assert!(rc.1.contains("NotAllowedInNoLoginMode"));
+}
+
+#[test]
+#[cfg(not(target_arch = "wasm32"))]
 fn test_gui_storage_accounts_functionality() {
     let passphrase = "test_gui_storage passphrase";
 

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -343,8 +343,7 @@ impl Mm2TestConf {
                 "i_am_seed": true,
                 "wallet_name": wallet_name,
                 "wallet_password": wallet_password,
-                "is_bootstrap_node": true,
-                "passphrase": "",
+                "is_bootstrap_node": true
             }),
             rpc_password: DEFAULT_RPC_PASSWORD.into(),
         }

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -343,7 +343,8 @@ impl Mm2TestConf {
                 "i_am_seed": true,
                 "wallet_name": wallet_name,
                 "wallet_password": wallet_password,
-                "is_bootstrap_node": true
+                "is_bootstrap_node": true,
+                "passphrase": "",
             }),
             rpc_password: DEFAULT_RPC_PASSWORD.into(),
         }


### PR DESCRIPTION
There is a potential risk that if users make a typo in the `passphrase` field of the KDF config and then run the `get_private_keys` RPC, the returned private key will be incorrect because an empty string will be used as the passphrase. A typo in `passphrase` means the field is not defined, which causes the KDF to assume the user wants to operate in no-login mode (this is exactly what happens in #2458).

This PR disables coin activation and `get_private_keys` in no-login mode to prevent any risk on no-login mode, so users do not risk their funds and private keys due to a simple typo.

Resolves: #2458