### PR TITLE
fix(evm-swapv2): no mempool inclusion required for maker payment validation

### DIFF
--- a/mm2src/coins/eth/eth_swap_v2/eth_maker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_maker_swap_v2.rs
@@ -133,9 +133,17 @@ impl EthCoin {
         let swap_id = self.etomic_swap_id_v2(args.time_lock, args.maker_secret_hash);
 
         let tx = args.maker_payment_tx;
-        let maker_address = public_to_address(args.maker_pub);
-        let taker_address = self.my_addr().await;
 
+        let maker_address = public_to_address(args.maker_pub);
+        if tx.sender() != maker_address {
+            return MmError::err(ValidatePaymentError::WrongPaymentTx(format!(
+                "Payment tx was sent from wrong address, expected {:?}, got {:?}",
+                maker_address,
+                tx.sender()
+            )));
+        }
+
+        let taker_address = self.my_addr().await;
         match tx.unsigned().action() {
             Action::Call(to) => {
                 if *to != maker_swap_v2_contract {
@@ -150,14 +158,6 @@ impl EthCoin {
                     "Tx action must be Call, found Create instead".to_string(),
                 ));
             },
-        }
-
-        if tx.sender() != maker_address {
-            return MmError::err(ValidatePaymentError::WrongPaymentTx(format!(
-                "Payment tx was sent from wrong address, expected {:?}, got {:?}",
-                maker_address,
-                tx.sender()
-            )));
         }
 
         let validation_args = {

--- a/mm2src/coins/eth/eth_swap_v2/eth_maker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_maker_swap_v2.rs
@@ -1,4 +1,6 @@
-use super::{validate_amount, EthPaymentType, PaymentMethod, PrepareTxDataError, ZERO_VALUE};
+use super::{
+    validate_amount, validate_from_to_addresses, EthPaymentType, PaymentMethod, PrepareTxDataError, ZERO_VALUE,
+};
 use crate::coin_errors::{ValidatePaymentError, ValidatePaymentResult};
 use crate::eth::{
     decode_contract_call, get_function_input_data, u256_from_big_decimal, EthCoin, EthCoinType, SignedEthTx,
@@ -133,39 +135,15 @@ impl EthCoin {
         let swap_id = self.etomic_swap_id_v2(args.time_lock, args.maker_secret_hash);
 
         let tx = args.maker_payment_tx;
-
         let maker_address = public_to_address(args.maker_pub);
-        if tx.sender() != maker_address {
-            return MmError::err(ValidatePaymentError::WrongPaymentTx(format!(
-                "Payment tx was sent from wrong address, expected {:?}, got {:?}",
-                maker_address,
-                tx.sender()
-            )));
-        }
-
-        let taker_address = self.my_addr().await;
-        match tx.unsigned().action() {
-            Action::Call(to) => {
-                if *to != maker_swap_v2_contract {
-                    return MmError::err(ValidatePaymentError::WrongPaymentTx(format!(
-                        "Payment tx was sent to wrong address, expected {:?}, got {:?}",
-                        maker_swap_v2_contract, to
-                    )));
-                }
-            },
-            Action::Create => {
-                return MmError::err(ValidatePaymentError::WrongPaymentTx(
-                    "Tx action must be Call, found Create instead".to_string(),
-                ));
-            },
-        }
+        validate_from_to_addresses(tx, maker_address, maker_swap_v2_contract).map_mm_err()?;
 
         let validation_args = {
             let amount = u256_from_big_decimal(&args.amount, self.decimals).map_mm_err()?;
             MakerValidationArgs {
                 swap_id,
                 amount,
-                taker: taker_address,
+                taker: self.my_addr().await,
                 taker_secret_hash,
                 maker_secret_hash,
                 payment_time_lock: args.time_lock,

--- a/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
@@ -3,10 +3,10 @@ use super::{
     PaymentMethod, PrepareTxDataError, SpendTxSearchParams, ZERO_VALUE,
 };
 use crate::eth::{
-    decode_contract_call, get_function_input_data, u256_from_big_decimal, EthCoin, EthCoinType, ParseCoinAssocTypes,
-    RefundFundingSecretArgs, RefundTakerPaymentArgs, SendTakerFundingArgs, SignedEthTx, SwapTxTypeWithSecretHash,
-    TakerPaymentStateV2, TransactionErr, ValidateSwapV2TxError, ValidateSwapV2TxResult, ValidateTakerFundingArgs,
-    TAKER_SWAP_V2,
+    decode_contract_call, get_function_input_data, signed_tx_from_web3_tx, u256_from_big_decimal, EthCoin, EthCoinType,
+    ParseCoinAssocTypes, RefundFundingSecretArgs, RefundTakerPaymentArgs, SendTakerFundingArgs, SignedEthTx,
+    SwapTxTypeWithSecretHash, TakerPaymentStateV2, TransactionErr, ValidateSwapV2TxError, ValidateSwapV2TxResult,
+    ValidateTakerFundingArgs, TAKER_SWAP_V2,
 };
 use crate::{
     FindPaymentSpendError, FundingTxSpend, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs, SearchForFundingSpendErr,
@@ -172,7 +172,9 @@ impl EthCoin {
             ))
         })?;
         let taker_address = public_to_address(args.taker_pub);
-        validate_from_to_addresses(tx_from_rpc, taker_address, taker_swap_v2_contract).map_mm_err()?;
+        let signed_tx = signed_tx_from_web3_tx(tx_from_rpc.clone())
+            .map_err(|err| ValidateSwapV2TxError::WrongPaymentTx(format!("Could not parse tx: {:?}", err)))?;
+        validate_from_to_addresses(&signed_tx, taker_address, taker_swap_v2_contract).map_mm_err()?;
 
         let validation_args = {
             let dex_fee = u256_from_big_decimal(&args.dex_fee.fee_amount().into(), self.decimals).map_mm_err()?;

--- a/mm2src/coins/eth/eth_swap_v2/mod.rs
+++ b/mm2src/coins/eth/eth_swap_v2/mod.rs
@@ -1,4 +1,5 @@
 use crate::eth::{decode_contract_call, signed_tx_from_web3_tx, EthCoin, EthCoinType, Transaction, TransactionErr};
+use crate::hd_wallet::DisplayAddress;
 use crate::{FindPaymentSpendError, MarketCoinOps};
 use common::executor::Timer;
 use common::log::{error, info};
@@ -181,7 +182,8 @@ pub(crate) fn validate_from_to_addresses(
 ) -> Result<(), MmError<ValidatePaymentV2Err>> {
     if signed_tx.sender() != expected_from {
         return MmError::err(ValidatePaymentV2Err::WrongPaymentTx(format!(
-            "Payment tx {signed_tx:?} was sent from wrong address, expected {expected_from:?}"
+            "Payment tx {signed_tx:?} was sent from wrong address, expected {}",
+            expected_from.display_address()
         )));
     }
 
@@ -190,8 +192,9 @@ pub(crate) fn validate_from_to_addresses(
         Action::Call(to) => {
             if *to != expected_to {
                 return MmError::err(ValidatePaymentV2Err::WrongPaymentTx(format!(
-                    "Payment tx was sent to wrong address, expected {:?}, got {:?}",
-                    expected_to, to
+                    "Payment tx was sent to wrong address, expected {}, got {}",
+                    expected_to.display_address(),
+                    to.display_address()
                 )));
             }
         },

--- a/mm2src/coins/eth/eth_swap_v2/mod.rs
+++ b/mm2src/coins/eth/eth_swap_v2/mod.rs
@@ -6,13 +6,13 @@ use common::now_sec;
 use derive_more::Display;
 use enum_derives::EnumFromStringify;
 use ethabi::{Contract, Token};
-use ethcore_transaction::SignedTransaction as SignedEthTx;
+use ethcore_transaction::{Action, SignedTransaction as SignedEthTx};
 use ethereum_types::{Address, H256, U256};
 use futures::compat::Future01CompatExt;
 use mm2_err_handle::prelude::{MmError, MmResult};
 use mm2_number::BigDecimal;
 use num_traits::Signed;
-use web3::types::{Transaction as Web3Tx, TransactionId};
+use web3::types::TransactionId;
 
 pub(crate) mod eth_maker_swap_v2;
 pub(crate) mod eth_taker_swap_v2;
@@ -175,21 +175,33 @@ impl EthCoin {
 }
 
 pub(crate) fn validate_from_to_addresses(
-    tx_from_rpc: &Web3Tx,
+    signed_tx: &SignedEthTx,
     expected_from: Address,
     expected_to: Address,
 ) -> Result<(), MmError<ValidatePaymentV2Err>> {
-    if tx_from_rpc.from != Some(expected_from) {
+    if signed_tx.sender() != expected_from {
         return MmError::err(ValidatePaymentV2Err::WrongPaymentTx(format!(
-            "Payment tx {tx_from_rpc:?} was sent from wrong address, expected {expected_from:?}"
+            "Payment tx {signed_tx:?} was sent from wrong address, expected {expected_from:?}"
         )));
     }
+
     // (in NFT case) as NFT owner calls "safeTransferFrom" directly, then in Transaction 'to' field we expect token_address
-    if tx_from_rpc.to != Some(expected_to) {
-        return MmError::err(ValidatePaymentV2Err::WrongPaymentTx(format!(
-            "Payment tx {tx_from_rpc:?} was sent to wrong address, expected {expected_to:?}",
-        )));
+    match signed_tx.unsigned().action() {
+        Action::Call(to) => {
+            if *to != expected_to {
+                return MmError::err(ValidatePaymentV2Err::WrongPaymentTx(format!(
+                    "Payment tx was sent to wrong address, expected {:?}, got {:?}",
+                    expected_to, to
+                )));
+            }
+        },
+        Action::Create => {
+            return MmError::err(ValidatePaymentV2Err::WrongPaymentTx(
+                "Tx action must be Call, found Create instead".to_string(),
+            ));
+        },
     }
+
     Ok(())
 }
 

--- a/mm2src/coins/eth/nft_swap_v2/mod.rs
+++ b/mm2src/coins/eth/nft_swap_v2/mod.rs
@@ -8,7 +8,7 @@ use mm2_number::BigDecimal;
 use num_traits::Signed;
 use web3::types::TransactionId;
 
-use super::ContractType;
+use super::{signed_tx_from_web3_tx, ContractType};
 use crate::coin_errors::{ValidatePaymentError, ValidatePaymentResult};
 use crate::eth::eth_swap_v2::{validate_from_to_addresses, PaymentMethod, PrepareTxDataError, ZERO_VALUE};
 use crate::eth::{
@@ -92,7 +92,9 @@ impl EthCoin {
                         args.maker_payment_tx.tx_hash()
                     ))
                 })?;
-                validate_from_to_addresses(tx_from_rpc, maker_address, *token_address).map_mm_err()?;
+                let signed_tx = signed_tx_from_web3_tx(tx_from_rpc.clone())
+                    .map_err(|err| ValidatePaymentError::WrongPaymentTx(format!("Could not parse tx: {:?}", err)))?;
+                validate_from_to_addresses(&signed_tx, maker_address, *token_address).map_mm_err()?;
 
                 let (decoded, bytes_index) = get_decoded_tx_data_and_bytes_index(contract_type, &tx_from_rpc.input.0)?;
 


### PR DESCRIPTION
### Problem
Taker-side validation failed when the maker broadcasted via private/MEV-protected relays (e.g., Polygon protect RPC), because the tx wasn’t visible on public RPCs. This caused false negatives and unnecessary refunds.

### What this PR changes
 Validate maker payment from the signed tx bytes (offline), without requiring mempool presence,  while deferring on-chain visibility to the existing confirmation step.

### Why this isn’t a complete solution
Offline checks don’t prove the maker actually broadcasted the tx. If the maker never submits the tx (and taker doesn’t rebroadcast it), the taker still waits until the maker-payment confirmation timeout before switching to the “immediate refund” path (refund via taker’s secret). This fixes the false‑negatives, but the drawback is that fast‑fail isn’t kept. The taker now may wait until the timeout if the maker never broadcasts.

### Future Work
- [ ] If this approach is accepted, apply it to other swap steps as needed:
   - `validate_taker_funding_impl`: Only a brief visibility delay is needed to find the transaction, since there’s no confirmation step yet (we may need to add one). Note: there is no need for a fast-fail for this step as the maker’s payment hasn’t been broadcast.
- [ ] Add taker rebroadcast fallback after a short pre-wait if the maker’s tx isn’t visible
- [ ] Treat rebroadcast as success only if:
   - `send_raw_transaction` returns the expected tx hash, or
   - Error explicitly indicates “already known” / “already imported” / “known transaction”
 - [ ] Do not treat “nonce too low” or “replacement underpriced” as success; instead:
    -  Immediately query `eth_getTransactionByHash` and proceed only if the hash is visible (pending or included) 