### PR TITLE
fix(zcoin): exact-anchor witnesses in wasm get_spendable_notes

### DIFF
--- a/mm2src/coins/lightning/ln_sql.rs
+++ b/mm2src/coins/lightning/ln_sql.rs
@@ -1104,7 +1104,7 @@ mod tests {
                 PaymentType::InboundPayment
             };
             let status_rng: u8 = rng.gen();
-            let status = if status_rng % 3 == 0 {
+            let status = if status_rng.is_multiple_of(3) {
                 HTLCStatus::Succeeded
             } else if status_rng % 3 == 1 {
                 HTLCStatus::Pending

--- a/mm2src/coins/nft/storage/mod.rs
+++ b/mm2src/coins/nft/storage/mod.rs
@@ -1,4 +1,3 @@
-use crate::eth::EthTxFeeDetails;
 use crate::nft::nft_structs::{
     Chain, Nft, NftList, NftListFilters, NftTokenAddrId, NftTransferHistory, NftTransferHistoryFilters,
     NftsTransferHistoryList, TransferMeta,
@@ -7,10 +6,15 @@ use async_trait::async_trait;
 use ethereum_types::Address;
 use mm2_err_handle::mm_error::MmResult;
 use mm2_err_handle::mm_error::NotMmError;
-use mm2_number::{BigDecimal, BigUint};
-use serde::{Deserialize, Serialize};
+use mm2_number::BigUint;
 use std::collections::HashSet;
 use std::num::NonZeroUsize;
+
+cfg_native! {
+    use crate::eth::EthTxFeeDetails;
+    use mm2_number::BigDecimal;
+    use serde::{Deserialize, Serialize};
+}
 
 #[cfg(any(test, target_arch = "wasm32"))]
 pub(crate) mod db_test_helpers;
@@ -231,6 +235,7 @@ fn get_offset_limit(max: bool, limit: usize, page_number: Option<NonZeroUsize>, 
 
 /// `NftDetailsJson` structure contains immutable parameters that are not needed for queries.
 /// This is what `details_json` string contains in db table.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub(crate) struct NftDetailsJson {
     pub(crate) owner_of: Address,
@@ -241,6 +246,7 @@ pub(crate) struct NftDetailsJson {
 
 /// `TransferDetailsJson` structure contains immutable parameters that are not needed for queries.
 /// This is what `details_json` string contains in db table.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub(crate) struct TransferDetailsJson {
     pub(crate) block_hash: Option<String>,

--- a/mm2src/coins/z_coin/storage/walletdb/wasm/storage.rs
+++ b/mm2src/coins/z_coin/storage/walletdb/wasm/storage.rs
@@ -1317,7 +1317,8 @@ impl WalletRead for WalletIndexedDb {
             .cursor_builder()
             .only("ticker", &self.ticker)
             .map_mm_err()?
-            .bound("block", 0u32, u32::from(anchor_height + 1))
+            .only("block", u32::from(anchor_height))
+            .map_mm_err()?
             .open_cursor(WalletDbSaplingWitnessesTable::TICKER_BLOCK_INDEX)
             .await
             .map_mm_err()?

--- a/mm2src/mm2_bitcoin/keys/src/segwitaddress.rs
+++ b/mm2src/mm2_bitcoin/keys/src/segwitaddress.rs
@@ -193,7 +193,7 @@ mod tests {
     use Public;
 
     fn hex_to_bytes(s: &str) -> Option<Vec<u8>> {
-        if s.len() % 2 == 0 {
+        if s.len().is_multiple_of(2) {
             (0..s.len())
                 .step_by(2)
                 .map(|i| s.get(i..i + 2).and_then(|sub| u8::from_str_radix(sub, 16).ok()))

--- a/mm2src/mm2_main/src/lp_ordermatch/simple_market_maker.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch/simple_market_maker.rs
@@ -204,21 +204,6 @@ pub enum StartSimpleMakerBotError {
     InternalError(String),
 }
 
-#[derive(Debug, Deserialize, Display, Serialize, SerializeErrorType)]
-#[serde(tag = "error_type", content = "error_data")]
-pub enum SwapUpdateNotificationError {
-    #[display(fmt = "{_0}")]
-    MyRecentSwapsError(LatestSwapsErr),
-    #[display(fmt = "Swap info not available")]
-    SwapInfoNotAvailable,
-}
-
-impl From<LatestSwapsErr> for SwapUpdateNotificationError {
-    fn from(e: LatestSwapsErr) -> Self {
-        SwapUpdateNotificationError::MyRecentSwapsError(e)
-    }
-}
-
 impl HttpStatusCode for StartSimpleMakerBotError {
     fn status_code(&self) -> StatusCode {
         match self {

--- a/mm2src/mm2_main/src/lp_stats.rs
+++ b/mm2src/mm2_main/src/lp_stats.rs
@@ -11,7 +11,7 @@ use mm2_libp2p::application::request_response::network_info::NetworkInfoRequest;
 use mm2_libp2p::{encode_message, NetworkInfo, PeerId, RelayAddress, RelayAddressError};
 use mm2_net::ip_addr::ParseAddressError;
 use serde_json::{self as json, Value as Json};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::convert::TryInto;
 use std::sync::Arc;
 
@@ -180,11 +180,6 @@ pub async fn remove_node_from_version_stat(ctx: MmArc, req: Json) -> NodeVersion
     delete_node_info_from_db(&ctx, node_name).map_to_mm(NodeVersionError::DatabaseError)?;
 
     Ok("success".into())
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct Mm2VersionRes {
-    nodes: HashMap<String, String>,
 }
 
 fn process_get_version_request(ctx: MmArc) -> Result<Vec<u8>, String> {

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -18,7 +18,7 @@ use mm2_metrics::{MetricType, MetricsJson};
 use mm2_number::BigDecimal;
 use mm2_rpc::data::legacy::{BalanceResponse, ElectrumProtocol};
 use rand::Rng;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::{self as json, json, Value as Json};
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -41,6 +41,7 @@ cfg_native! {
     use futures::task::SpawnExt;
     use http::Request;
     use regex::Regex;
+    use serde::Deserialize;
     use std::fs;
     use std::io::Write;
     use std::net::Ipv4Addr;
@@ -1844,6 +1845,7 @@ where
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Serialize, Deserialize, Debug)]
 struct ToWaitForLogRe {
     ctx: u32,


### PR DESCRIPTION
This is to match the sqlite version from librustzcash https://github.com/KomodoPlatform/librustzcash/blob/4e030a0f44cc17f100bf5f019563be25c5b8755f/zcash_client_sqlite/src/wallet/transact.rs#L75