### PR TITLE
fix(tests): fix/remove kmd rewards failing test

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2493,17 +2493,11 @@ impl From<TendermintFeeDetails> for TxFeeDetails {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct KmdRewardsDetails {
     amount: BigDecimal,
-    /// Note that we don't have a case where this boolean is set to false.
-    /// It persists here though for backward compatibility and potential future use cases.
-    claimed_by_me: bool,
 }
 
 impl KmdRewardsDetails {
-    pub fn claimed_by_me(amount: BigDecimal) -> KmdRewardsDetails {
-        KmdRewardsDetails {
-            amount,
-            claimed_by_me: true,
-        }
+    pub fn new(amount: BigDecimal) -> KmdRewardsDetails {
+        KmdRewardsDetails { amount }
     }
 }
 

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2493,6 +2493,8 @@ impl From<TendermintFeeDetails> for TxFeeDetails {
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct KmdRewardsDetails {
     amount: BigDecimal,
+    /// Note that we don't have a case where this boolean is set to false.
+    /// It persists here though for backward compatibility and potential future use cases.
     claimed_by_me: bool,
 }
 

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -630,7 +630,7 @@ impl<'a, T: AsRef<UtxoCoinFields> + UtxoTxGenerationOps> UtxoTxBuilder<'a, T> {
     fn make_kmd_rewards_data(coin: &T, interest: u64) -> Option<KmdRewardsDetails> {
         let rewards_amount = big_decimal_from_sat_unsigned(interest, coin.as_ref().decimals);
         if coin.supports_interest() {
-            Some(KmdRewardsDetails::claimed_by_me(rewards_amount))
+            Some(KmdRewardsDetails::new(rewards_amount))
         } else {
             None
         }
@@ -4102,11 +4102,8 @@ pub async fn tx_details_by_hash<T: UtxoCommonOps>(
     //     // `fee = input_amount - actual_output_amount` or simplified `fee = input_amount - output_amount + kmd_rewards`
     //     let fee = input_amount as i64 - output_amount as i64 + kmd_rewards as i64;
     //
-    //     let my_address = &coin.as_ref().my_address;
-    //     let claimed_by_me = from_addresses.iter().all(|from| from == my_address) && to_addresses.contains(my_address);
     //     let kmd_rewards_details = KmdRewardsDetails {
     //         amount: big_decimal_from_sat_unsigned(kmd_rewards, coin.as_ref().decimals),
-    //         claimed_by_me,
     //     };
     //     (
     //         big_decimal_from_sat(fee, coin.as_ref().decimals),
@@ -4216,8 +4213,6 @@ where
 /// `actual_fee = input_amount - actual_output_amount` or `actual_fee = input_amount - output_amount + kmd_rewards`.
 /// Substitute [`TransactionDetails::fee`] to the last equation:
 /// `actual_fee = TransactionDetails::fee + kmd_rewards`
-///
-/// Note: This assumes that the KMD rewards is always claimed by us and thus sets the `claimed_by_me` field to true.
 pub async fn update_kmd_rewards<T>(
     coin: &T,
     tx_details: &mut TransactionDetails,
@@ -4255,7 +4250,7 @@ where
         }));
     }
 
-    tx_details.kmd_rewards = Some(KmdRewardsDetails::claimed_by_me(kmd_rewards));
+    tx_details.kmd_rewards = Some(KmdRewardsDetails::new(kmd_rewards));
     Ok(())
 }
 

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -933,10 +933,7 @@ fn test_withdraw_kmd_rewards_impl(
     let tx_details = block_on_f01(coin.withdraw(withdraw_req)).unwrap();
     assert_eq!(tx_details.fee_details, Some(expected_fee));
 
-    let expected_rewards = expected_rewards.map(|amount| KmdRewardsDetails {
-        amount,
-        claimed_by_me: true,
-    });
+    let expected_rewards = expected_rewards.map(|amount| KmdRewardsDetails { amount });
     assert_eq!(tx_details.kmd_rewards, expected_rewards);
 }
 
@@ -3345,14 +3342,13 @@ fn test_tx_details_kmd_rewards() {
 
     let expected_kmd_rewards = KmdRewardsDetails {
         amount: BigDecimal::from_str("0.10431954").unwrap(),
-        claimed_by_me: true,
     };
     assert_eq!(tx_details.kmd_rewards, Some(expected_kmd_rewards));
 }
 
-/// If the ticker is `KMD` AND no rewards were accrued due to a value less than 10 or for any other reasons,
-/// then `TransactionDetails::kmd_rewards` has to be `Some(0)`, not `None`.
 /// https://kmdexplorer.io/tx/f09e8894959e74c1e727ffa5a753a30bf2dc6d5d677cc1f24b7ee5bb64e32c7d
+/// If the rewards were not claimed by us (claimed by a different address than `my_address`), `kmd_rewards`
+/// should still show up in the transaction details (as it's independent of `my_address`).
 #[test]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_tx_details_kmd_rewards_claimed_by_other() {
@@ -3424,7 +3420,6 @@ fn test_update_kmd_rewards() {
 
     let expected_rewards = KmdRewardsDetails {
         amount: BigDecimal::from_str("0.10431954").unwrap(),
-        claimed_by_me: true,
     };
     assert_eq!(tx_details.kmd_rewards, Some(expected_rewards));
 

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -3318,7 +3318,6 @@ fn zer_mtp() {
 }
 
 #[test]
-#[ignore]
 fn test_tx_details_kmd_rewards() {
     let electrum = electrum_client_for_test(&[
         "electrum1.cipig.net:10001",
@@ -3332,10 +3331,11 @@ fn test_tx_details_kmd_rewards() {
     );
     let coin = utxo_coin_from_fields(fields);
 
-    let tx_details = get_tx_details_eq_for_both_versions(
+    let mut tx_details = get_tx_details_eq_for_both_versions(
         &coin,
         "535ffa3387d3fca14f4a4d373daf7edf00e463982755afce89bc8c48d8168024",
     );
+    block_on(coin.update_kmd_rewards(&mut tx_details, &mut HashMap::new())).expect("!update_kmd_rewards");
 
     let expected_fee = TxFeeDetails::Utxo(UtxoFeeDetails {
         coin: Some("KMD".into()),
@@ -3354,7 +3354,6 @@ fn test_tx_details_kmd_rewards() {
 /// then `TransactionDetails::kmd_rewards` has to be `Some(0)`, not `None`.
 /// https://kmdexplorer.io/tx/f09e8894959e74c1e727ffa5a753a30bf2dc6d5d677cc1f24b7ee5bb64e32c7d
 #[test]
-#[ignore]
 #[cfg(not(target_arch = "wasm32"))]
 fn test_tx_details_kmd_rewards_claimed_by_other() {
     const TX_HASH: &str = "f09e8894959e74c1e727ffa5a753a30bf2dc6d5d677cc1f24b7ee5bb64e32c7d";
@@ -3371,7 +3370,8 @@ fn test_tx_details_kmd_rewards_claimed_by_other() {
     );
     let coin = utxo_coin_from_fields(fields);
 
-    let tx_details = get_tx_details_eq_for_both_versions(&coin, TX_HASH);
+    let mut tx_details = get_tx_details_eq_for_both_versions(&coin, TX_HASH);
+    block_on(coin.update_kmd_rewards(&mut tx_details, &mut HashMap::new())).expect("!update_kmd_rewards");
 
     let expected_fee = TxFeeDetails::Utxo(UtxoFeeDetails {
         coin: Some("KMD".into()),
@@ -3379,11 +3379,10 @@ fn test_tx_details_kmd_rewards_claimed_by_other() {
     });
     assert_eq!(tx_details.fee_details, Some(expected_fee));
 
-    let expected_kmd_rewards = KmdRewardsDetails {
-        amount: BigDecimal::from_str("0.00022428").unwrap(),
-        claimed_by_me: false,
-    };
-    assert_eq!(tx_details.kmd_rewards, Some(expected_kmd_rewards));
+    assert_eq!(
+        tx_details.kmd_rewards.unwrap().amount,
+        BigDecimal::from_str("0.00022428").unwrap()
+    );
 }
 
 #[test]
@@ -3426,40 +3425,6 @@ fn test_update_kmd_rewards() {
     let expected_rewards = KmdRewardsDetails {
         amount: BigDecimal::from_str("0.10431954").unwrap(),
         claimed_by_me: true,
-    };
-    assert_eq!(tx_details.kmd_rewards, Some(expected_rewards));
-
-    let expected_fee_details = TxFeeDetails::Utxo(UtxoFeeDetails {
-        coin: Some("KMD".into()),
-        amount: BigDecimal::from_str("0.00001").unwrap(),
-    });
-    assert_eq!(tx_details.fee_details, Some(expected_fee_details));
-}
-
-#[test]
-fn test_update_kmd_rewards_claimed_not_by_me() {
-    // The custom 535ffa3387d3fca14f4a4d373daf7edf00e463982755afce89bc8c48d8168024 transaction with the additional 'from' address.
-    const OUTDATED_TX_DETAILS: &str = r#"{"tx_hex":"0400008085202f8901afcadb73880bc1c9e7ce96b8274c2e2a4547415e649f425f98791685be009b73020000006b483045022100b8fbb77efea482b656ad16fc53c5a01d289054c2e429bf1d7bab16c3e822a83602200b87368a95c046b2ce6d0d092185138a3f234a7eb0d7f8227b196ef32358b93f012103b1e544ce2d860219bc91314b5483421a553a7b33044659eff0be9214ed58adddffffffff01dd15c293000000001976a91483762a373935ca241d557dfce89171d582b486de88ac99fe9960000000000000000000000000000000","tx_hash":"535ffa3387d3fca14f4a4d373daf7edf00e463982755afce89bc8c48d8168024","from":["RMGJ9tRST45RnwEKHPGgBLuY3moSYP7Mhk", "RMDc4fvQeekJwrXxuaw1R2b7CTPEuVguMP"],"to":["RMGJ9tRST45RnwEKHPGgBLuY3moSYP7Mhk"],"total_amount":"24.68539379","spent_by_me":"24.68539379","received_by_me":"24.78970333","my_balance_change":"0.10430954","block_height":2387532,"timestamp":1620705483,"fee_details":{"type":"Utxo","amount":"-0.10430954"},"coin":"KMD","internal_id":"535ffa3387d3fca14f4a4d373daf7edf00e463982755afce89bc8c48d8168024"}"#;
-
-    let electrum = electrum_client_for_test(&[
-        "electrum1.cipig.net:10001",
-        "electrum2.cipig.net:10001",
-        "electrum3.cipig.net:10001",
-    ]);
-    let mut fields = utxo_coin_fields_for_test(electrum.into(), None, false);
-    fields.conf.ticker = "KMD".to_owned();
-    fields.derivation_method = DerivationMethod::SingleAddress(
-        Address::from_legacyaddress("RMGJ9tRST45RnwEKHPGgBLuY3moSYP7Mhk", &KMD_PREFIXES).unwrap(),
-    );
-    let coin = utxo_coin_from_fields(fields);
-
-    let mut input_transactions = HistoryUtxoTxMap::default();
-    let mut tx_details: TransactionDetails = json::from_str(OUTDATED_TX_DETAILS).unwrap();
-    block_on(coin.update_kmd_rewards(&mut tx_details, &mut input_transactions)).expect("!update_kmd_rewards");
-
-    let expected_rewards = KmdRewardsDetails {
-        amount: BigDecimal::from_str("0.10431954").unwrap(),
-        claimed_by_me: false,
     };
     assert_eq!(tx_details.kmd_rewards, Some(expected_rewards));
 


### PR DESCRIPTION
since the test was already duplicated of the other one above it (test_update_kmd_rewards) but only has the `from` addresses manually changed to trigger setting `claimed_by_me: false`, the test was removed all together.

noteably, we don't have a usecase ever where we get `claimed_by_me` is set to `false`. not internally, nor via the RPC. leaving the field though just for backward combatability and future extensions (maybe?).

also, unignored two other tests.