### PR TITLE
chore(ci): bump CI container image to debian bullseye-slim to match dev

### DIFF
--- a/.docker/Dockerfile.ci-container
+++ b/.docker/Dockerfile.ci-container
@@ -1,4 +1,4 @@
-FROM docker.io/debian:buster-slim
+FROM docker.io/debian:bullseye-slim
 
 MAINTAINER Onur Özkan <onur@komodoplatform.com>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 **Build and Dependency Management**:
 - A CI job was added to build macOS Universal2 artifacts for KDF, this combines `x86_64-apple-darwin` and `aarch64-apple-darwin` binaries via `lipo` to produce a single binary that runs natively on both Intel and Apple Silicon. The universal binary is uploaded as `kdf_<commit>-mac-universal.zip`. [#2628](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2628)
 - The `parity-util-mem` dependency was removed. [#2632](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2632)
+- CI container base image was bumped to `debian:bullseye-slim` [#2534](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2534) [#2641](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2641)
 
 ---
 


### PR DESCRIPTION
This PR backports the update of the CI container image to debian bullseye-slim from dev to staging branch. ref. https://github.com/KomodoPlatform/komodo-defi-framework/pull/2534

This will be re-propagated to dev only to preserve linear git history