### PR TITLE
Switch Rust toolchain from nightly to stable

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,25 @@
 [env]
+# Enables unstable features for specific crates to take advantage of useful
+# functionality not yet stabilized. Remove a crate from the list once all
+# required features are stabilized.
+#
+# # Core crates (used in production)
+#
+# - mm2_state_machine: Depends on `negative_impls` and `auto_traits`.
+# - mm2_err_handle: Depends on `negative_impls`, `auto_traits` and `allocator_api`.
+#
+# # Test crates (not leaked into the binary)
+#
+# - mocktopus: nightly only dependency.
+# - mocktopus_macros: nightly only dependency.
+# - docker_tests_main: Depends on `custom_test_frameworks` and `test`.
+# - docker_tests_sia_unique: Depends on `custom_test_frameworks` and `test`.
+RUSTC_BOOTSTRAP = "mm2_state_machine,mm2_err_handle,mocktopus,mocktopus_macros,docker_tests_main,docker_tests_sia_unique"
+
 JEMALLOC_SYS_WITH_MALLOC_CONF = "background_thread:true,narenas:1,tcache:false,dirty_decay_ms:0,muzzy_decay_ms:0,metadata_thp:auto"
 
 [target.'cfg(all())']
-rustflags = [ "-Zshare-generics=y", '--cfg=curve25519_dalek_backend="fiat"' ]
+rustflags = [ '--cfg=curve25519_dalek_backend="fiat"' ]
 
 # # Install lld using package manager
 # [target.x86_64-unknown-linux-gnu]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -984,7 +984,7 @@ dependencies = [
  "lightning",
  "log",
  "parking_lot",
- "parking_lot_core 0.6.2",
+ "parking_lot_core",
  "paste",
  "primitive-types",
  "rand 0.7.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ num-rational = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 pairing_api = { git = "https://github.com/komodoplatform/walletconnectrust", tag = "k-0.1.3" }
 parking_lot = { version = "0.12.0", default-features = false }
-parking_lot_core = { version = "0.6", features = ["nightly"] }
+parking_lot_core = { version = "0.9", features = ["nightly"] }
 passwords = "3.1"
 paste = "1.0"
 pin-project = "1.1.2"

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -78,7 +78,7 @@ mm2_rpc = { path = "../mm2_rpc" }
 mm2_state_machine = { path = "../mm2_state_machine" }
 mocktopus = { workspace =  true, optional = true }
 num-traits.workspace = true
-parking_lot = { workspace = true, features = ["nightly"] }
+parking_lot = { workspace = true }
 primitives = { path = "../mm2_bitcoin/primitives" }
 prost.workspace = true
 protobuf.workspace = true

--- a/mm2src/coins_activation/Cargo.toml
+++ b/mm2src/coins_activation/Cargo.toml
@@ -26,7 +26,7 @@ mm2_err_handle = { path = "../mm2_err_handle" }
 mm2_event_stream = { path = "../mm2_event_stream" }
 mm2_metrics = { path = "../mm2_metrics" }
 mm2_number = { path = "../mm2_number" }
-parking_lot = { workspace = true, features = ["nightly"] }
+parking_lot = { workspace = true }
 rpc = { path = "../mm2_bitcoin/rpc" }
 rpc_task = { path = "../rpc_task" }
 secp256k1 = { version = "0.24" }

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -34,7 +34,7 @@ http-body.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-parking_lot = { workspace = true, features = ["nightly"] }
+parking_lot = { workspace = true }
 parking_lot_core.workspace = true 
 paste.workspace = true
 primitive-types.workspace = true

--- a/mm2src/crypto/Cargo.toml
+++ b/mm2src/crypto/Cargo.toml
@@ -32,7 +32,7 @@ lazy_static.workspace = true
 mm2_core = { path = "../mm2_core" }
 mm2_err_handle = { path = "../mm2_err_handle" }
 num-traits.workspace = true
-parking_lot = { workspace = true, features = ["nightly"] }
+parking_lot = { workspace = true }
 primitives = { path = "../mm2_bitcoin/primitives" }
 rpc = { path = "../mm2_bitcoin/rpc" }
 rpc_task = { path = "../rpc_task" }

--- a/mm2src/kdf_walletconnect/Cargo.toml
+++ b/mm2src/kdf_walletconnect/Cargo.toml
@@ -19,7 +19,7 @@ hkdf.workspace = true
 mm2_db = { path = "../mm2_db" }
 mm2_core = { path = "../mm2_core" }
 mm2_err_handle = { path = "../mm2_err_handle" }
-parking_lot = { workspace = true, features = ["nightly"] }
+parking_lot = { workspace = true }
 pairing_api.workspace = true
 rand = "0.8"
 relay_client.workspace = true

--- a/mm2src/mm2_metamask/Cargo.toml
+++ b/mm2src/mm2_metamask/Cargo.toml
@@ -14,7 +14,7 @@ jsonrpc-core.workspace = true
 lazy_static.workspace = true
 mm2_err_handle = { path = "../mm2_err_handle" }
 mm2_eth = { path = "../mm2_eth" }
-parking_lot = { workspace = true, features = ["nightly"] }
+parking_lot = { workspace = true }
 serde.workspace = true
 serde_json = { workspace = true, features = ["preserve_order", "raw_value"] }
 serde_derive.workspace = true

--- a/mm2src/mm2_p2p/Cargo.toml
+++ b/mm2src/mm2_p2p/Cargo.toml
@@ -24,7 +24,7 @@ mm2_core = { path = "../mm2_core" }
 mm2_event_stream = { path = "../mm2_event_stream" }
 mm2_net = { path = "../mm2_net" }
 mm2_number = { path = "../mm2_number", optional = true }
-parking_lot = { workspace = true, features = ["nightly"] }
+parking_lot = { workspace = true }
 rand = { workspace = true, features = ["wasm-bindgen"] }
 regex.workspace = true
 rmp-serde.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-06-01"
+channel = "stable"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
Updated `rust-toolchain.toml` to use the stable Rust channel instead of the nightly build (`nightly-2023-06-01`).

**p.s.** **DO NOT MERGE PLEASE**. Until I make it compatible with MacOS build.