### PR TITLE
fix(swapv2): offline validation, tx visibility check and one-shot rebroadcast

### DIFF
--- a/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
+++ b/mm2src/coins/eth/eth_swap_v2/eth_taker_swap_v2.rs
@@ -3,10 +3,10 @@ use super::{
     PaymentMethod, PrepareTxDataError, SpendTxSearchParams, ZERO_VALUE,
 };
 use crate::eth::{
-    decode_contract_call, get_function_input_data, signed_tx_from_web3_tx, u256_from_big_decimal, EthCoin, EthCoinType,
-    ParseCoinAssocTypes, RefundFundingSecretArgs, RefundTakerPaymentArgs, SendTakerFundingArgs, SignedEthTx,
-    SwapTxTypeWithSecretHash, TakerPaymentStateV2, TransactionErr, ValidateSwapV2TxError, ValidateSwapV2TxResult,
-    ValidateTakerFundingArgs, TAKER_SWAP_V2,
+    decode_contract_call, get_function_input_data, u256_from_big_decimal, EthCoin, EthCoinType, ParseCoinAssocTypes,
+    RefundFundingSecretArgs, RefundTakerPaymentArgs, SendTakerFundingArgs, SignedEthTx, SwapTxTypeWithSecretHash,
+    TakerPaymentStateV2, TransactionErr, ValidateSwapV2TxError, ValidateSwapV2TxResult, ValidateTakerFundingArgs,
+    TAKER_SWAP_V2,
 };
 use crate::{
     FindPaymentSpendError, FundingTxSpend, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs, SearchForFundingSpendErr,
@@ -20,7 +20,7 @@ use ethkey::public_to_address;
 use futures::compat::Future01CompatExt;
 use mm2_err_handle::prelude::{MapToMmResult, MmError, MmResult, MmResultExt};
 use std::convert::TryInto;
-use web3::types::{BlockNumber, TransactionId};
+use web3::types::BlockNumber;
 
 const ETH_TAKER_PAYMENT: &str = "ethTakerPayment";
 const ERC20_TAKER_PAYMENT: &str = "erc20TakerPayment";
@@ -164,17 +164,9 @@ impl EthCoin {
         validate_amount(&args.trading_amount).map_err(ValidateSwapV2TxError::Internal)?;
         let swap_id = self.etomic_swap_id_v2(args.payment_time_lock, args.maker_secret_hash);
 
-        let tx_from_rpc = self.transaction(TransactionId::Hash(args.funding_tx.tx_hash())).await?;
-        let tx_from_rpc = tx_from_rpc.as_ref().ok_or_else(|| {
-            ValidateSwapV2TxError::TxDoesNotExist(format!(
-                "Didn't find provided tx {:?} on ETH node",
-                args.funding_tx.tx_hash()
-            ))
-        })?;
+        let tx = args.funding_tx;
         let taker_address = public_to_address(args.taker_pub);
-        let signed_tx = signed_tx_from_web3_tx(tx_from_rpc.clone())
-            .map_err(|err| ValidateSwapV2TxError::WrongPaymentTx(format!("Could not parse tx: {:?}", err)))?;
-        validate_from_to_addresses(&signed_tx, taker_address, taker_swap_v2_contract).map_mm_err()?;
+        validate_from_to_addresses(tx, taker_address, taker_swap_v2_contract).map_mm_err()?;
 
         let validation_args = {
             let dex_fee = u256_from_big_decimal(&args.dex_fee.fee_amount().into(), self.decimals).map_mm_err()?;
@@ -194,12 +186,12 @@ impl EthCoin {
         match self.coin_type {
             EthCoinType::Eth => {
                 let function = TAKER_SWAP_V2.function(ETH_TAKER_PAYMENT)?;
-                let decoded = decode_contract_call(function, &tx_from_rpc.input.0)?;
-                validate_eth_taker_payment_data(&decoded, &validation_args, function, tx_from_rpc.value)?;
+                let decoded = decode_contract_call(function, tx.unsigned().data())?;
+                validate_eth_taker_payment_data(&decoded, &validation_args, function, tx.unsigned().value())?;
             },
             EthCoinType::Erc20 { token_addr, .. } => {
                 let function = TAKER_SWAP_V2.function(ERC20_TAKER_PAYMENT)?;
-                let decoded = decode_contract_call(function, &tx_from_rpc.input.0)?;
+                let decoded = decode_contract_call(function, tx.unsigned().data())?;
                 validate_erc20_taker_payment_data(&decoded, &validation_args, function, token_addr)?;
             },
             EthCoinType::Nft { .. } => {

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -47,9 +47,10 @@ extern crate ser_error_derive;
 
 use async_trait::async_trait;
 use bip32::ExtendedPrivateKey;
+use common::custom_futures::repeatable::Action::{Ready, Retry};
 use common::custom_futures::timeout::TimeoutError;
 use common::executor::{abortable_queue::WeakSpawner, AbortedError, SpawnFuture};
-use common::log::{warn, LogOnError};
+use common::log::{info, warn, LogOnError};
 use common::{calc_total_pages, now_sec, ten, HttpStatusCode, DEX_BURN_ADDR_RAW_PUBKEY, DEX_FEE_ADDR_RAW_PUBKEY};
 use crypto::{
     derive_secp256k1_secret, Bip32Error, Bip44Chain, CryptoCtx, CryptoCtxError, DerivationPath, GlobalHDAccountArc,
@@ -1895,6 +1896,12 @@ pub trait MakerCoinSwapOpsV2: ParseCoinAssocTypes + CommonSwapOpsV2 + Send + Syn
     async fn send_maker_payment_v2(&self, args: SendMakerPaymentArgs<'_, Self>) -> Result<Self::Tx, TransactionErr>;
 
     /// Validate maker payment transaction
+    ///
+    /// Important:
+    /// - Offline semantic validation only (destination address/script, value/ABI args/pubs).
+    /// - Must not perform any network I/O: no RPC calls, no mempool lookups, no confirmation checks.
+    /// - Presence and confirmations are enforced by the swap state machine
+    /// (e.g., before the taker waits for maker payment confirmation to allow for fast failure).
     async fn validate_maker_payment_v2(&self, args: ValidateMakerPaymentArgs<'_, Self>) -> ValidatePaymentResult<()>;
 
     /// Refund maker payment transaction using timelock path
@@ -2045,6 +2052,12 @@ pub trait TakerCoinSwapOpsV2: ParseCoinAssocTypes + CommonSwapOpsV2 + Send + Syn
     async fn send_taker_funding(&self, args: SendTakerFundingArgs<'_>) -> Result<Self::Tx, TransactionErr>;
 
     /// Validates taker funding transaction.
+    ///
+    /// Important:
+    /// - Offline semantic validation only (destination address/script, value/ABI args/pubs).
+    /// - Must not perform any network I/O: no RPC calls, no mempool lookups, no confirmation checks.
+    /// - Presence and confirmations are enforced by the swap state machine
+    /// (e.g., before Maker sends their payment if they don't require funding confirmation).
     async fn validate_taker_funding(&self, args: ValidateTakerFundingArgs<'_, Self>) -> ValidateSwapV2TxResult;
 
     /// Refunds taker funding transaction using time-locked path without secret reveal.
@@ -3748,6 +3761,57 @@ pub trait MmCoin: SwapOps + WatcherOps + MarketCoinOps + Send + Sync + 'static {
 
     /// For Handling the removal/deactivation of token on platform coin deactivation.
     fn on_token_deactivated(&self, ticker: &str);
+}
+
+/// Best-effort tx mempool visibility within the grace window. If the tx is not seen initially,
+/// a one-shot rebroadcast is done, then a poll until the tx is seen or the grace window expires.
+pub async fn ensure_tx_is_broadcasted<C, T>(coin: &C, tx: &T, total_grace_secs: f64, poll_every_secs: f64) -> bool
+where
+    C: MmCoin + ?Sized,
+    T: Transaction + ?Sized,
+{
+    let tx_hash_bytes = tx.tx_hash_as_bytes().0.clone();
+    let raw_bytes = tx.tx_hex();
+
+    let did_rebroadcast = Arc::new(AtomicBool::new(false));
+
+    let result = repeatable!(async {
+        match coin.get_tx_hex_by_hash(tx_hash_bytes.clone()).compat().await {
+            Ok(_) => Ready(()),
+            Err(e) => {
+                // One-shot best-effort rebroadcast on first miss.
+                if did_rebroadcast
+                    .compare_exchange(false, true, AtomicOrdering::Relaxed, AtomicOrdering::Relaxed)
+                    .is_ok()
+                {
+                    match coin.send_raw_tx_bytes(&raw_bytes).compat().await {
+                        Ok(tx_hash) => {
+                            info!(
+                                "ensure_tx_is_broadcasted: [{}] rebroadcast attempt for {} accepted by node as {}",
+                                coin.ticker(),
+                                hex::encode(&tx_hash_bytes),
+                                tx_hash
+                            );
+                        },
+                        Err(err) => {
+                            warn!(
+                                "ensure_tx_is_broadcasted: [{}] rebroadcast attempt for {} failed: {}",
+                                coin.ticker(),
+                                hex::encode(&tx_hash_bytes),
+                                err
+                            );
+                        },
+                    }
+                }
+                Retry(e)
+            },
+        }
+    })
+    .repeat_every_secs(poll_every_secs)
+    .with_timeout_secs(total_grace_secs)
+    .await;
+
+    result.is_ok()
 }
 
 #[derive(Clone)]

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -4794,6 +4794,8 @@ where
     let expected_redeem = tx_type_with_secret_hash.redeem_script(time_lock, first_pub0, second_pub0);
     let tx_hash = tx.tx_hash_as_bytes();
 
+    // Note: This is redundant when used in swaps v2.
+    // It will be removed if we implemented cross-publishing swap payments in swaps v1.
     let tx_from_rpc = retry_on_err!(async {
         coin.as_ref()
             .rpc_client
@@ -5431,21 +5433,6 @@ where
             expected_output,
             args.funding_tx.outputs.first()
         )));
-    }
-
-    let tx_bytes_from_rpc = coin
-        .as_ref()
-        .rpc_client
-        .get_transaction_bytes(&args.funding_tx.hash().reversed().into())
-        .compat()
-        .await
-        .map_mm_err()?;
-    let actual_tx_bytes = serialize(args.funding_tx).take();
-    if tx_bytes_from_rpc.0 != actual_tx_bytes {
-        return MmError::err(ValidateSwapV2TxError::TxBytesMismatch {
-            from_rpc: tx_bytes_from_rpc,
-            actual: actual_tx_bytes.into(),
-        });
     }
 
     // import funding address in native mode to track funding tx spend

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -4794,7 +4794,7 @@ where
     let expected_redeem = tx_type_with_secret_hash.redeem_script(time_lock, first_pub0, second_pub0);
     let tx_hash = tx.tx_hash_as_bytes();
 
-    // Note: This is redundant when used in swaps v2.
+    // TODO: This is redundant when used in swaps v2.
     // It will be removed if we implemented cross-publishing swap payments in swaps v1.
     let tx_from_rpc = retry_on_err!(async {
         coin.as_ref()

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -3389,7 +3389,7 @@ async fn start_maker_swap_state_machine<
         secret_hash_algo: *params.secret_hash_algo,
         lock_duration: *params.locktime,
         taker_p2p_pubkey: *taker_p2p_pubkey,
-        require_taker_funding_confirm_before_maker_payment: true,
+        require_taker_funding_confirm_before_maker_payment: false,
         require_taker_payment_spend_confirm: true,
         swap_version: maker_order.swap_version.version,
     };

--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -3389,6 +3389,7 @@ async fn start_maker_swap_state_machine<
         secret_hash_algo: *params.secret_hash_algo,
         lock_duration: *params.locktime,
         taker_p2p_pubkey: *taker_p2p_pubkey,
+        require_taker_funding_confirm_before_maker_payment: true,
         require_taker_payment_spend_confirm: true,
         swap_version: maker_order.swap_version.version,
     };

--- a/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
@@ -423,6 +423,7 @@ pub struct MakerSwapStateMachine<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCo
     pub taker_p2p_pubkey: PublicKey,
     /// Whether to require confirmation of taker funding transaction before sending maker payment.
     /// If false, mempool visibility is sufficient.
+    /// Default: false. Check `Trading Protocol Upgrade (“swap v2”) policy` section at the top of `swap_v2_common.rs`.
     pub require_taker_funding_confirm_before_maker_payment: bool,
     /// Determines if the taker payment spend transaction must be confirmed before marking swap as Completed.
     pub require_taker_payment_spend_confirm: bool,
@@ -756,7 +757,7 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
             uuid,
             p2p_keypair: repr.p2p_keypair.map(|k| k.into_inner()),
             taker_p2p_pubkey: repr.taker_p2p_pub.into(),
-            require_taker_funding_confirm_before_maker_payment: true,
+            require_taker_funding_confirm_before_maker_payment: false,
             require_taker_payment_spend_confirm: true,
             swap_version: repr.swap_version,
         };
@@ -1309,6 +1310,28 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
             )
             .await;
 
+            // IMPORTANT (timing):
+            // - Default: require_taker_funding_confirm_before_maker_payment = false.
+            // - Behavior: proceed once the taker funding transaction is visible in the mempool (0-conf).
+            //
+            // Rationale:
+            // - On UTXO chains, waiting for 1 confirmation often exceeds the taker's ~90 s window,
+            //   causing timeouts and wasted network fees.
+            //
+            // Trade-off:
+            // - If the funding transaction is dropped or replaced before confirmation, the maker's
+            //   payment may remain locked until the refund path becomes available.
+            //
+            // Intent and future options:
+            // - This is an intentional speed optimization.
+            // - We may expose a config for makers who want to opt into stricter confirmation requirements.
+            // - Alternatively, confirmations can be only allowed for trusted makers until a reputation system is in place.
+            //   Meaning takers increase the time-out where they wait for the maker payment p2p message from a trusted maker.
+            //   It can also be a setting from maker related to the volume of the trade.
+            //
+            // NOTE(PR #2496):
+            // It's worth considering allowing maker to not mark balance as locked by swap until funding transaction
+            // is visible or confirmed depending on if `require_taker_funding_confirm_before_maker_payment` is set.
             let confs = state_machine.taker_funding_required_confs();
             if confs == 0 {
                 if !visible {

--- a/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
@@ -438,7 +438,7 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
     /// One confirmation at most is safe enough for this stage of the swap.
     /// Makers can opt out if they want to serve faster swaps to taker at the risk of getting their funds stuck occasionally.
     #[inline]
-    fn taker_funding_required_confs(&self) -> u64 {
+    fn taker_funding_required_confirmations(&self) -> u64 {
         if self.require_taker_funding_confirm_before_maker_payment {
             self.conf_settings.taker_coin_confs.min(1)
         } else {
@@ -1311,39 +1311,32 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
             .await;
 
             // IMPORTANT (timing):
-            // - Default: require_taker_funding_confirm_before_maker_payment = false.
-            // - Behavior: proceed once the taker funding transaction is visible in the mempool (0-conf).
+            //   - Default: require_taker_funding_confirm_before_maker_payment = false.
+            //   - Behavior: proceed once the taker funding transaction is visible in the mempool (0-conf).
             //
             // Rationale:
-            // - On UTXO chains, waiting for 1 confirmation often exceeds the taker's ~90 s window,
-            //   causing timeouts and wasted network fees.
+            //   - On UTXO chains, waiting for 1 confirmation often exceeds the taker's ~90 s window,
+            //     causing timeouts and wasted network fees.
             //
             // Trade-off:
-            // - If the funding transaction is dropped or replaced before confirmation, the maker's
-            //   payment may remain locked until the refund path becomes available.
+            //   - If the funding transaction is dropped or replaced before confirmation, the maker's
+            //     payment may remain locked until the refund path becomes available.
             //
             // Intent and future options:
-            // - This is an intentional speed optimization.
-            // - We may expose a config for makers who want to opt into stricter confirmation requirements.
-            // - Alternatively, confirmations can be only allowed for trusted makers until a reputation system is in place.
-            //   Meaning takers increase the time-out where they wait for the maker payment p2p message from a trusted maker.
-            //   It can also be a setting from maker related to the volume of the trade.
+            //   - This is an intentional speed optimization.
+            //   - We may expose a config for makers who want to opt into stricter confirmation requirements.
+            //   - Alternatively, confirmations can be only allowed for trusted makers until a reputation system is in place.
+            //     Meaning takers increase the time-out where they wait for the maker payment p2p message from a trusted maker.
+            //     It can also be a setting from maker related to the volume of the trade.
             //
-            // NOTE(PR #2496):
+            // TODO(PR #2496):
             // It's worth considering allowing maker to not mark balance as locked by swap until funding transaction
             // is visible or confirmed depending on if `require_taker_funding_confirm_before_maker_payment` is set.
-            let confs = state_machine.taker_funding_required_confs();
-            if confs == 0 {
-                if !visible {
-                    let reason = AbortReason::TakerFundingValidationFailed(
-                        "Taker funding transaction is not visible on network even after fallback rebroadcast".into(),
-                    );
-                    return Self::change_state(Aborted::new(reason), state_machine).await;
-                }
-            } else {
+            let confirmations = state_machine.taker_funding_required_confirmations();
+            if confirmations > 0 {
                 let input = ConfirmPaymentInput {
                     payment_tx: self.taker_funding.tx_hex(),
-                    confirmations: confs,
+                    confirmations,
                     requires_nota: state_machine.conf_settings.taker_coin_nota,
                     wait_until: state_machine.maker_payment_locktime(),
                     check_every: 10,
@@ -1354,6 +1347,11 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
                     ));
                     return Self::change_state(Aborted::new(reason), state_machine).await;
                 }
+            } else if !visible {
+                let reason = AbortReason::TakerFundingValidationFailed(
+                    "Taker funding transaction is not visible on network even after fallback rebroadcast".into(),
+                );
+                return Self::change_state(Aborted::new(reason), state_machine).await;
             }
         }
 

--- a/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
@@ -15,10 +15,11 @@ use async_trait::async_trait;
 use bitcrypto::{dhash160, sha256};
 use coins::hd_wallet::AddrToString;
 use coins::{
-    CanRefundHtlc, ConfirmPaymentInput, DexFee, FeeApproxStage, FundingTxSpend, GenTakerFundingSpendArgs,
-    GenTakerPaymentSpendArgs, MakerCoinSwapOpsV2, MmCoin, ParseCoinAssocTypes, RefundMakerPaymentSecretArgs,
-    RefundMakerPaymentTimelockArgs, SearchForFundingSpendErr, SendMakerPaymentArgs, SwapTxTypeWithSecretHash,
-    TakerCoinSwapOpsV2, ToBytes, TradePreimageValue, Transaction, TxPreimageWithSig, ValidateTakerFundingArgs,
+    ensure_tx_is_broadcasted, CanRefundHtlc, ConfirmPaymentInput, DexFee, FeeApproxStage, FundingTxSpend,
+    GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs, MakerCoinSwapOpsV2, MmCoin, ParseCoinAssocTypes,
+    RefundMakerPaymentSecretArgs, RefundMakerPaymentTimelockArgs, SearchForFundingSpendErr, SendMakerPaymentArgs,
+    SwapTxTypeWithSecretHash, TakerCoinSwapOpsV2, ToBytes, TradePreimageValue, Transaction, TxPreimageWithSig,
+    ValidateTakerFundingArgs,
 };
 use common::executor::abortable_queue::AbortableQueue;
 use common::executor::{AbortableSystem, Timer};
@@ -420,6 +421,9 @@ pub struct MakerSwapStateMachine<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCo
     pub abortable_system: AbortableQueue,
     /// Taker's P2P pubkey
     pub taker_p2p_pubkey: PublicKey,
+    /// Whether to require confirmation of taker funding transaction before sending maker payment.
+    /// If false, mempool visibility is sufficient.
+    pub require_taker_funding_confirm_before_maker_payment: bool,
     /// Determines if the taker payment spend transaction must be confirmed before marking swap as Completed.
     pub require_taker_payment_spend_confirm: bool,
     /// Swap protocol version
@@ -429,6 +433,18 @@ pub struct MakerSwapStateMachine<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCo
 impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOpsV2>
     MakerSwapStateMachine<MakerCoin, TakerCoin>
 {
+    /// Required confirmations for taker funding before sending maker payment.
+    /// One confirmation at most is safe enough for this stage of the swap.
+    /// Makers can opt out if they want to serve faster swaps to taker at the risk of getting their funds stuck occasionally.
+    #[inline]
+    fn taker_funding_required_confs(&self) -> u64 {
+        if self.require_taker_funding_confirm_before_maker_payment {
+            self.conf_settings.taker_coin_confs.min(1)
+        } else {
+            0
+        }
+    }
+
     /// Timeout for taker payment's on-chain confirmation.
     #[inline]
     fn taker_payment_conf_timeout(&self) -> u64 {
@@ -740,6 +756,7 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
             uuid,
             p2p_keypair: repr.p2p_keypair.map(|k| k.into_inner()),
             taker_p2p_pubkey: repr.taker_p2p_pub.into(),
+            require_taker_funding_confirm_before_maker_payment: true,
             require_taker_payment_spend_confirm: true,
             swap_version: repr.swap_version,
         };
@@ -1262,6 +1279,7 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
     type StateMachine = MakerSwapStateMachine<MakerCoin, TakerCoin>;
 
     async fn on_changed(self: Box<Self>, state_machine: &mut Self::StateMachine) -> StateResult<Self::StateMachine> {
+        // 1) Offline semantic validation
         let unique_data = state_machine.unique_data();
         let validation_args = ValidateTakerFundingArgs {
             funding_tx: &self.taker_funding,
@@ -1281,6 +1299,42 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
             return Self::change_state(Aborted::new(reason), state_machine).await;
         }
 
+        // 2) Propagation/confirm gate for taker funding
+        {
+            let visible = ensure_tx_is_broadcasted(
+                &state_machine.taker_coin,
+                &self.taker_funding,
+                SWAP_TX_VISIBILITY_GRACE_SECS,
+                SWAP_TX_VISIBILITY_POLL_SECS,
+            )
+            .await;
+
+            let confs = state_machine.taker_funding_required_confs();
+            if confs == 0 {
+                if !visible {
+                    let reason = AbortReason::TakerFundingValidationFailed(
+                        "Taker funding transaction is not visible on network even after fallback rebroadcast".into(),
+                    );
+                    return Self::change_state(Aborted::new(reason), state_machine).await;
+                }
+            } else {
+                let input = ConfirmPaymentInput {
+                    payment_tx: self.taker_funding.tx_hex(),
+                    confirmations: confs,
+                    requires_nota: state_machine.conf_settings.taker_coin_nota,
+                    wait_until: state_machine.maker_payment_locktime(),
+                    check_every: 10,
+                };
+                if let Err(e) = state_machine.taker_coin.wait_for_confirmations(input).compat().await {
+                    let reason = AbortReason::TakerFundingValidationFailed(format!(
+                        "Taker funding wasn't confirmed in time: {e}"
+                    ));
+                    return Self::change_state(Aborted::new(reason), state_machine).await;
+                }
+            }
+        }
+
+        // 3) Prepare preimage and send maker payment
         let args = GenTakerFundingSpendArgs {
             funding_tx: &self.taker_funding,
             maker_pub: &state_machine.taker_coin.derive_htlc_pubkey_v2(&unique_data),

--- a/mm2src/mm2_main/src/lp_swap/swap_v2_common.rs
+++ b/mm2src/mm2_main/src/lp_swap/swap_v2_common.rs
@@ -31,6 +31,18 @@ cfg_wasm32!(
     use mm2_db::indexed_db::{DbTransactionError, InitDbError, MultiIndex};
 );
 
+/// Best‑effort mempool visibility grace period (seconds).
+/// Set to ~2× the average Ethereum block time (~15s → 30s).
+/// Rationale: avoid failing early when propagation is temporarily slow (e.g., private/MEV relays,
+/// node lag), while still keeping swaps fast by proceeding as soon as the tx is reasonably
+/// expected to be discoverable by its txid. This is not a confirmation wait, only a visibility window.
+pub(super) const SWAP_TX_VISIBILITY_GRACE_SECS: f64 = 30.0;
+/// Poll interval (seconds) while waiting for tx visibility within the grace window.
+/// Default 1s balances responsiveness and RPC load for public mempools.
+/// DISCUSS: On private/MEV‑protected relays the tx may remain invisible until inclusion,
+/// consider a longer interval (e.g., 2–3s) or adaptive backoff to reduce unnecessary requests.
+pub(super) const SWAP_TX_VISIBILITY_POLL_SECS: f64 = 1.0;
+
 /// Information about active swap to be stored in swaps context
 pub struct ActiveSwapV2Info {
     pub uuid: Uuid,

--- a/mm2src/mm2_main/src/lp_swap/swap_v2_common.rs
+++ b/mm2src/mm2_main/src/lp_swap/swap_v2_common.rs
@@ -1,3 +1,97 @@
+//! Trading Protocol Upgrade (“swap v2”) policy: confirms, 0‑conf windows, visibility, and caps
+//!
+//! Canonical reference for confirmation and visibility policy used by the swap v2 state machines.
+//! Other modules should link here rather than restating details.
+//!
+//! What this covers
+//! - Default gating policy (who waits for what, and where)
+//! - Visibility grace windows and polling
+//! - Where and how the gates are enforced in code
+//! - High‑level rationale (EVM vs UTXO)
+//! - Future Design considerations
+//!
+//! At‑a‑glance defaults:
+//! - Maker side (on taker funding):
+//!   - Proceed on mempool visibility (0‑conf) by default.
+//!     Flag: [`MakerSwapStateMachine::require_taker_funding_confirm_before_maker_payment`] = `false`.
+//!     Guarded by the visibility window: [`SWAP_TX_VISIBILITY_GRACE_SECS`] with polling [`SWAP_TX_VISIBILITY_POLL_SECS`].
+//!
+//! - Taker side (on maker payment):
+//!   - Require on‑chain confirmation of maker payment before broadcasting the taker funding spend.
+//!     Flag: [`TakerSwapStateMachine::require_maker_payment_confirm_before_funding_spend`] = `true`.
+//!
+//! - Post‑spend confirmation gates:
+//!   - Maker requires taker payment spend confirmation before completing:
+//!     Flag: [`MakerSwapStateMachine::require_taker_payment_spend_confirm`] = `true`.
+//!   - Taker requires maker payment spend confirmation before completing:
+//!     Flag: [`TakerSwapStateMachine::require_maker_payment_spend_confirm`] = `true`.
+//!
+//! - Visibility grace (best‑effort mempool discovery):
+//!   - Window: [`SWAP_TX_VISIBILITY_GRACE_SECS`] seconds, polled every [`SWAP_TX_VISIBILITY_POLL_SECS`] seconds.
+//!   - Used to avoid failing early when a tx is temporarily invisible but broadcastable (rebroadcast fallback included).
+//!
+//! Rationale
+//! - UTXO chains often have 1‑conf > typical taker waiting windows (BTC ~10m, LTC ~2.5m, KMD ~60s).
+//!   Proceeding on 0‑conf taker funding keeps swaps fast, at the cost of occasional maker locks if funding is dropped/replaced.
+//! - Taker must not risk a replaced maker payment (e.g., RBF), hence the taker’s confirmation gate before spending the funding.
+//! - EVM chains have short blocks (~12–15s), but we keep consistent policy across families; 0‑conf visibility gating is still used.
+//!
+//! Where this is enforced (high level)
+//! - Maker (taker funding gate):
+//!   - In maker state “taker funding received”, the maker first validates funding, then:
+//!     - If `require_taker_funding_confirm_before_maker_payment == false` (default): ensure mempool visibility within
+//!       [`SWAP_TX_VISIBILITY_GRACE_SECS`], else abort to refund path.
+//!     - If `true`: require 1‑conf (capped by the taker time window), else abort to refund path.
+//!   - On success, maker sends maker payment and shares the taker‑funding spend preimage.
+//!
+//! - Taker (maker payment gate):
+//!   - In taker state “maker payment and funding spend preimage received”, the taker validates maker payment,
+//!     ensures mempool visibility within [`SWAP_TX_VISIBILITY_GRACE_SECS`], then:
+//!     - If `require_maker_payment_confirm_before_funding_spend == true` (default): wait confirmations before spending funding.
+//!     - If `false` (non‑default, opt‑in): may spend after visibility; still re‑check before any spend is ever broadcast.
+//!
+//! - Post‑spend gates (completion):
+//!   - Maker waits for taker payment spend confirmation if
+//!     [`MakerSwapStateMachine::require_taker_payment_spend_confirm`] is `true` (default).
+//!   - Taker waits for maker payment spend confirmation if
+//!     [`TakerSwapStateMachine::require_maker_payment_spend_confirm`] is `true` (default).
+//!
+//! Constants (this module)
+//! - [`SWAP_TX_VISIBILITY_GRACE_SECS`]: best‑effort mempool visibility window (seconds).
+//! - [`SWAP_TX_VISIBILITY_POLL_SECS`]: poll interval (seconds) while waiting for visibility.
+//!
+//! Related timeouts
+//! - Negotiation phase: see `NEGOTIATION_TIMEOUT_SEC`.
+//! - Chain confirmation waits: use per‑coin confirmations/notarizations via `ConfirmPaymentInput` at call sites.
+//! - Lock‑time policy: see [`crate::lp_swap::lp_atomic_locktime_v2`] and helpers in `lp_swap.rs`.
+//!
+//! Notes for maintainers
+//! - If you change defaults above, update:
+//!   - This doc,
+//!   - The default field values on the state machines,
+//!   - Any unit/integration tests relying on the gates/timings.
+//! - Visibility gating uses a rebroadcast‑and‑poll loop; keep values conservative for public RPCs.
+//!
+//! Future design considerations (non‑normative; suggestions, not commitments)
+//!
+//! - Use 0‑conf to enable maker competition:
+//!   Makers can compete on speed as well as price by offering fast success path swaps to build a track record.
+//!   Risk comes from pre‑confirmation drops/replacements, which can lead to maker funds being locked.
+//!
+//! - Client trust annotations:
+//!   Clients can keep local trust annotations (allowlists/overrides) informed by the current stats DB:
+//!   successful swap counts, time‑weighted confirmed volume, and failures attributable to the maker.
+//!   This is a stopgap until reputation, stake/slashing, or better solutions are in place.
+//!   “Trusted” makers may benefit from confirmations, as larger‑volume takers will tend to select them even if swaps
+//!   take longer; they can still require 0‑conf, so the choice remains with makers.
+//!   New makers can compete on speed, not only pricing, to earn trust.
+//!
+//! - Removing the funding transaction:
+//!   If explored, this would reduce fees and latency by skipping taker funding, but it introduces a backout risk:
+//!   maker funds can remain locked while the taker sends nothing, but it's worth considering as it's' not less risky
+//!   than requiring 0‑conf for funding.
+//!   This would also be up to makers, who choose allowed volumes and parameters to compete for volume and trust/reputation.
+
 use crate::lp_network::{subscribe_to_topic, unsubscribe_from_topic};
 use crate::lp_swap::maker_swap_v2::{MakerSwapDbRepr, MakerSwapStateMachine, MakerSwapStorage};
 use crate::lp_swap::swap_lock::{SwapLock, SwapLockError, SwapLockOps};

--- a/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
@@ -451,6 +451,7 @@ pub struct TakerSwapStateMachine<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCo
     /// Maker's P2P pubkey
     pub maker_p2p_pubkey: PublicKey,
     /// Whether to require maker payment confirmation before transferring funding tx to payment
+    /// Default: true. Check `Trading Protocol Upgrade (“swap v2”) policy` section at the top of `swap_v2_common.rs`.
     pub require_maker_payment_confirm_before_funding_spend: bool,
     /// Determines if the maker payment spend transaction must be confirmed before marking swap as Completed.
     pub require_maker_payment_spend_confirm: bool,
@@ -1411,6 +1412,16 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
             state_machine.p2p_keypair,
         );
 
+        // IMPORTANT(negotiation-window):
+        // The taker waits up to `NEGOTIATION_TIMEOUT_SEC` for the maker’s payment after the taker’s funding is broadcast.
+        // Since the maker proceeds on mempool-visible funding (0-conf), UTXO confirmation delays should not consume this window.
+        //
+        // Negotiation timing alignments to avoid drift:
+        // - Keep `NEGOTIATION_TIMEOUT_SEC` long enough for network propagation and several P2P resend cycles.
+        // - Prefer `NEGOTIATE_SEND_INTERVAL` to evenly divide `NEGOTIATION_TIMEOUT_SEC` so rebroadcasts align cleanly.
+        // - Ensure `SWAP_TX_VISIBILITY_POLL_SECS` is not less frequent than `NEGOTIATE_SEND_INTERVAL`, and avoid overly aggressive polling.
+        // - If maker payment confirmation is required before proceeding, grow `NEGOTIATION_TIMEOUT_SEC` to cover that delay.
+        // - These knobs are interrelated; `NEGOTIATION_TIMEOUT_SEC` can be reduced or tuned later, but adjust the others accordingly.
         let recv_fut = recv_swap_v2_msg(
             state_machine.ctx.clone(),
             |store| store.maker_payment.take(),

--- a/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
@@ -14,10 +14,10 @@ use async_trait::async_trait;
 use bitcrypto::{dhash160, sha256};
 use coins::hd_wallet::AddrToString;
 use coins::{
-    CanRefundHtlc, ConfirmPaymentInput, DexFee, FeeApproxStage, GenTakerFundingSpendArgs, GenTakerPaymentSpendArgs,
-    MakerCoinSwapOpsV2, MmCoin, ParseCoinAssocTypes, RefundFundingSecretArgs, RefundTakerPaymentArgs,
-    SendTakerFundingArgs, SpendMakerPaymentArgs, SwapTxTypeWithSecretHash, TakerCoinSwapOpsV2, ToBytes, TradeFee,
-    TradePreimageValue, Transaction, TxPreimageWithSig, ValidateMakerPaymentArgs,
+    ensure_tx_is_broadcasted, CanRefundHtlc, ConfirmPaymentInput, DexFee, FeeApproxStage, GenTakerFundingSpendArgs,
+    GenTakerPaymentSpendArgs, MakerCoinSwapOpsV2, MmCoin, ParseCoinAssocTypes, RefundFundingSecretArgs,
+    RefundTakerPaymentArgs, SendTakerFundingArgs, SpendMakerPaymentArgs, SwapTxTypeWithSecretHash, TakerCoinSwapOpsV2,
+    ToBytes, TradeFee, TradePreimageValue, Transaction, TxPreimageWithSig, ValidateMakerPaymentArgs,
 };
 use common::executor::abortable_queue::AbortableQueue;
 use common::executor::{AbortableSystem, Timer};
@@ -1572,6 +1572,7 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
         let unique_data = state_machine.unique_data();
         let my_secret_hash = state_machine.taker_secret_hash();
 
+        // 1) Offline semantic validation
         let input = ValidateMakerPaymentArgs {
             maker_payment_tx: &self.maker_payment,
             time_lock: self.negotiation_data.maker_payment_locktime,
@@ -1617,6 +1618,32 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
             return Self::change_state(next_state, state_machine).await;
         }
 
+        // 2) Require maker payment visibility first. If it's not visible, refund funding.
+        {
+            let visible = ensure_tx_is_broadcasted(
+                &state_machine.maker_coin,
+                &self.maker_payment,
+                SWAP_TX_VISIBILITY_GRACE_SECS,
+                SWAP_TX_VISIBILITY_POLL_SECS,
+            )
+            .await;
+
+            if !visible {
+                let next_state = TakerFundingRefundRequired {
+                    maker_coin_start_block: self.maker_coin_start_block,
+                    taker_coin_start_block: self.taker_coin_start_block,
+                    taker_funding: self.taker_funding,
+                    negotiation_data: self.negotiation_data,
+                    reason: TakerFundingRefundReason::DidNotReceiveMakerPayment(
+                        "Maker payment transaction is not visible on network even after fallback rebroadcast".into(),
+                    ),
+                };
+                return Self::change_state(next_state, state_machine).await;
+            }
+        }
+
+        // 3) Spend funding if maker payment is visible and no confirmation is required
+        // or wait for confirmation and then spend funding in `MakerPaymentConfirmed` state.
         if state_machine.require_maker_payment_confirm_before_funding_spend {
             let input = ConfirmPaymentInput {
                 payment_tx: self.maker_payment.tx_hex(),


### PR DESCRIPTION
This is a follow‑up to #2618.

### Problem
Taker‑side validation failed when the maker broadcasted via private/MEV‑protected relays (e.g., Polygon Protect RPC), because the tx wasn’t visible on public RPCs. This caused false negatives and unnecessary refunds.

### Previous PR (#2618)
- Validated the maker’s payment offline from signed bytes on the taker side to remove the hard dependency on mempool presence. This was done for EVM transactions only.
- Deferred on‑chain visibility for EVM maker payment to the existing confirmation step, eliminating false negatives caused by private/MEV relays for that stage.

### What this PR changes
- Extends offline validation while adding best‑effort visibility gates with a one‑shot rebroadcast fallback to all coins, this is now part of the state machine instead of being coin specific.
- Taker (v2)
  - Validates the maker payment offline, from signed bytes.
  - Requires maker payment to become visible within a short grace window, if still invisible after a one‑shot rebroadcast, refunds the funding transaction.
  - If configured, waits for on‑chain confirmations before spending the funding tx.
- Maker (v2)
  - Validates taker funding offline (no RPC lookups).
  - Before sending the maker payment, either:
    - requires funding tx visibility within a grace window (one‑shot rebroadcast on first miss), or
    - waits up to one on‑chain confirmation if configured.
- Adds a generic visibility helper
  - `ensure_tx_is_broadcasted(…)`: polls by tx hash within a grace window, on the first miss performs a one‑shot rebroadcast, continues polling until timeout.
- EVM specifics
  - `validate_taker_funding_impl`: now parses `SignedEthTx` and validates from/to, ABI inputs and value offline (no RPC fetch for the tx).
- UTXO specifics
  - Removed strict byte‑for‑byte RPC match for taker funding in the v2 path to avoid false negatives.
  - Legacy v1 validation remains unchanged, but `validate_maker_payment_v2` uses it so a change in `validate_maker_payment_v2` might follow, it's not a big issue for UTXO but will be done for completeness.
  
### How this fixes the problem
- Decouples correctness from mempool presence:
  - Offline semantic checks verify that each signed transaction matches the expected sender/recipient, method/inputs, and value without any RPC dependency.
- Guarantees a clear and fast outcome:
  - Visibility gate with a one‑shot rebroadcast ensures that transactions sent via private/MEV relays either appear on public mempools quickly or trigger a deterministic fallback.
  - Outcomes by role:
    - Taker:
      -  checks maker payment: 
        - visible within the grace window → proceed;
        - still invisible after a single rebroadcast and the window elapses → refund taker funding immediately.
    - Maker
      - checks taker funding:
        - visible (or 1 confirmation, if configured) → send maker payment;
        - not visible after the window → do not send maker payment.
- Net effect: no more false negatives when private relays are used, while keeping the original confirmation‑based safety for operators who want it.

### Not done from prior “Future Work” in #2618 and why
- “Add taker rebroadcast fallback after a short pre‑wait”
  - Chosen approach: rebroadcast immediately on first miss.
  - Why better: reduces latency and avoids an extra tunable, the grace window already accounts for propagation variance. 

- “Treat rebroadcast as success only based on transport responses”
  - Chosen approach: never infer success from transport strings, success is defined solely by tx visibility by hash.
  - Why better: avoids brittle, client‑specific error matching and yields consistent behavior across RPC providers and coins.

- “Do not treat ‘nonce too low’ or ‘replacement underpriced’ as success, query tx by hash”
  - Effectively addressed: transport errors are not considered success, we only proceed when the expected tx hash becomes visible (pending or included). Until then, we keep polling within the grace window.

### Defaults and constants
- Maker policy default: `require_taker_funding_confirm_before_maker_payment = true` (wait up to 1 confirmation).
- Visibility timing defaults:
  - `SWAP_TX_VISIBILITY_GRACE_SECS = 30s`
  - `SWAP_TX_VISIBILITY_POLL_SECS = 1s`

### Todo in this PR:
- [ ] Make sure that `validate_maker_payment_v2` validates tx offline only (UTXO parity). Not required for resolving the private‑relay false‑negative, but desirable for completeness.