### PR TITLE
feat(legacy-stats): broadcast swap status for privacy coins

### DIFF
--- a/mm2src/common/log.rs
+++ b/mm2src/common/log.rs
@@ -176,6 +176,18 @@ macro_rules! covered_warn {
     };
 }
 
+#[macro_export]
+/// A macro to log errors in production environment and panic in tests.
+macro_rules! covered_error {
+    ($($arg:tt)+) => {
+        if cfg!(not(test)) {
+            common::log::error!($($arg)+)
+        } else {
+            panic!($($arg)+)
+        }
+    };
+}
+
 /// Debug logging.
 ///
 /// This logging SHOULD be human-readable but it is not intended for the end users specifically.

--- a/mm2src/db_common/src/sqlite.rs
+++ b/mm2src/db_common/src/sqlite.rs
@@ -1,6 +1,7 @@
 #![allow(deprecated)] // TODO: remove this once rusqlite is >= 0.29
 
 pub use rusqlite;
+pub use rusqlite::types::Value as SqlValue;
 pub use sql_builder;
 
 use log::debug;

--- a/mm2src/db_common/src/sqlite.rs
+++ b/mm2src/db_common/src/sqlite.rs
@@ -322,7 +322,7 @@ pub fn run_optimization_pragmas(conn: &Connection) -> Result<(), SqlError> {
     Ok(())
 }
 
-pub fn execute_batch(statement: &'static [&str]) -> Vec<(&'static str, Vec<String>)> {
+pub fn execute_batch<T>(statement: &'static [&str]) -> Vec<(&'static str, Vec<T>)> {
     statement.iter().map(|sql| (*sql, vec![])).collect()
 }
 

--- a/mm2src/mm2_main/src/database.rs
+++ b/mm2src/mm2_main/src/database.rs
@@ -8,8 +8,8 @@ pub mod stats_swaps;
 use crate::database::stats_swaps::fix_maker_and_taker_pubkeys_in_stats_db;
 use crate::CREATE_MY_SWAPS_TABLE;
 use common::log::{debug, error, info};
-use db_common::sqlite::run_optimization_pragmas;
-use db_common::sqlite::rusqlite::{params_from_iter, types::Value as SqlValue, Result as SqlResult};
+use db_common::sqlite::rusqlite::{params_from_iter, Result as SqlResult};
+use db_common::sqlite::{run_optimization_pragmas, SqlValue};
 use mm2_core::mm_ctx::MmArc;
 
 use my_swaps::{fill_my_swaps_from_json_statements, set_is_finished_for_legacy_swaps_statements};

--- a/mm2src/mm2_main/src/database.rs
+++ b/mm2src/mm2_main/src/database.rs
@@ -9,7 +9,7 @@ use crate::database::stats_swaps::fix_maker_and_taker_pubkeys_in_stats_db;
 use crate::CREATE_MY_SWAPS_TABLE;
 use common::log::{debug, error, info};
 use db_common::sqlite::run_optimization_pragmas;
-use db_common::sqlite::rusqlite::{params_from_iter, Result as SqlResult};
+use db_common::sqlite::rusqlite::{params_from_iter, types::Value as SqlValue, Result as SqlResult};
 use mm2_core::mm_ctx::MmArc;
 
 use my_swaps::{fill_my_swaps_from_json_statements, set_is_finished_for_legacy_swaps_statements};
@@ -72,66 +72,68 @@ fn clean_db(ctx: &MmArc) {
     }
 }
 
-async fn migration_1(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> { fill_my_swaps_from_json_statements(ctx).await }
+async fn migration_1(ctx: &MmArc) -> Vec<(&'static str, Vec<SqlValue>)> {
+    fill_my_swaps_from_json_statements(ctx).await
+}
 
-async fn migration_2(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
+async fn migration_2(ctx: &MmArc) -> Vec<(&'static str, Vec<SqlValue>)> {
     create_and_fill_stats_swaps_from_json_statements(ctx).await
 }
 
-fn migration_3() -> Vec<(&'static str, Vec<String>)> { vec![(stats_swaps::ADD_STARTED_AT_INDEX, vec![])] }
+fn migration_3() -> Vec<(&'static str, Vec<SqlValue>)> { vec![(stats_swaps::ADD_STARTED_AT_INDEX, vec![])] }
 
-fn migration_4() -> Vec<(&'static str, Vec<String>)> {
+fn migration_4() -> Vec<(&'static str, Vec<SqlValue>)> {
     db_common::sqlite::execute_batch(stats_swaps::ADD_SPLIT_TICKERS)
 }
 
-fn migration_5() -> Vec<(&'static str, Vec<String>)> { vec![(my_orders::CREATE_MY_ORDERS_TABLE, vec![])] }
+fn migration_5() -> Vec<(&'static str, Vec<SqlValue>)> { vec![(my_orders::CREATE_MY_ORDERS_TABLE, vec![])] }
 
-fn migration_6() -> Vec<(&'static str, Vec<String>)> {
+fn migration_6() -> Vec<(&'static str, Vec<SqlValue>)> {
     vec![
         (stats_nodes::CREATE_NODES_TABLE, vec![]),
         (stats_nodes::CREATE_STATS_NODES_TABLE, vec![]),
     ]
 }
 
-fn migration_7() -> Vec<(&'static str, Vec<String>)> {
+fn migration_7() -> Vec<(&'static str, Vec<SqlValue>)> {
     db_common::sqlite::execute_batch(stats_swaps::ADD_COINS_PRICE_INFOMATION)
 }
 
-fn migration_8() -> Vec<(&'static str, Vec<String>)> {
+fn migration_8() -> Vec<(&'static str, Vec<SqlValue>)> {
     db_common::sqlite::execute_batch(stats_swaps::ADD_MAKER_TAKER_PUBKEYS)
 }
 
-fn migration_9() -> Vec<(&'static str, Vec<String>)> {
+fn migration_9() -> Vec<(&'static str, Vec<SqlValue>)> {
     db_common::sqlite::execute_batch(my_swaps::TRADING_PROTO_UPGRADE_MIGRATION)
 }
 
-async fn migration_10(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
+async fn migration_10(ctx: &MmArc) -> Vec<(&'static str, Vec<SqlValue>)> {
     set_is_finished_for_legacy_swaps_statements(ctx).await
 }
 
-fn migration_11() -> Vec<(&'static str, Vec<String>)> {
+fn migration_11() -> Vec<(&'static str, Vec<SqlValue>)> {
     db_common::sqlite::execute_batch(stats_swaps::ADD_MAKER_TAKER_GUI_AND_VERSION)
 }
 
-fn migration_12() -> Vec<(&'static str, Vec<String>)> {
+fn migration_12() -> Vec<(&'static str, Vec<SqlValue>)> {
     vec![
         (my_swaps::ADD_OTHER_P2P_PUBKEY_FIELD, vec![]),
         (my_swaps::ADD_DEX_FEE_BURN_FIELD, vec![]),
     ]
 }
 
-fn migration_13() -> Vec<(&'static str, Vec<String>)> {
+fn migration_13() -> Vec<(&'static str, Vec<SqlValue>)> {
     vec![
         (my_swaps::ADD_SWAP_VERSION_FIELD, vec![]),  // Step 1: Add new column
         (my_swaps::SET_LEGACY_SWAP_VERSION, vec![]), // Step 2: Update old rows
     ]
 }
 
-async fn migration_14(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
+async fn migration_14(ctx: &MmArc) -> Vec<(&'static str, Vec<SqlValue>)> {
     fix_maker_and_taker_pubkeys_in_stats_db(ctx).await
 }
 
-async fn statements_for_migration(ctx: &MmArc, current_migration: i64) -> Option<Vec<(&'static str, Vec<String>)>> {
+async fn statements_for_migration(ctx: &MmArc, current_migration: i64) -> Option<Vec<(&'static str, Vec<SqlValue>)>> {
     match current_migration {
         1 => Some(migration_1(ctx).await),
         2 => Some(migration_2(ctx).await),

--- a/mm2src/mm2_main/src/database.rs
+++ b/mm2src/mm2_main/src/database.rs
@@ -5,6 +5,7 @@ pub mod my_swaps;
 pub mod stats_nodes;
 pub mod stats_swaps;
 
+use crate::database::stats_swaps::fix_maker_and_taker_pubkeys_in_stats_db;
 use crate::CREATE_MY_SWAPS_TABLE;
 use common::log::{debug, error, info};
 use db_common::sqlite::run_optimization_pragmas;
@@ -126,6 +127,10 @@ fn migration_13() -> Vec<(&'static str, Vec<String>)> {
     ]
 }
 
+async fn migration_14(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
+    fix_maker_and_taker_pubkeys_in_stats_db(ctx).await
+}
+
 async fn statements_for_migration(ctx: &MmArc, current_migration: i64) -> Option<Vec<(&'static str, Vec<String>)>> {
     match current_migration {
         1 => Some(migration_1(ctx).await),
@@ -141,6 +146,7 @@ async fn statements_for_migration(ctx: &MmArc, current_migration: i64) -> Option
         11 => Some(migration_11()),
         12 => Some(migration_12()),
         13 => Some(migration_13()),
+        14 => Some(migration_14(ctx).await),
         _ => None,
     }
 }

--- a/mm2src/mm2_main/src/database/my_swaps.rs
+++ b/mm2src/mm2_main/src/database/my_swaps.rs
@@ -4,7 +4,7 @@
 use crate::lp_swap::{MyRecentSwapsUuids, MySwapsFilter, SavedSwap, SavedSwapIo};
 use common::log::debug;
 use common::PagingOptions;
-use db_common::sqlite::rusqlite::{Connection, Error as SqlError, Result as SqlResult, ToSql};
+use db_common::sqlite::rusqlite::{types::Value as SqlValue, Connection, Error as SqlError, Result as SqlResult, ToSql};
 use db_common::sqlite::sql_builder::SqlBuilder;
 use db_common::sqlite::{offset_by_uuid, query_single_row};
 use mm2_core::mm_ctx::MmArc;
@@ -134,7 +134,7 @@ pub fn insert_new_swap_v2(ctx: &MmArc, params: &[(&str, &dyn ToSql)]) -> SqlResu
 
 /// Returns SQL statements to initially fill my_swaps table using existing DB with JSON files
 /// Use this only in migration code!
-pub async fn fill_my_swaps_from_json_statements(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
+pub async fn fill_my_swaps_from_json_statements(ctx: &MmArc) -> Vec<(&'static str, Vec<SqlValue>)> {
     let swaps = SavedSwap::load_all_my_swaps_from_db(ctx).await.unwrap_or_default();
     swaps
         .into_iter()
@@ -143,7 +143,7 @@ pub async fn fill_my_swaps_from_json_statements(ctx: &MmArc) -> Vec<(&'static st
 }
 
 /// Use this only in migration code!
-fn insert_saved_swap_sql_migration_1(swap: SavedSwap) -> Option<(&'static str, Vec<String>)> {
+fn insert_saved_swap_sql_migration_1(swap: SavedSwap) -> Option<(&'static str, Vec<SqlValue>)> {
     let swap_info = match swap.get_my_info() {
         Some(s) => s,
         // get_my_info returning None means that swap did not even start - so we can keep it away from indexing.
@@ -154,7 +154,11 @@ fn insert_saved_swap_sql_migration_1(swap: SavedSwap) -> Option<(&'static str, V
         swap_info.other_coin,
         swap.uuid().to_string(),
         swap_info.started_at.to_string(),
-    ];
+    ]
+    .into_iter()
+    .map(SqlValue::from)
+    .collect();
+
     Some((INSERT_MY_SWAP_MIGRATION_1, params))
 }
 
@@ -353,13 +357,13 @@ WHERE uuid = :uuid;
 "#;
 
 /// Returns SQL statements to set is_finished to 1 for completed legacy swaps
-pub async fn set_is_finished_for_legacy_swaps_statements(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
+pub async fn set_is_finished_for_legacy_swaps_statements(ctx: &MmArc) -> Vec<(&'static str, Vec<SqlValue>)> {
     let swaps = SavedSwap::load_all_my_swaps_from_db(ctx).await.unwrap_or_default();
     swaps
         .into_iter()
         .filter_map(|swap| {
             if swap.is_finished() {
-                Some((UPDATE_SWAP_IS_FINISHED_BY_UUID, vec![swap.uuid().to_string()]))
+                Some((UPDATE_SWAP_IS_FINISHED_BY_UUID, vec![swap.uuid().to_string().into()]))
             } else {
                 None
             }

--- a/mm2src/mm2_main/src/database/my_swaps.rs
+++ b/mm2src/mm2_main/src/database/my_swaps.rs
@@ -4,9 +4,9 @@
 use crate::lp_swap::{MyRecentSwapsUuids, MySwapsFilter, SavedSwap, SavedSwapIo};
 use common::log::debug;
 use common::PagingOptions;
-use db_common::sqlite::rusqlite::{types::Value as SqlValue, Connection, Error as SqlError, Result as SqlResult, ToSql};
+use db_common::sqlite::rusqlite::{Connection, Error as SqlError, Result as SqlResult, ToSql};
 use db_common::sqlite::sql_builder::SqlBuilder;
-use db_common::sqlite::{offset_by_uuid, query_single_row};
+use db_common::sqlite::{offset_by_uuid, query_single_row, SqlValue};
 use mm2_core::mm_ctx::MmArc;
 use std::convert::TryInto;
 use uuid::{Error as UuidError, Uuid};

--- a/mm2src/mm2_main/src/database/stats_swaps.rs
+++ b/mm2src/mm2_main/src/database/stats_swaps.rs
@@ -3,8 +3,8 @@
 use crate::lp_swap::{MakerSavedSwap, SavedSwap, SavedSwapIo, TakerSavedSwap};
 use common::log::{debug, error};
 use db_common::{owned_named_params,
-                sqlite::{rusqlite::{params_from_iter, types::Value as SqlValue, Connection, OptionalExtension},
-                         AsSqlNamedParams, OwnedSqlNamedParams}};
+                sqlite::{rusqlite::{params_from_iter, Connection, OptionalExtension},
+                         AsSqlNamedParams, OwnedSqlNamedParams, SqlValue}};
 use mm2_core::mm_ctx::MmArc;
 use std::collections::HashSet;
 

--- a/mm2src/mm2_main/src/database/stats_swaps.rs
+++ b/mm2src/mm2_main/src/database/stats_swaps.rs
@@ -3,7 +3,7 @@
 use crate::lp_swap::{MakerSavedSwap, SavedSwap, SavedSwapIo, TakerSavedSwap};
 use common::log::{debug, error};
 use db_common::{owned_named_params,
-                sqlite::{rusqlite::{params_from_iter, Connection, OptionalExtension},
+                sqlite::{rusqlite::{params_from_iter, types::Value as SqlValue, Connection, OptionalExtension},
                          AsSqlNamedParams, OwnedSqlNamedParams}};
 use mm2_core::mm_ctx::MmArc;
 use std::collections::HashSet;
@@ -92,7 +92,7 @@ pub const ADD_MAKER_TAKER_GUI_AND_VERSION: &[&str] = &[
 pub const SELECT_ID_BY_UUID: &str = "SELECT id FROM stats_swaps WHERE uuid = ?1";
 
 /// Returns SQL statements to initially fill stats_swaps table using existing DB with JSON files
-pub async fn create_and_fill_stats_swaps_from_json_statements(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
+pub async fn create_and_fill_stats_swaps_from_json_statements(ctx: &MmArc) -> Vec<(&'static str, Vec<SqlValue>)> {
     let maker_swaps = SavedSwap::load_all_from_maker_stats_db(ctx).await.unwrap_or_default();
     let taker_swaps = SavedSwap::load_all_from_taker_stats_db(ctx).await.unwrap_or_default();
 
@@ -116,7 +116,7 @@ pub async fn create_and_fill_stats_swaps_from_json_statements(ctx: &MmArc) -> Ve
     result
 }
 
-pub async fn fix_maker_and_taker_pubkeys_in_stats_db(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
+pub async fn fix_maker_and_taker_pubkeys_in_stats_db(ctx: &MmArc) -> Vec<(&'static str, Vec<SqlValue>)> {
     let maker_swaps = SavedSwap::load_all_from_maker_stats_db(ctx).await.unwrap_or_default();
     let taker_swaps = SavedSwap::load_all_from_taker_stats_db(ctx).await.unwrap_or_default();
 
@@ -127,11 +127,17 @@ pub async fn fix_maker_and_taker_pubkeys_in_stats_db(ctx: &MmArc) -> Vec<(&'stat
         const UPDATE_MAKER_PUBKEY: &str = "UPDATE stats_swaps SET maker_pubkey = ?1 WHERE uuid = ?2;";
         match maker_swap.maker_pubkey() {
             Ok(maker_pubkey) => {
-                result.push((UPDATE_MAKER_PUBKEY, vec![maker_pubkey, maker_swap.uuid.to_string()]));
+                result.push((UPDATE_MAKER_PUBKEY, vec![
+                    maker_pubkey.into(),
+                    maker_swap.uuid.to_string().into(),
+                ]));
             },
             Err(e) => {
                 error!("Error {} on getting maker_pubkey for swap {}", e, maker_swap.uuid);
-                result.push((UPDATE_MAKER_PUBKEY, vec!["NULL".into(), maker_swap.uuid.to_string()]));
+                result.push((UPDATE_MAKER_PUBKEY, vec![
+                    SqlValue::Null,
+                    maker_swap.uuid.to_string().into(),
+                ]));
             },
         }
     }
@@ -140,11 +146,17 @@ pub async fn fix_maker_and_taker_pubkeys_in_stats_db(ctx: &MmArc) -> Vec<(&'stat
         const UPDATE_TAKER_PUBKEY: &str = "UPDATE stats_swaps SET taker_pubkey = ?1 WHERE uuid = ?2;";
         match taker_swap.taker_pubkey() {
             Ok(taker_pubkey) => {
-                result.push((UPDATE_TAKER_PUBKEY, vec![taker_pubkey, taker_swap.uuid.to_string()]));
+                result.push((UPDATE_TAKER_PUBKEY, vec![
+                    taker_pubkey.into(),
+                    taker_swap.uuid.to_string().into(),
+                ]));
             },
             Err(e) => {
                 error!("Error {} on getting taker_pubkey for swap {}", e, taker_swap.uuid);
-                result.push((UPDATE_TAKER_PUBKEY, vec!["NULL".into(), taker_swap.uuid.to_string()]));
+                result.push((UPDATE_TAKER_PUBKEY, vec![
+                    SqlValue::Null,
+                    taker_swap.uuid.to_string().into(),
+                ]));
             },
         }
     }
@@ -201,7 +213,7 @@ fn insert_stats_maker_swap_sql(swap: &MakerSavedSwap) -> Option<(&'static str, O
     Some((INSERT_STATS_SWAP, params))
 }
 
-fn insert_stats_maker_swap_sql_init(swap: &MakerSavedSwap) -> Option<(&'static str, Vec<String>)> {
+fn insert_stats_maker_swap_sql_init(swap: &MakerSavedSwap) -> Option<(&'static str, Vec<SqlValue>)> {
     let swap_data = match swap.swap_data() {
         Ok(d) => d,
         Err(e) => {
@@ -229,7 +241,11 @@ fn insert_stats_maker_swap_sql_init(swap: &MakerSavedSwap) -> Option<(&'static s
         swap_data.maker_amount.to_string(),
         swap_data.taker_amount.to_string(),
         (is_success as u32).to_string(),
-    ];
+    ]
+    .into_iter()
+    .map(SqlValue::from)
+    .collect();
+
     Some((INSERT_STATS_SWAP_ON_INIT, params))
 }
 
@@ -273,7 +289,7 @@ fn insert_stats_taker_swap_sql(swap: &TakerSavedSwap) -> Option<(&'static str, O
     Some((INSERT_STATS_SWAP, params))
 }
 
-fn insert_stats_taker_swap_sql_init(swap: &TakerSavedSwap) -> Option<(&'static str, Vec<String>)> {
+fn insert_stats_taker_swap_sql_init(swap: &TakerSavedSwap) -> Option<(&'static str, Vec<SqlValue>)> {
     let swap_data = match swap.swap_data() {
         Ok(d) => d,
         Err(e) => {
@@ -301,7 +317,11 @@ fn insert_stats_taker_swap_sql_init(swap: &TakerSavedSwap) -> Option<(&'static s
         swap_data.maker_amount.to_string(),
         swap_data.taker_amount.to_string(),
         (is_success as u32).to_string(),
-    ];
+    ]
+    .into_iter()
+    .map(SqlValue::from)
+    .collect();
+
     Some((INSERT_STATS_SWAP_ON_INIT, params))
 }
 

--- a/mm2src/mm2_main/src/database/stats_swaps.rs
+++ b/mm2src/mm2_main/src/database/stats_swaps.rs
@@ -120,7 +120,7 @@ pub async fn fix_maker_and_taker_pubkeys_in_stats_db(ctx: &MmArc) -> Vec<(&'stat
     let maker_swaps = SavedSwap::load_all_from_maker_stats_db(ctx).await.unwrap_or_default();
     let taker_swaps = SavedSwap::load_all_from_taker_stats_db(ctx).await.unwrap_or_default();
 
-    let mut result = vec![(CREATE_STATS_SWAPS_TABLE, vec![])];
+    let mut result = Vec::new();
 
     // Update all the `maker_pubkey`s using maker's `my_persistent_pub` field
     for maker_swap in maker_swaps {
@@ -131,6 +131,7 @@ pub async fn fix_maker_and_taker_pubkeys_in_stats_db(ctx: &MmArc) -> Vec<(&'stat
             },
             Err(e) => {
                 error!("Error {} on getting maker_pubkey for swap {}", e, maker_swap.uuid);
+                result.push((UPDATE_MAKER_PUBKEY, vec!["NULL".into(), maker_swap.uuid.to_string()]));
             },
         }
     }
@@ -143,6 +144,7 @@ pub async fn fix_maker_and_taker_pubkeys_in_stats_db(ctx: &MmArc) -> Vec<(&'stat
             },
             Err(e) => {
                 error!("Error {} on getting taker_pubkey for swap {}", e, taker_swap.uuid);
+                result.push((UPDATE_TAKER_PUBKEY, vec!["NULL".into(), taker_swap.uuid.to_string()]));
             },
         }
     }

--- a/mm2src/mm2_main/src/database/stats_swaps.rs
+++ b/mm2src/mm2_main/src/database/stats_swaps.rs
@@ -133,7 +133,7 @@ pub async fn fix_maker_and_taker_pubkeys_in_stats_db(ctx: &MmArc) -> Vec<(&'stat
                 ]));
             },
             Err(e) => {
-                error!("Error {} on getting maker_pubkey for swap {}", e, maker_swap.uuid);
+                covered_error!("Error {} on getting maker_pubkey for swap {}", e, maker_swap.uuid);
                 result.push((UPDATE_MAKER_PUBKEY, vec![
                     SqlValue::Null,
                     maker_swap.uuid.to_string().into(),
@@ -152,7 +152,7 @@ pub async fn fix_maker_and_taker_pubkeys_in_stats_db(ctx: &MmArc) -> Vec<(&'stat
                 ]));
             },
             Err(e) => {
-                error!("Error {} on getting taker_pubkey for swap {}", e, taker_swap.uuid);
+                covered_error!("Error {} on getting taker_pubkey for swap {}", e, taker_swap.uuid);
                 result.push((UPDATE_TAKER_PUBKEY, vec![
                     SqlValue::Null,
                     taker_swap.uuid.to_string().into(),
@@ -338,7 +338,7 @@ fn update_optional_info(swap: &SavedSwap) -> Option<(String, OwnedSqlNamedParams
                 params.push((":maker_pubkey", maker_pubkey.into()));
             },
             Err(e) => {
-                error!("[{}] Error on getting maker_pubkey for stats: {}", swap.uuid(), e);
+                covered_error!("[{}] Error on getting maker_pubkey for stats: {}", swap.uuid(), e);
             },
         }
     }
@@ -349,7 +349,7 @@ fn update_optional_info(swap: &SavedSwap) -> Option<(String, OwnedSqlNamedParams
                 params.push((":taker_pubkey", taker_pubkey.into()));
             },
             Err(e) => {
-                error!("[{}] Error on getting taker_pubkey for stats: {}", swap.uuid(), e);
+                covered_error!("[{}] Error on getting taker_pubkey for stats: {}", swap.uuid(), e);
             },
         }
     }

--- a/mm2src/mm2_main/src/database/stats_swaps.rs
+++ b/mm2src/mm2_main/src/database/stats_swaps.rs
@@ -116,6 +116,40 @@ pub async fn create_and_fill_stats_swaps_from_json_statements(ctx: &MmArc) -> Ve
     result
 }
 
+pub async fn fix_maker_and_taker_pubkeys_in_stats_db(ctx: &MmArc) -> Vec<(&'static str, Vec<String>)> {
+    let maker_swaps = SavedSwap::load_all_from_maker_stats_db(ctx).await.unwrap_or_default();
+    let taker_swaps = SavedSwap::load_all_from_taker_stats_db(ctx).await.unwrap_or_default();
+
+    let mut result = vec![(CREATE_STATS_SWAPS_TABLE, vec![])];
+
+    // Update all the `maker_pubkey`s using maker's `my_persistent_pub` field
+    for maker_swap in maker_swaps {
+        const UPDATE_MAKER_PUBKEY: &str = "UPDATE stats_swaps SET maker_pubkey = ?1 WHERE uuid = ?2;";
+        match maker_swap.maker_pubkey() {
+            Ok(maker_pubkey) => {
+                result.push((UPDATE_MAKER_PUBKEY, vec![maker_pubkey, maker_swap.uuid.to_string()]));
+            },
+            Err(e) => {
+                error!("Error {} on getting maker_pubkey for swap {}", e, maker_swap.uuid);
+            },
+        }
+    }
+    // Update all the `taker_pubkey`s using taker's `my_persistent_pub` field
+    for taker_swap in taker_swaps {
+        const UPDATE_TAKER_PUBKEY: &str = "UPDATE stats_swaps SET taker_pubkey = ?1 WHERE uuid = ?2;";
+        match taker_swap.taker_pubkey() {
+            Ok(taker_pubkey) => {
+                result.push((UPDATE_TAKER_PUBKEY, vec![taker_pubkey, taker_swap.uuid.to_string()]));
+            },
+            Err(e) => {
+                error!("Error {} on getting taker_pubkey for swap {}", e, taker_swap.uuid);
+            },
+        }
+    }
+
+    result
+}
+
 fn split_coin(coin: &str) -> (String, String) {
     let mut split = coin.split('-');
     let ticker = split.next().expect("split returns empty string at least").into();

--- a/mm2src/mm2_main/src/database/stats_swaps.rs
+++ b/mm2src/mm2_main/src/database/stats_swaps.rs
@@ -43,14 +43,9 @@ const INSERT_STATS_SWAP: &str = "INSERT INTO stats_swaps (
     finished_at,
     maker_amount,
     taker_amount,
-    is_success,
-    maker_coin_usd_price,
-    taker_coin_usd_price,
-    maker_pubkey,
-    taker_pubkey
+    is_success
 ) VALUES (:maker_coin, :maker_coin_ticker, :maker_coin_platform, :taker_coin, :taker_coin_ticker, 
-:taker_coin_platform, :uuid, :started_at, :finished_at, :maker_amount, :taker_amount, :is_success, 
-:maker_coin_usd_price, :taker_coin_usd_price, :maker_pubkey, :taker_pubkey)";
+:taker_coin_platform, :uuid, :started_at, :finished_at, :maker_amount, :taker_amount, :is_success)";
 
 pub const ADD_STARTED_AT_INDEX: &str = "CREATE INDEX timestamp_index ON stats_swaps (started_at);";
 
@@ -145,14 +140,6 @@ fn insert_stats_maker_swap_sql(swap: &MakerSavedSwap) -> Option<(&'static str, O
         },
     };
 
-    let pubkeys = match swap.swap_pubkeys() {
-        Ok(p) => p,
-        Err(e) => {
-            error!("Error {} on getting swap {} pubkeys", e, swap.uuid);
-            return None;
-        },
-    };
-
     let is_success = swap
         .is_success()
         .expect("is_success can return error only when swap is not finished");
@@ -173,25 +160,9 @@ fn insert_stats_maker_swap_sql(swap: &MakerSavedSwap) -> Option<(&'static str, O
         ":maker_amount": swap_data.maker_amount.to_string(),
         ":taker_amount": swap_data.taker_amount.to_string(),
         ":is_success": (is_success as u32).to_string(),
-        ":maker_coin_usd_price": swap.maker_coin_usd_price.as_ref().map(|p| p.to_string()),
-        ":taker_coin_usd_price": swap.taker_coin_usd_price.as_ref().map(|p| p.to_string()),
-        ":maker_pubkey": pubkeys.maker,
-        ":taker_pubkey": pubkeys.taker,
     };
 
     Some((INSERT_STATS_SWAP, params))
-}
-
-fn update_stats_maker_gui_version(swap: &MakerSavedSwap) -> (&'static str, OwnedSqlNamedParams) {
-    const UPDATE_STATS_SWAP_GUI_AND_VERSION_MAKER: &str =
-        "UPDATE stats_swaps set maker_gui = :maker_gui, maker_version = :maker_version WHERE uuid = :uuid;";
-    let params = owned_named_params! {
-        ":maker_gui": swap.gui.clone(),
-        ":maker_version": swap.mm_version.clone(),
-        ":uuid": swap.uuid.to_string(),
-    };
-
-    (UPDATE_STATS_SWAP_GUI_AND_VERSION_MAKER, params)
 }
 
 fn insert_stats_maker_swap_sql_init(swap: &MakerSavedSwap) -> Option<(&'static str, Vec<String>)> {
@@ -242,14 +213,6 @@ fn insert_stats_taker_swap_sql(swap: &TakerSavedSwap) -> Option<(&'static str, O
         },
     };
 
-    let pubkeys = match swap.swap_pubkeys() {
-        Ok(p) => p,
-        Err(e) => {
-            error!("Error {} on getting swap {} pubkeys", e, swap.uuid);
-            return None;
-        },
-    };
-
     let is_success = swap
         .is_success()
         .expect("is_success can return error only when swap is not finished");
@@ -270,24 +233,8 @@ fn insert_stats_taker_swap_sql(swap: &TakerSavedSwap) -> Option<(&'static str, O
         ":maker_amount": swap_data.maker_amount.to_string(),
         ":taker_amount": swap_data.taker_amount.to_string(),
         ":is_success": (is_success as u32).to_string(),
-        ":maker_coin_usd_price": swap.maker_coin_usd_price.as_ref().map(|p| p.to_string()),
-        ":taker_coin_usd_price": swap.taker_coin_usd_price.as_ref().map(|p| p.to_string()),
-        ":maker_pubkey": pubkeys.maker,
-        ":taker_pubkey": pubkeys.taker,
     };
     Some((INSERT_STATS_SWAP, params))
-}
-
-fn update_stats_taker_gui_version(swap: &TakerSavedSwap) -> (&'static str, OwnedSqlNamedParams) {
-    const UPDATE_STATS_SWAP_GUI_AND_VERSION_TAKER: &str =
-        "UPDATE stats_swaps set taker_gui = :taker_gui, taker_version = :taker_version WHERE uuid = :uuid;";
-    let params = owned_named_params! {
-        ":taker_gui": swap.gui.clone(),
-        ":taker_version": swap.mm_version.clone(),
-        ":uuid": swap.uuid.to_string(),
-    };
-
-    (UPDATE_STATS_SWAP_GUI_AND_VERSION_TAKER, params)
 }
 
 fn insert_stats_taker_swap_sql_init(swap: &TakerSavedSwap) -> Option<(&'static str, Vec<String>)> {
@@ -320,6 +267,71 @@ fn insert_stats_taker_swap_sql_init(swap: &TakerSavedSwap) -> Option<(&'static s
         (is_success as u32).to_string(),
     ];
     Some((INSERT_STATS_SWAP_ON_INIT, params))
+}
+
+/// Constructs the update query for optional fields of the swap.
+/// These are fields which are usually sent unilaterally from one side and combined together based on the shared UUID.
+fn update_optional_info(swap: &SavedSwap) -> Option<(String, OwnedSqlNamedParams)> {
+    let mut extra_args = Vec::new();
+    let mut params = OwnedSqlNamedParams::new();
+
+    if let Some(maker_pubkey) = swap.maker_pubkey() {
+        match maker_pubkey {
+            Ok(maker_pubkey) => {
+                extra_args.push("maker_pubkey = :maker_pubkey");
+                params.push((":maker_pubkey", maker_pubkey.into()));
+            },
+            Err(e) => {
+                error!("[{}] Error on getting maker_pubkey for stats: {}", swap.uuid(), e);
+            },
+        }
+    }
+    if let Some(taker_pubkey) = swap.taker_pubkey() {
+        match taker_pubkey {
+            Ok(taker_pubkey) => {
+                extra_args.push("taker_pubkey = :taker_pubkey");
+                params.push((":taker_pubkey", taker_pubkey.into()));
+            },
+            Err(e) => {
+                error!("[{}] Error on getting taker_pubkey for stats: {}", swap.uuid(), e);
+            },
+        }
+    }
+    if let Some(maker_coin_usd_price) = swap.maker_usd_price() {
+        extra_args.push("maker_coin_usd_price = :maker_coin_usd_price");
+        params.push((":maker_coin_usd_price", maker_coin_usd_price.to_string().into()));
+    }
+    if let Some(taker_coin_usd_price) = swap.taker_usd_price() {
+        extra_args.push("taker_coin_usd_price = :taker_coin_usd_price");
+        params.push((":taker_coin_usd_price", taker_coin_usd_price.to_string().into()));
+    }
+    if let Some(maker_gui) = swap.maker_gui() {
+        extra_args.push("maker_gui = :maker_gui");
+        params.push((":maker_gui", maker_gui.clone().into()));
+    }
+    if let Some(maker_version) = swap.maker_mm_version() {
+        extra_args.push("maker_version = :maker_version");
+        params.push((":maker_version", maker_version.clone().into()));
+    }
+    if let Some(taker_gui) = swap.taker_gui() {
+        extra_args.push("taker_gui = :taker_gui");
+        params.push((":taker_gui", taker_gui.clone().into()));
+    }
+    if let Some(taker_version) = swap.taker_mm_version() {
+        extra_args.push("taker_version = :taker_version");
+        params.push((":taker_version", taker_version.clone().into()));
+    }
+
+    // If no updates were needed, return None
+    if extra_args.is_empty() {
+        return None;
+    }
+
+    let update_query = format!("UPDATE stats_swaps set {} WHERE uuid = :uuid;", extra_args.join(", "));
+
+    params.push((":uuid", swap.uuid().to_string().into()));
+
+    Some((update_query, params))
 }
 
 fn execute_query_with_params(conn: &Connection, sql: &str, params: OwnedSqlNamedParams) {
@@ -357,12 +369,9 @@ pub fn add_swap_to_index(conn: &Connection, swap: &SavedSwap) {
         },
     };
 
-    let (sql, params) = match swap {
-        SavedSwap::Maker(maker) => update_stats_maker_gui_version(maker),
-        SavedSwap::Taker(taker) => update_stats_taker_gui_version(taker),
-    };
-
-    execute_query_with_params(conn, sql, params);
+    if let Some((sql, params)) = update_optional_info(swap) {
+        execute_query_with_params(conn, &sql, params);
+    }
 }
 
 #[test]

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -1624,11 +1624,6 @@ pub fn detect_secret_hash_algo_v2(maker_coin: &MmCoinEnum, taker_coin: &MmCoinEn
     }
 }
 
-pub struct SwapPubkeys {
-    pub maker: String,
-    pub taker: String,
-}
-
 /// P2P topic used to broadcast messages during execution of the upgraded swap protocol.
 pub fn swap_v2_topic(uuid: &Uuid) -> String { pub_sub_topic(SWAP_V2_PREFIX, &uuid.to_string()) }
 

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -2156,7 +2156,6 @@ pub async fn run_maker_swap(swap: RunMakerSwapInput, ctx: MmArc) {
     subscribe_to_topic(&ctx, swap_topic(&swap.uuid));
     let mut status = ctx.log.status_handle();
     let uuid_str = swap.uuid.to_string();
-    let to_broadcast = !(swap.maker_coin.is_privacy() || swap.taker_coin.is_privacy());
     macro_rules! swap_tags {
         () => {
             &[&"swap", &("uuid", uuid_str.as_str())]
@@ -2223,10 +2222,8 @@ pub async fn run_maker_swap(swap: RunMakerSwapInput, ctx: MmArc) {
                             error!("!mark_swap_finished({}): {}", uuid, e);
                         }
 
-                        if to_broadcast {
-                            if let Err(e) = broadcast_my_swap_status(&ctx, uuid).await {
-                                error!("!broadcast_my_swap_status({}): {}", uuid, e);
-                            }
+                        if let Err(e) = broadcast_my_swap_status(&ctx, uuid).await {
+                            error!("!broadcast_my_swap_status({}): {}", uuid, e);
                         }
                         break;
                     },

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -2206,7 +2206,7 @@ pub async fn run_maker_swap(swap: RunMakerSwapInput, ctx: MmArc) {
                         }
 
                         if let Err(e) = broadcast_my_swap_status(&ctx, uuid).await {
-                            error!("!broadcast_my_swap_status({}): {}", uuid, e);
+                            covered_error!("!broadcast_my_swap_status({}): {}", uuid, e);
                         }
                         break;
                     },

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -8,7 +8,7 @@ use super::{broadcast_my_swap_status, broadcast_p2p_tx_msg, broadcast_swap_msg_e
             taker_payment_spend_deadline, tx_helper_topic, wait_for_maker_payment_conf_until, AtomicSwap,
             LockedAmount, MySwapInfo, NegotiationDataMsg, NegotiationDataV2, NegotiationDataV3, RecoveredSwap,
             RecoveredSwapAction, SavedSwap, SavedSwapIo, SavedTradeFee, SwapConfirmationsSettings, SwapError, SwapMsg,
-            SwapPubkeys, SwapTxDataMsg, SwapsContext, TransactionIdentifier, INCLUDE_REFUND_FEE, NO_REFUND_FEE,
+            SwapTxDataMsg, SwapsContext, TransactionIdentifier, INCLUDE_REFUND_FEE, NO_REFUND_FEE,
             TAKER_FEE_VALIDATION_ATTEMPTS, TAKER_FEE_VALIDATION_RETRY_DELAY_SECS, WAIT_CONFIRM_INTERVAL_SEC};
 use crate::lp_dispatcher::{DispatcherContext, LpEvents};
 use crate::lp_network::subscribe_to_topic;
@@ -2039,31 +2039,14 @@ impl MakerSavedSwap {
         }
     }
 
-    // TODO: Adjust for private coins when/if they are braodcasted
-    // TODO: Adjust for HD wallet when completed
-    pub fn swap_pubkeys(&self) -> Result<SwapPubkeys, String> {
-        let maker = match &self.events.first() {
+    pub fn maker_pubkey(&self) -> Result<String, String> {
+        match &self.events.first() {
             Some(event) => match &event.event {
-                MakerSwapEvent::Started(started) => started.my_persistent_pub.to_string(),
-                _ => return ERR!("First swap event must be Started"),
+                MakerSwapEvent::Started(started) => Ok(started.my_persistent_pub.to_string()),
+                _ => ERR!("First swap event must be Started"),
             },
-            None => return ERR!("Can't get maker's pubkey while events are empty"),
-        };
-
-        let taker = match self.events.get(1) {
-            Some(event) => match &event.event {
-                MakerSwapEvent::Negotiated(neg) => {
-                    let Some(key) = neg.taker_coin_htlc_pubkey else {
-                        return ERR!("taker's pubkey is empty");
-                    };
-                    key.to_string()
-                },
-                _ => return ERR!("Swap must be negotiated to get taker's pubkey"),
-            },
-            None => return ERR!("Can't get taker's pubkey while there's no Negotiated event"),
-        };
-
-        Ok(SwapPubkeys { maker, taker })
+            None => ERR!("Can't get maker's pubkey while events are empty"),
+        }
     }
 }
 

--- a/mm2src/mm2_main/src/lp_swap/recreate_swap_data.rs
+++ b/mm2src/mm2_main/src/lp_swap/recreate_swap_data.rs
@@ -347,6 +347,8 @@ async fn recreate_taker_swap(ctx: MmArc, maker_swap: MakerSavedSwap) -> Recreate
         taker_coin: started_event.taker_coin,
         maker_coin: started_event.maker_coin.clone(),
         maker_pubkey: H256Json::from(maker_p2p_pubkey),
+        // FIXME: If you peek into where we set the value of `taker_pubkey`, we only set it to `Default::default()`, which means such value is incorrect?
+        //        Same goes for `maker_pubkey` on the other side of the swap.
         my_persistent_pub: negotiated_event.taker_pubkey,
         lock_duration: started_event.lock_duration,
         maker_amount: started_event.maker_amount,

--- a/mm2src/mm2_main/src/lp_swap/recreate_swap_data.rs
+++ b/mm2src/mm2_main/src/lp_swap/recreate_swap_data.rs
@@ -347,8 +347,6 @@ async fn recreate_taker_swap(ctx: MmArc, maker_swap: MakerSavedSwap) -> Recreate
         taker_coin: started_event.taker_coin,
         maker_coin: started_event.maker_coin.clone(),
         maker_pubkey: H256Json::from(maker_p2p_pubkey),
-        // FIXME: If you peek into where we set the value of `taker_pubkey`, we only set it to `Default::default()`, which means such value is incorrect?
-        //        Same goes for `maker_pubkey` on the other side of the swap.
         my_persistent_pub: negotiated_event.taker_pubkey,
         lock_duration: started_event.lock_duration,
         maker_amount: started_event.maker_amount,

--- a/mm2src/mm2_main/src/lp_swap/saved_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/saved_swap.rs
@@ -143,6 +143,11 @@ impl SavedSwap {
                 if let Some(ref mut event) = swap.events.first_mut() {
                     if let MakerSwapEvent::Started(ref mut data) = event.event {
                         data.secret = H256Json::default();
+                        // If we are using a spun up private key for this swap, then we probably want to hide our
+                        // persistent pubkey as well.
+                        if data.p2p_privkey.is_some() {
+                            data.my_persistent_pub = None;
+                        }
                         data.p2p_privkey = None;
                     }
                 }
@@ -150,6 +155,11 @@ impl SavedSwap {
             SavedSwap::Taker(swap) => {
                 if let Some(ref mut event) = swap.events.first_mut() {
                     if let TakerSwapEvent::Started(ref mut data) = event.event {
+                        // If we are using a spun up private key for this swap, then we probably want to hide our
+                        // persistent pubkey as well.
+                        if data.p2p_privkey.is_some() {
+                            data.my_persistent_pub = None;
+                        }
                         data.p2p_privkey = None;
                     }
                 }

--- a/mm2src/mm2_main/src/lp_swap/saved_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/saved_swap.rs
@@ -143,11 +143,12 @@ impl SavedSwap {
                 if let Some(ref mut event) = swap.events.first_mut() {
                     if let MakerSwapEvent::Started(ref mut data) = event.event {
                         data.secret = H256Json::default();
+                        // Remove the taker's pubkey. Let the stats node get it from the taker directly.
+                        data.taker_pubkey = Default::default();
                         // If we are using a spun up private key for this swap, then we probably want to hide our
-                        // persistent pubkey as well as the other party's pubkey.
+                        // persistent pubkey as well.
                         if data.p2p_privkey.is_some() {
                             data.my_persistent_pub = Default::default();
-                            data.taker_pubkey = Default::default();
                         }
                         data.p2p_privkey = None;
                     }
@@ -156,11 +157,12 @@ impl SavedSwap {
             SavedSwap::Taker(swap) => {
                 if let Some(ref mut event) = swap.events.first_mut() {
                     if let TakerSwapEvent::Started(ref mut data) = event.event {
+                        // Remove the maker's pubkey. Let the stats node get it from the maker directly.
+                        data.maker_pubkey = Default::default();
                         // If we are using a spun up private key for this swap, then we probably want to hide our
-                        // persistent pubkey as well as the other party's pubkey.
+                        // persistent pubkey as well.
                         if data.p2p_privkey.is_some() {
                             data.my_persistent_pub = Default::default();
-                            data.maker_pubkey = Default::default();
                         }
                         data.p2p_privkey = None;
                     }

--- a/mm2src/mm2_main/src/lp_swap/saved_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/saved_swap.rs
@@ -144,9 +144,10 @@ impl SavedSwap {
                     if let MakerSwapEvent::Started(ref mut data) = event.event {
                         data.secret = H256Json::default();
                         // If we are using a spun up private key for this swap, then we probably want to hide our
-                        // persistent pubkey as well.
+                        // persistent pubkey as well as the other party's pubkey.
                         if data.p2p_privkey.is_some() {
-                            data.my_persistent_pub = None;
+                            data.my_persistent_pub = Default::default();
+                            data.taker_pubkey = Default::default();
                         }
                         data.p2p_privkey = None;
                     }
@@ -156,9 +157,10 @@ impl SavedSwap {
                 if let Some(ref mut event) = swap.events.first_mut() {
                     if let TakerSwapEvent::Started(ref mut data) = event.event {
                         // If we are using a spun up private key for this swap, then we probably want to hide our
-                        // persistent pubkey as well.
+                        // persistent pubkey as well as the other party's pubkey.
                         if data.p2p_privkey.is_some() {
-                            data.my_persistent_pub = None;
+                            data.my_persistent_pub = Default::default();
+                            data.maker_pubkey = Default::default();
                         }
                         data.p2p_privkey = None;
                     }

--- a/mm2src/mm2_main/src/lp_swap/saved_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/saved_swap.rs
@@ -6,6 +6,7 @@ use coins::lp_coinfind;
 use derive_more::Display;
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::*;
+use mm2_number::BigDecimal;
 use rpc::v1::types::H256 as H256Json;
 use uuid::Uuid;
 #[cfg(target_arch = "wasm32")]
@@ -175,6 +176,62 @@ impl SavedSwap {
         match self {
             SavedSwap::Maker(maker) => maker.fetch_and_set_usd_prices().await,
             SavedSwap::Taker(taker) => taker.fetch_and_set_usd_prices().await,
+        }
+    }
+
+    pub fn taker_pubkey(&self) -> Option<Result<String, String>> {
+        match self {
+            SavedSwap::Taker(swap) => Some(swap.taker_pubkey()),
+            SavedSwap::Maker(_) => None,
+        }
+    }
+
+    pub fn maker_pubkey(&self) -> Option<Result<String, String>> {
+        match self {
+            SavedSwap::Maker(swap) => Some(swap.maker_pubkey()),
+            SavedSwap::Taker(_) => None,
+        }
+    }
+
+    pub fn maker_usd_price(&self) -> Option<&BigDecimal> {
+        match self {
+            SavedSwap::Maker(swap) => swap.maker_coin_usd_price.as_ref(),
+            SavedSwap::Taker(swap) => swap.maker_coin_usd_price.as_ref(),
+        }
+    }
+
+    pub fn taker_usd_price(&self) -> Option<&BigDecimal> {
+        match self {
+            SavedSwap::Maker(swap) => swap.taker_coin_usd_price.as_ref(),
+            SavedSwap::Taker(swap) => swap.taker_coin_usd_price.as_ref(),
+        }
+    }
+
+    pub fn maker_gui(&self) -> Option<&String> {
+        match self {
+            SavedSwap::Maker(swap) => swap.gui.as_ref(),
+            SavedSwap::Taker(_) => None,
+        }
+    }
+
+    pub fn taker_gui(&self) -> Option<&String> {
+        match self {
+            SavedSwap::Taker(swap) => swap.gui.as_ref(),
+            SavedSwap::Maker(_) => None,
+        }
+    }
+
+    pub fn maker_mm_version(&self) -> Option<&String> {
+        match self {
+            SavedSwap::Maker(swap) => swap.mm_version.as_ref(),
+            SavedSwap::Taker(_) => None,
+        }
+    }
+
+    pub fn taker_mm_version(&self) -> Option<&String> {
+        match self {
+            SavedSwap::Taker(swap) => swap.mm_version.as_ref(),
+            SavedSwap::Maker(_) => None,
         }
     }
 }

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -467,7 +467,6 @@ pub async fn run_taker_swap(swap: RunTakerSwapInput, ctx: MmArc) {
     subscribe_to_topic(&ctx, swap_topic(&swap.uuid));
     let mut status = ctx.log.status_handle();
     let uuid_str = uuid.to_string();
-    let to_broadcast = !(swap.maker_coin.is_privacy() || swap.taker_coin.is_privacy());
     let running_swap = Arc::new(swap);
     let swap_ctx = SwapsContext::from_ctx(&ctx).unwrap();
     swap_ctx.init_msg_store(running_swap.uuid, running_swap.maker_pubkey);
@@ -524,10 +523,8 @@ pub async fn run_taker_swap(swap: RunTakerSwapInput, ctx: MmArc) {
                             error!("!mark_swap_finished({}): {}", uuid_str, e);
                         }
 
-                        if to_broadcast {
-                            if let Err(e) = broadcast_my_swap_status(&ctx, running_swap.uuid).await {
-                                error!("!broadcast_my_swap_status({}): {}", uuid_str, e);
-                            }
+                        if let Err(e) = broadcast_my_swap_status(&ctx, running_swap.uuid).await {
+                            error!("!broadcast_my_swap_status({}): {}", uuid_str, e);
                         }
                         break;
                     },

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -8,7 +8,7 @@ use super::{broadcast_my_swap_status, broadcast_swap_message, broadcast_swap_msg
             check_other_coin_balance_for_swap, get_locked_amount, recv_swap_msg, swap_topic,
             wait_for_maker_payment_conf_until, AtomicSwap, LockedAmount, MySwapInfo, NegotiationDataMsg,
             NegotiationDataV2, NegotiationDataV3, RecoveredSwap, RecoveredSwapAction, SavedSwap, SavedSwapIo,
-            SavedTradeFee, SwapConfirmationsSettings, SwapError, SwapMsg, SwapPubkeys, SwapTxDataMsg, SwapsContext,
+            SavedTradeFee, SwapConfirmationsSettings, SwapError, SwapMsg, SwapTxDataMsg, SwapsContext,
             TransactionIdentifier, INCLUDE_REFUND_FEE, NO_REFUND_FEE, WAIT_CONFIRM_INTERVAL_SEC};
 use crate::lp_network::subscribe_to_topic;
 use crate::lp_ordermatch::TakerOrderBuilder;
@@ -350,31 +350,14 @@ impl TakerSavedSwap {
         }
     }
 
-    // TODO: Adjust for private coins when/if they are braodcasted
-    // TODO: Adjust for HD wallet when completed
-    pub fn swap_pubkeys(&self) -> Result<SwapPubkeys, String> {
-        let taker = match &self.events.first() {
+    pub fn taker_pubkey(&self) -> Result<String, String> {
+        match &self.events.first() {
             Some(event) => match &event.event {
-                TakerSwapEvent::Started(started) => started.my_persistent_pub.to_string(),
-                _ => return ERR!("First swap event must be Started"),
+                TakerSwapEvent::Started(started) => Ok(started.my_persistent_pub.to_string()),
+                _ => ERR!("First swap event must be Started"),
             },
-            None => return ERR!("Can't get taker's pubkey while events are empty"),
-        };
-
-        let maker = match self.events.get(1) {
-            Some(event) => match &event.event {
-                TakerSwapEvent::Negotiated(neg) => {
-                    let Some(key) = neg.maker_coin_htlc_pubkey else {
-                        return ERR!("maker's pubkey is empty");
-                    };
-                    key.to_string()
-                },
-                _ => return ERR!("Swap must be negotiated to get maker's pubkey"),
-            },
-            None => return ERR!("Can't get maker's pubkey while there's no Negotiated event"),
-        };
-
-        Ok(SwapPubkeys { maker, taker })
+            None => ERR!("Can't get taker's pubkey while events are empty"),
+        }
     }
 }
 

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -507,7 +507,7 @@ pub async fn run_taker_swap(swap: RunTakerSwapInput, ctx: MmArc) {
                         }
 
                         if let Err(e) = broadcast_my_swap_status(&ctx, running_swap.uuid).await {
-                            error!("!broadcast_my_swap_status({}): {}", uuid_str, e);
+                            covered_error!("!broadcast_my_swap_status({}): {}", uuid_str, e);
                         }
                         break;
                     },


### PR DESCRIPTION
# This PR now includes a DB migration. Backup your DB before testing!

This PR allows broadcasting the swap status for privacy coins after hiding the identifying information from it (namely: `my_persistent_pub`).

We also decided to clear out `MakerSwapData.taker_pubkey` and `TakerSwapData.maker_pubkey` so not to reveal the other side's persistent pubkey. They can reveal it themselves when they want.

This PR also correct the stats db index pubkeys, where in the past we used to store one persistent pubkey for side X and htlc pubkey for side Y, but now we store persistent pubkey for side X and also the persistent pubkey for side Y. (X & Y here being the maker or taker interchangeably. such a behaviour mainly depended on who's status messages reached the stats node first)