### PR TITLE
chore(git-blame): add a revs ignore file for git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# Toolchain upgrades:
+1979c6e3667e78ff53b47aecafb90ca9507d10e2
+daf43ebeadf0b8e17f2b76019c6496236f4dd46c
+7d51c5a6ab4390e4db8c4510db7012abe6cec8ad


### PR DESCRIPTION
adds a `.git-blame-ignore-revs` file with a couple of toolchain upgrade commits that keep popping up a lot for me with each blame peek (using gitlens on vscode).

whenever i wanna read the commit message associated with some line or take a quick look at the diff of the commit that introduced a certain line, i face one of these commits in the blame view and gotta pass by them and back to the original line change.

this is probably not all the commits that should be ignored, we might have other fmt/clippy/renamings commits, but these are the most prominent ones that keep popping up for me.