### PR TITLE
fix(zcoin): align `get_nullifiers` with sqlite counterpart

### DIFF
--- a/mm2src/coins/z_coin/storage/walletdb/wasm/storage.rs
+++ b/mm2src/coins/z_coin/storage/walletdb/wasm/storage.rs
@@ -1079,22 +1079,24 @@ impl WalletRead for WalletIndexedDb {
 
         let mut nullifiers = vec![];
         for (_, note) in maybe_notes {
-            let matching_tx = maybe_txs.iter().find(|(id_tx, _tx)| id_tx.to_bigint() == note.spent);
-
-            if let Some((_, tx)) = matching_tx {
-                if tx.block.is_some() {
-                    nullifiers.push((
-                        AccountId(
-                            note.account
-                                .to_u32()
-                                .ok_or_else(|| ZcoinStorageError::GetFromStorageError("Invalid amount".to_string()))?,
-                        ),
-                        Nullifier::from_slice(&note.nf.clone().ok_or_else(|| {
-                            ZcoinStorageError::GetFromStorageError("Error while putting tx_meta".to_string())
-                        })?)
-                        .unwrap(),
-                    ));
-                }
+            let maybe_spending_tx = maybe_txs.iter().find(|(id_tx, _tx)| id_tx.to_bigint() == note.spent);
+            let add_nullifier = match maybe_spending_tx {
+                Some((_, tx)) if tx.block.is_none() => true,
+                None => true,
+                _ => false,
+            };
+            if add_nullifier {
+                nullifiers.push((
+                    AccountId(
+                        note.account
+                            .to_u32()
+                            .ok_or_else(|| ZcoinStorageError::GetFromStorageError("Invalid amount".to_string()))?,
+                    ),
+                    Nullifier::from_slice(&note.nf.clone().ok_or_else(|| {
+                        ZcoinStorageError::GetFromStorageError("Error while putting tx_meta".to_string())
+                    })?)
+                    .unwrap(),
+                ));
             }
         }
 

--- a/mm2src/coins/z_coin/storage/walletdb/wasm/storage.rs
+++ b/mm2src/coins/z_coin/storage/walletdb/wasm/storage.rs
@@ -1086,17 +1086,17 @@ impl WalletRead for WalletIndexedDb {
                 _ => false,
             };
             if add_nullifier {
-                nullifiers.push((
-                    AccountId(
+                if let Some(ref nf_bytes) = note.nf {
+                    let account_id = AccountId(
                         note.account
                             .to_u32()
-                            .ok_or_else(|| ZcoinStorageError::GetFromStorageError("Invalid amount".to_string()))?,
-                    ),
-                    Nullifier::from_slice(&note.nf.clone().ok_or_else(|| {
-                        ZcoinStorageError::GetFromStorageError("Error while putting tx_meta".to_string())
-                    })?)
-                    .unwrap(),
-                ));
+                            .ok_or_else(|| ZcoinStorageError::GetFromStorageError("Invalid account id".to_string()))?,
+                    );
+                    let nf = Nullifier::from_slice(nf_bytes).map_err(|e| {
+                        ZcoinStorageError::GetFromStorageError(format!("Invalid nullifier bytes error: {}", e))
+                    })?;
+                    nullifiers.push((account_id, nf));
+                }
             }
         }
 


### PR DESCRIPTION
This PR is a quick fix for zcoin wasm build to return correct balance and tx history (spent_amount).
Corrects the `get_nullifiers` function to return nullfiers both for unspent notes and notes with unconfirmed spends (see the same function in librustcash for native platform).

Fixes #2650.

TODO: Add a wasm-bindgen test for zombie chain for this case