### PR TITLE
improvement(protocol): implement tendermint `get_trade_fee`

### DIFF
--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -3664,7 +3664,7 @@ pub trait MmCoin: SwapOps + WatcherOps + MarketCoinOps + Send + Sync + 'static {
     /// Transaction history background sync status
     fn history_sync_status(&self) -> HistorySyncState;
 
-    /// Get fee to be paid per 1 swap transaction
+    /// Returns the approximate amount of the miner fee that is paid per swap transaction.
     fn get_trade_fee(&self) -> Box<dyn Future<Item = TradeFee, Error = String> + Send>;
 
     /// Get fee to be paid by sender per whole swap (including possible refund) using the sending value and check if the wallet has sufficient balance to pay the fee.

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -3524,7 +3524,27 @@ impl MmCoin for TendermintCoin {
     }
 
     fn get_trade_fee(&self) -> Box<dyn Future<Item = TradeFee, Error = String> + Send> {
-        Box::new(futures01::future::err("Not implemented".into()))
+        let coin = self.clone();
+
+        let fut = async move {
+            let fee = try_s!(
+                coin.get_sender_trade_fee_for_denom(
+                    coin.ticker.to_owned(),
+                    coin.protocol_info.denom.clone(),
+                    coin.protocol_info.decimals,
+                    coin.min_tx_amount(),
+                )
+                .await
+            );
+
+            Ok(TradeFee {
+                coin: coin.ticker.to_owned(),
+                amount: fee.amount,
+                paid_from_trading_vol: false,
+            })
+        };
+
+        Box::new(fut.boxed().compat())
     }
 
     async fn get_sender_trade_fee(

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -3532,6 +3532,7 @@ impl MmCoin for TendermintCoin {
                     coin.ticker.to_owned(),
                     coin.protocol_info.denom.clone(),
                     coin.protocol_info.decimals,
+                    // Transaction amount does not influence the fee.
                     coin.min_tx_amount(),
                 )
                 .await

--- a/mm2src/coins/tendermint/tendermint_token.rs
+++ b/mm2src/coins/tendermint/tendermint_token.rs
@@ -604,7 +604,7 @@ impl MmCoin for TendermintToken {
     }
 
     fn get_trade_fee(&self) -> Box<dyn Future<Item = TradeFee, Error = String> + Send> {
-        Box::new(futures01::future::err("Not implemented".into()))
+        self.platform_coin.get_trade_fee()
     }
 
     async fn get_sender_trade_fee(


### PR DESCRIPTION
Implements `get_trade_fee` for the Tendermint protocol. Note that this function is not applicable to wallet-only assets as it is specifically designed for trade/swap operations.

It also won't work on fresh accounts with no transaction history (you would get an error like "Transport error: Account is None") as those are considered non-existent on Cosmos networks.

Demo:

```sh
$ ./enable_new_tendermint_mainnet
{"mmrpc":"2.0","result":{"ticker":"IRIS","address":"iaa1e0rx87mdj79zejewuc4jg7ql9ud2286g2us8f2","current_block":32404139,"balance":{"spendable":"0.903764","unspendable":"0"},"tokens_balances":{}},"id":0}
$ ./get_trade_fee
{"result":{"coin":"IRIS","amount":"0.046274","amount_fraction":{"numer":"23137","denom":"500000"},"amount_rat":[[1,[23137]],[1,[500000]]]}}
```

It's very accurate with the recent transactions on the network:

<img width="1379" height="804" alt="image" src="https://github.com/user-attachments/assets/665da594-e391-4a7b-811f-e4870fc7939e" />


Resolves #2657