### PR TITLE
improvement(core): handle more OS signals and broadcast them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4405,6 +4405,7 @@ dependencies = [
  "serialization",
  "serialization_derive",
  "sia-rust",
+ "signal-hook-tokio",
  "sp-runtime-interface",
  "sp-trie",
  "spv_validation",
@@ -6874,12 +6875,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "signal-hook-tokio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213241f76fb1e37e27de3b6aa1b068a2c333233b59cca6634f634b80a27ecf1e"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio",
 ]
 
 [[package]]

--- a/mm2src/mm2_event_stream/src/streamer_ids.rs
+++ b/mm2src/mm2_event_stream/src/streamer_ids.rs
@@ -6,6 +6,8 @@ const NETWORK: &str = "NETWORK";
 const HEARTBEAT: &str = "HEARTBEAT";
 const SWAP_STATUS: &str = "SWAP_STATUS";
 const ORDER_STATUS: &str = "ORDER_STATUS";
+#[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+const SHUTDOWN_SIGNAL: &str = "SHUTDOWN_SIGNAL";
 
 const TASK_PREFIX: &str = "TASK:";
 const BALANCE_PREFIX: &str = "BALANCE:";
@@ -13,8 +15,6 @@ const TX_HISTORY_PREFIX: &str = "TX_HISTORY:";
 const FEE_ESTIMATION_PREFIX: &str = "FEE_ESTIMATION:";
 const DATA_NEEDED_PREFIX: &str = "DATA_NEEDED:";
 const ORDERBOOK_UPDATE_PREFIX: &str = "ORDERBOOK_UPDATE:";
-#[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
-const SHUTDOWN_SIGNAL: &str = "SHUTDOWN_SIGNAL";
 #[cfg(any(test, target_arch = "wasm32"))]
 const FOR_TESTING_PREFIX: &str = "TEST_STREAMER:";
 
@@ -57,6 +57,8 @@ impl fmt::Display for StreamerId {
             StreamerId::Heartbeat => write!(f, "{HEARTBEAT}"),
             StreamerId::SwapStatus => write!(f, "{SWAP_STATUS}"),
             StreamerId::OrderStatus => write!(f, "{ORDER_STATUS}"),
+            #[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+            StreamerId::ShutdownSignal => write!(f, "{SHUTDOWN_SIGNAL}"),
             StreamerId::Task { task_id } => write!(f, "{TASK_PREFIX}{task_id}"),
             StreamerId::Balance { coin } => write!(f, "{BALANCE_PREFIX}{coin}"),
             StreamerId::TxHistory { coin } => write!(f, "{TX_HISTORY_PREFIX}{coin}"),
@@ -65,8 +67,6 @@ impl fmt::Display for StreamerId {
             StreamerId::OrderbookUpdate { topic } => write!(f, "{ORDERBOOK_UPDATE_PREFIX}{topic}"),
             #[cfg(any(test, target_arch = "wasm32"))]
             StreamerId::ForTesting { test_streamer } => write!(f, "{FOR_TESTING_PREFIX}{test_streamer}"),
-            #[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
-            StreamerId::ShutdownSignal => write!(f, "{SHUTDOWN_SIGNAL}"),
         }
     }
 }
@@ -103,6 +103,8 @@ impl<'de> Deserialize<'de> for StreamerId {
                     HEARTBEAT => Ok(StreamerId::Heartbeat),
                     SWAP_STATUS => Ok(StreamerId::SwapStatus),
                     ORDER_STATUS => Ok(StreamerId::OrderStatus),
+                    #[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+                    SHUTDOWN_SIGNAL => Ok(StreamerId::ShutdownSignal),
                     v if v.starts_with(TASK_PREFIX) => Ok(StreamerId::Task {
                         task_id: v[TASK_PREFIX.len()..].parse().map_err(de::Error::custom)?,
                     }),
@@ -125,8 +127,6 @@ impl<'de> Deserialize<'de> for StreamerId {
                     v if v.starts_with(FOR_TESTING_PREFIX) => Ok(StreamerId::ForTesting {
                         test_streamer: v[FOR_TESTING_PREFIX.len()..].to_string(),
                     }),
-                    #[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
-                    SHUTDOWN_SIGNAL => Ok(StreamerId::ShutdownSignal),
                     _ => Err(de::Error::custom(format!("Invalid StreamerId: {value}"))),
                 }
             }

--- a/mm2src/mm2_event_stream/src/streamer_ids.rs
+++ b/mm2src/mm2_event_stream/src/streamer_ids.rs
@@ -13,6 +13,8 @@ const TX_HISTORY_PREFIX: &str = "TX_HISTORY:";
 const FEE_ESTIMATION_PREFIX: &str = "FEE_ESTIMATION:";
 const DATA_NEEDED_PREFIX: &str = "DATA_NEEDED:";
 const ORDERBOOK_UPDATE_PREFIX: &str = "ORDERBOOK_UPDATE:";
+#[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+const SHUTDOWN_SIGNAL: &str = "SHUTDOWN_SIGNAL";
 #[cfg(any(test, target_arch = "wasm32"))]
 const FOR_TESTING_PREFIX: &str = "TEST_STREAMER:";
 
@@ -44,6 +46,8 @@ pub enum StreamerId {
     ForTesting {
         test_streamer: String,
     },
+    #[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+    ShutdownSignal,
 }
 
 impl fmt::Display for StreamerId {
@@ -61,6 +65,8 @@ impl fmt::Display for StreamerId {
             StreamerId::OrderbookUpdate { topic } => write!(f, "{ORDERBOOK_UPDATE_PREFIX}{topic}"),
             #[cfg(any(test, target_arch = "wasm32"))]
             StreamerId::ForTesting { test_streamer } => write!(f, "{FOR_TESTING_PREFIX}{test_streamer}"),
+            #[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+            StreamerId::ShutdownSignal => write!(f, "{SHUTDOWN_SIGNAL}"),
         }
     }
 }
@@ -119,6 +125,8 @@ impl<'de> Deserialize<'de> for StreamerId {
                     v if v.starts_with(FOR_TESTING_PREFIX) => Ok(StreamerId::ForTesting {
                         test_streamer: v[FOR_TESTING_PREFIX.len()..].to_string(),
                     }),
+                    #[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+                    SHUTDOWN_SIGNAL => Ok(StreamerId::ShutdownSignal),
                     _ => Err(de::Error::custom(format!("Invalid StreamerId: {value}"))),
                 }
             }

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -127,12 +127,14 @@ hyper = { workspace = true, features = ["client", "http2", "server", "tcp"] }
 rcgen.workspace = true
 rustls = { workspace = true, default-features = false }
 rustls-pemfile.workspace = true
-signal-hook-tokio = { version = "0.3", features = [ "futures-v0_3" ] }
 timed-map = { workspace = true, features = ["rustc-hash"] }
 tokio = { workspace = true, features = ["io-util", "rt-multi-thread", "net"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi.workspace = true
+
+[target.'cfg(not(any(target_arch = "wasm32", target_os = "windows")))'.dependencies]
+signal-hook-tokio = { version = "0.3", features = [ "futures-v0_3" ] }
 
 [dev-dependencies]
 coins = { path = "../coins", features = ["for-tests"] }

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -127,6 +127,7 @@ hyper = { workspace = true, features = ["client", "http2", "server", "tcp"] }
 rcgen.workspace = true
 rustls = { workspace = true, default-features = false }
 rustls-pemfile.workspace = true
+signal-hook-tokio = { version = "0.3", features = [ "futures-v0_3" ] }
 timed-map = { workspace = true, features = ["rustc-hash"] }
 tokio = { workspace = true, features = ["io-util", "rt-multi-thread", "net", "signal"] }
 

--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -129,7 +129,7 @@ rustls = { workspace = true, default-features = false }
 rustls-pemfile.workspace = true
 signal-hook-tokio = { version = "0.3", features = [ "futures-v0_3" ] }
 timed-map = { workspace = true, features = ["rustc-hash"] }
-tokio = { workspace = true, features = ["io-util", "rt-multi-thread", "net", "signal"] }
+tokio = { workspace = true, features = ["io-util", "rt-multi-thread", "net"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi.workspace = true

--- a/mm2src/mm2_main/src/mm2.rs
+++ b/mm2src/mm2_main/src/mm2.rs
@@ -85,6 +85,8 @@ pub mod lp_stats;
 pub mod lp_swap;
 pub mod lp_wallet;
 pub mod rpc;
+#[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+pub mod shutdown_signal_event;
 mod swap_versioning;
 #[cfg(all(target_arch = "wasm32", test))]
 mod wasm_tests;
@@ -236,16 +238,19 @@ fn spawn_os_signal_handler(ctx: MmArc) {
             return;
         };
 
+        let signal_name = match signal {
+            libc::SIGINT => "SIGINT".to_owned(),
+            libc::SIGTERM => "SIGTERM".to_owned(),
+            libc::SIGQUIT => "SIGQUIT".to_owned(),
+            _ => format!("UNKNOWN({signal})"),
+        };
+
+        ctx.event_stream_manager
+            .send(&mm2_event_stream::StreamerId::ShutdownSignal, signal_name.clone())
+            .unwrap();
+
         if signals_to_handle.contains(&signal) {
-            let signal_name = match signal {
-                libc::SIGINT => "SIGINT",
-                libc::SIGTERM => "SIGTERM",
-                libc::SIGQUIT => "SIGQUIT",
-                _ => unreachable!(),
-            };
-
             log::info!("Received {signal_name} signal from the OS. Wrapping things up and shutting down...");
-
             dispatch_lp_event(ctx.clone(), StopCtxEvent.into()).await;
             ctx.stop().await.expect("Couldn't stop the KDF runtime.");
         } else {

--- a/mm2src/mm2_main/src/mm2.rs
+++ b/mm2src/mm2_main/src/mm2.rs
@@ -198,7 +198,7 @@ pub async fn lp_main(
         .into_mm_arc();
     ctx_cb(try_s!(ctx.ffi_handle()));
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
     spawn_os_signal_handler(ctx.clone());
 
     try_s!(lp_init(ctx.clone(), version, datetime).await);
@@ -221,7 +221,7 @@ pub async fn lp_run(ctx: MmArc) {
 /// Handles various OS signals and shutdowns the KDF runtime gracefully.
 ///
 /// It's important to spawn this task as soon as `Ctx` is in the correct state.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
 fn spawn_os_signal_handler(ctx: MmArc) {
     use crate::lp_dispatcher::{dispatch_lp_event, StopCtxEvent};
     use futures::StreamExt;

--- a/mm2src/mm2_main/src/mm2.rs
+++ b/mm2src/mm2_main/src/mm2.rs
@@ -199,7 +199,7 @@ pub async fn lp_main(
     ctx_cb(try_s!(ctx.ffi_handle()));
 
     #[cfg(not(target_arch = "wasm32"))]
-    spawn_ctrl_c_handler(ctx.clone());
+    spawn_os_signal_handler(ctx.clone());
 
     try_s!(lp_init(ctx.clone(), version, datetime).await);
     Ok(ctx)
@@ -218,22 +218,39 @@ pub async fn lp_run(ctx: MmArc) {
     lp_swap::clear_running_swaps(&ctx);
 }
 
-/// Handles CTRL-C signals and shutdowns the KDF runtime gracefully.
+/// Handles various OS signals and shutdowns the KDF runtime gracefully.
 ///
 /// It's important to spawn this task as soon as `Ctx` is in the correct state.
 #[cfg(not(target_arch = "wasm32"))]
-fn spawn_ctrl_c_handler(ctx: MmArc) {
+fn spawn_os_signal_handler(ctx: MmArc) {
     use crate::lp_dispatcher::{dispatch_lp_event, StopCtxEvent};
+    use futures::StreamExt;
 
     common::executor::spawn(async move {
-        tokio::signal::ctrl_c()
-            .await
-            .expect("Couldn't listen for the CTRL-C signal.");
+        let signals_to_handle = [libc::SIGINT, libc::SIGTERM, libc::SIGQUIT];
+        let mut signals =
+            signal_hook_tokio::Signals::new(signals_to_handle).expect("Couldn't listen for the CTRL-C signal.");
 
-        log::info!("Wrapping things up and shutting down...");
+        let Some(signal) = signals.next().await else {
+            log::error!("Could not catch the OS signal.");
+            return;
+        };
 
-        dispatch_lp_event(ctx.clone(), StopCtxEvent.into()).await;
-        ctx.stop().await.expect("Couldn't stop the KDF runtime.");
+        if signals_to_handle.contains(&signal) {
+            let signal_name = match signal {
+                libc::SIGINT => "SIGINT",
+                libc::SIGTERM => "SIGTERM",
+                libc::SIGQUIT => "SIGQUIT",
+                _ => unreachable!(),
+            };
+
+            log::info!("Received {signal_name} signal from the OS. Wrapping things up and shutting down...");
+
+            dispatch_lp_event(ctx.clone(), StopCtxEvent.into()).await;
+            ctx.stop().await.expect("Couldn't stop the KDF runtime.");
+        } else {
+            log::warn!("Received a signal ({signal}) from the OS that cannot be handled.");
+        }
     });
 }
 

--- a/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
+++ b/mm2src/mm2_main/src/rpc/dispatcher/dispatcher.rs
@@ -430,6 +430,8 @@ async fn rpc_streaming_dispatcher(
         "order_status::enable" => handle_mmrpc(ctx, request, streaming_activations::enable_order_status).await,
         "tx_history::enable" => handle_mmrpc(ctx, request, streaming_activations::enable_tx_history).await,
         "orderbook::enable" => handle_mmrpc(ctx, request, streaming_activations::enable_orderbook).await,
+        #[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+        "shutdown_signal::enable" => handle_mmrpc(ctx, request, streaming_activations::enable_shutdown_signal).await,
         "disable" => handle_mmrpc(ctx, request, streaming_activations::disable_streamer).await,
         _ => MmError::err(DispatcherError::NoSuchMethod),
     }

--- a/mm2src/mm2_main/src/rpc/streaming_activations/mod.rs
+++ b/mm2src/mm2_main/src/rpc/streaming_activations/mod.rs
@@ -5,6 +5,8 @@ mod heartbeat;
 mod network;
 mod orderbook;
 mod orders;
+#[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+mod shutdown_signal;
 mod swaps;
 mod tx_history;
 
@@ -16,6 +18,8 @@ pub use heartbeat::*;
 pub use network::*;
 pub use orderbook::*;
 pub use orders::*;
+#[cfg(not(any(target_arch = "wasm32", target_os = "windows")))]
+pub use shutdown_signal::*;
 pub use swaps::*;
 pub use tx_history::*;
 

--- a/mm2src/mm2_main/src/rpc/streaming_activations/shutdown_signal.rs
+++ b/mm2src/mm2_main/src/rpc/streaming_activations/shutdown_signal.rs
@@ -1,0 +1,35 @@
+//! RPC activation and deactivation for the shutdown signals.
+use super::{EnableStreamingRequest, EnableStreamingResponse};
+
+use crate::shutdown_signal_event::ShutdownSignalEvent;
+use common::HttpStatusCode;
+use derive_more::Display;
+use http::StatusCode;
+use mm2_core::mm_ctx::MmArc;
+use mm2_err_handle::{map_to_mm::MapToMmResult, mm_error::MmResult};
+
+#[derive(Deserialize)]
+pub struct EnableShutdownSignalRequest;
+
+#[derive(Display, Serialize, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum ShutdownSignalRequestError {
+    EnableError(String),
+}
+
+impl HttpStatusCode for ShutdownSignalRequestError {
+    fn status_code(&self) -> StatusCode {
+        StatusCode::BAD_REQUEST
+    }
+}
+
+pub async fn enable_shutdown_signal(
+    ctx: MmArc,
+    req: EnableStreamingRequest<EnableShutdownSignalRequest>,
+) -> MmResult<EnableStreamingResponse, ShutdownSignalRequestError> {
+    ctx.event_stream_manager
+        .add(req.client_id, ShutdownSignalEvent, ctx.spawner())
+        .await
+        .map(EnableStreamingResponse::new)
+        .map_to_mm(|e| ShutdownSignalRequestError::EnableError(format!("{e:?}")))
+}

--- a/mm2src/mm2_main/src/shutdown_signal_event.rs
+++ b/mm2src/mm2_main/src/shutdown_signal_event.rs
@@ -1,0 +1,30 @@
+use async_trait::async_trait;
+use futures::channel::oneshot;
+use futures::StreamExt;
+use mm2_event_stream::{Broadcaster, Event, EventStreamer, StreamHandlerInput, StreamerId};
+
+pub struct ShutdownSignalEvent;
+
+#[async_trait]
+impl EventStreamer for ShutdownSignalEvent {
+    type DataInType = String;
+
+    fn streamer_id(&self) -> StreamerId {
+        StreamerId::ShutdownSignal
+    }
+
+    async fn handle(
+        self,
+        broadcaster: Broadcaster,
+        ready_tx: oneshot::Sender<Result<(), String>>,
+        mut data_rx: impl StreamHandlerInput<Self::DataInType>,
+    ) {
+        ready_tx
+            .send(Ok(()))
+            .expect("Receiver is dropped, which should never happen.");
+
+        while let Some(signal) = data_rx.next().await {
+            broadcaster.broadcast(Event::new(self.streamer_id(), json!(signal)));
+        }
+    }
+}


### PR DESCRIPTION
Makes KDF to broadcast (through streaming manager) OS signal before the graceful shutdown.

Also, refactors the `spawn_ctrl_c_handler` function to cover more signals in a more generic way (can handle more signals easily when needed).

The event activation RPC:

```sh
curl --url "http://127.0.0.1:7783" --data '{
  "userpass":"'$userpass'",
  "method":"stream::shutdown_signal::enable",
  "mmrpc":"2.0",
  "params": {},
  "id": "'$client_id'"
}'
```

The broadcasted message:

<img width="1208" height="240" alt="image" src="https://github.com/user-attachments/assets/872e800a-7cbf-4c3a-b0e8-153474ccc0af" />

for the signals we can't gracefully shutdown, the message will be "UNKNOWN($id_of_the_signal)".

This feature isn't supported on Windows, and doesn't run on Web for obvious reasons.