### PR TITLE
Fix Electrum max_connected=1 strict single-connection mode

### DIFF
--- a/mm2src/coins/utxo/rpc_clients/electrum_rpc/client.rs
+++ b/mm2src/coins/utxo/rpc_clients/electrum_rpc/client.rs
@@ -19,7 +19,7 @@ use common::executor::abortable_queue::{AbortableQueue, WeakSpawner};
 use common::jsonrpc_client::{JsonRpcBatchClient, JsonRpcClient, JsonRpcError, JsonRpcErrorType, JsonRpcId,
                              JsonRpcMultiClient, JsonRpcRemoteAddr, JsonRpcRequest, JsonRpcRequestEnum,
                              JsonRpcResponseEnum, JsonRpcResponseFut, RpcRes};
-use common::log::warn;
+use common::log::{info, warn};
 use common::{median, OrdRange};
 use keys::hash::H256;
 use keys::Address;
@@ -319,22 +319,55 @@ impl ElectrumClient {
             Ok(response) => Ok(response),
             // If we failed the request using only the active connections, try again using all connections.
             Err(_) if !send_to_all => {
-                warn!(
-                    "[coin={}] Failed to send the request using active connections, trying all connections.",
-                    self.coin_ticker()
-                );
+                let max_connected = self.connection_manager.config().max_connected;
+                let min_connected = self.connection_manager.config().min_connected;
+                let active_conns = self.connection_manager.get_active_connections().len();
                 let connections = self.connection_manager.get_all_connections();
-                // At this point we should have all the connections disconnected since all
-                // the active connections failed (and we disconnected them in the process).
-                // So use a higher concurrency to speed up the response time.
-                //
-                // Note that a side effect of this is that we might break the `max_connected` threshold for
-                // a short time since the connection manager's background task will be trying to establish
-                // connections at the same time. This is not as bad though since the manager's background task
-                // tries connections sequentially and we are expected for finish much quicker due to parallelizing.
-                let concurrency = self.connection_manager.config().max_connected;
+                let all_conns = connections.len();
+                
+                warn!(
+                    "[coin={}] FALLBACK: Failed to send request using active connections, trying all connections. \
+                     Config: max_connected={}, min_connected={}, active_conns={}, all_conns={}",
+                    self.coin_ticker(),
+                    max_connected,
+                    min_connected,
+                    active_conns,
+                    all_conns
+                );
+                
+                // For strict single-connection mode (max_connected=1), we need to ensure only one connection
+                // is established at any time. Use concurrency=1 to try servers strictly sequentially.
+                let concurrency = if max_connected == 1 {
+                    info!(
+                        "[coin={}] FALLBACK: Strict single-connection mode enabled, trying servers sequentially",
+                        self.coin_ticker()
+                    );
+                    1
+                } else {
+                    max_connected
+                };
+                
                 match self.send_request_using(&request, connections, false, concurrency).await {
-                    Ok(response) => Ok(response),
+                    Ok(response) => {
+                        // In strict single-connection mode, ensure we only have one maintained connection
+                        if max_connected == 1 {
+                            let maintained = self.connection_manager.get_active_connections();
+                            if maintained.len() > 1 {
+                                warn!(
+                                    "[coin={}] FALLBACK: After success, found {} maintained connections in strict mode, pruning extras",
+                                    self.coin_ticker(),
+                                    maintained.len()
+                                );
+                                for (idx, conn) in maintained.iter().enumerate() {
+                                    if idx > 0 {
+                                        self.connection_manager.not_needed(conn.address());
+                                        conn.disconnect(None);
+                                    }
+                                }
+                            }
+                        }
+                        Ok(response)
+                    },
                     Err(err_vec) => Err(JsonRpcErrorType::Internal(format!("All servers errored: {err_vec:?}"))),
                 }
             },

--- a/mm2src/coins/utxo/rpc_clients/electrum_rpc/connection_manager/manager.rs
+++ b/mm2src/coins/utxo/rpc_clients/electrum_rpc/connection_manager/manager.rs
@@ -9,7 +9,7 @@ use super::connection_context::ConnectionContext;
 use crate::utxo::rpc_clients::UtxoRpcClientOps;
 use common::executor::abortable_queue::AbortableQueue;
 use common::executor::{AbortableSystem, SpawnFuture, Timer};
-use common::log::{debug, error, LogOnError};
+use common::log::{debug, error, info, warn, LogOnError};
 use common::notifier::{Notifiee, Notifier};
 use common::now_ms;
 use keys::Address;
@@ -430,6 +430,14 @@ impl ConnectionManager {
             if maintained_connections_size < self.config().max_connected
                 || connection_id < lowest_priority_connection_id
             {
+                info!(
+                    "BACKGROUND_TASK: Attempting to establish connection to {} (maintained={}, max={}, strict_mode={})",
+                    address,
+                    maintained_connections_size,
+                    self.config().max_connected,
+                    self.config().max_connected == 1
+                );
+                
                 // Now that we know the connection is good to be inserted, try to establish it.
                 if let Err(e) = connection.establish_connection_loop(client.clone()).await {
                     if log_errors {
@@ -441,7 +449,13 @@ impl ConnectionManager {
                     }
                     continue;
                 }
-                self.maintain(connection_id, address);
+                self.maintain(connection_id, address.clone());
+                
+                info!(
+                    "BACKGROUND_TASK: Successfully maintained connection to {} (total_maintained={})",
+                    address,
+                    self.read_maintained_connections().len()
+                );
             } else {
                 // If any of the two conditions on the `if` statement above are not met, there is nothing to do.
                 // At this point we have already collected `max_connected` connections and also the current connection
@@ -486,8 +500,15 @@ impl ConnectionManager {
         maintained_connections.insert(id, server_address);
         // If we have reached the `max_connected` threshold then remove the lowest priority connection.
         if maintained_connections.len() > self.config().max_connected {
+            warn!(
+                "PRUNING: maintained_connections={} exceeds max_connected={}, removing lowest priority connection",
+                maintained_connections.len(),
+                self.config().max_connected
+            );
             let lowest_priority_connection_id = *maintained_connections.keys().next_back().unwrap_or(&u32::MAX);
-            maintained_connections.remove(&lowest_priority_connection_id);
+            if let Some(removed_addr) = maintained_connections.remove(&lowest_priority_connection_id) {
+                info!("PRUNING: Removed connection to {} (id={})", removed_addr, lowest_priority_connection_id);
+            }
         }
     }
 


### PR DESCRIPTION
# Fix Electrum max_connected=1 strict single-connection mode

## Summary
Fixes an issue where multiple Electrum connections were being established simultaneously despite `max_connected=1` configuration. The root cause was two concurrent processes both trying to establish connections:
1. The fallback path (when active connections fail)
2. The connection manager's background task (maintaining min_connected)

**Changes:**
- Modified fallback path to use `concurrency=1` (sequential server trials) when `max_connected=1`
- Added connection pruning after successful fallback to ensure only one connection remains in strict mode
- Added comprehensive logging to track connection attempts in both fallback path and background task
- Imported `info` and `warn` logging macros

**Behavioral changes:**
- When `max_connected=1`: Servers are now tried strictly sequentially during fallback, and extra connections are immediately pruned
- When `max_connected > 1`: No behavior change (existing parallel recovery preserved)

## Review & Testing Checklist for Human
- [ ] **Functional test with max_connected=1**: Enable a coin with `max_connected: 1` and verify only one Electrum connection is established. Trigger a fallback scenario (disconnect active connection) and verify recovery establishes only one connection
- [ ] **Test with max_connected > 1**: Verify coins with multiple connections still work correctly and haven't regressed
- [ ] **Review logging output**: Check that the new INFO and WARN logs are helpful and not too verbose in production
- [ ] **Connection stability**: Verify the pruning logic (disconnecting extras after fallback) doesn't cause connection instability or disconnect the wrong connection
- [ ] **Race condition review**: Review the concurrency logic carefully - ensure fallback and background task can't still race to establish multiple connections simultaneously in edge cases

### Test Plan
1. Configure a UTXO coin with Electrum mode and `max_connected: 1`
2. Monitor logs for "FALLBACK:" and "BACKGROUND_TASK:" messages
3. Verify only one connection appears in logs as "is now connected"
4. Trigger connection failure and observe recovery behavior
5. Repeat with `max_connected: 3` to verify multi-connection mode still works

### Notes
- Session: https://app.devin.ai/sessions/057e01e62aeb455b963cfcdfdb5f2a41
- Requested by: ca333 (ca@cex24.com) / @ca333
- Build tested locally, compiles successfully
- ⚠️ **Not functionally tested** with actual Electrum servers - human testing is critical