### PR TITLE
improvement(sse-example): copy the query params in the url to the event-stream initialization

### DIFF
--- a/examples/sse/index.html
+++ b/examples/sse/index.html
@@ -8,7 +8,8 @@
 
   <script>
     if (typeof (EventSource) !== "undefined") {
-      var source = new EventSource("http://localhost:7783/event-stream", {
+      const urlParams = new URLSearchParams(window.location.search);
+      var source = new EventSource("http://localhost:7783/event-stream?" + urlParams.toString(), {
         withCredentials: false,
       });
       source.onmessage = function (event) {


### PR DESCRIPTION
Looks like this was confusing for some (the fact that the query param to specify the client id goes inside the `EventSource` constructor rather than a query parameters of the open html file on browser's url bar; i.e. u need to edit the html file to change the client id).

This PR just copies the the query params from the url bar into the `EventSource` constructor, which means we no longer have to edit the html file manually but rather just include any query params we want in the url search bar directly.