### PR TITLE
fix(legacy-swap): make payment transaction broadcast interval smaller

### DIFF
--- a/mm2src/coins/eth/fee_estimation/eip1559/mod.rs
+++ b/mm2src/coins/eth/fee_estimation/eip1559/mod.rs
@@ -9,9 +9,10 @@ use url::Url;
 pub(crate) const FEE_PRIORITY_LEVEL_N: usize = 3;
 
 /// Indicates which provider was used to get fee per gas estimations
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum EstimationSource {
     /// filled by default values
+    #[default]
     Empty,
     /// internal simple estimator
     Simple,
@@ -27,12 +28,6 @@ impl std::fmt::Display for EstimationSource {
             EstimationSource::Infura => write!(f, "infura"),
             EstimationSource::Blocknative => write!(f, "blocknative"),
         }
-    }
-}
-
-impl Default for EstimationSource {
-    fn default() -> Self {
-        Self::Empty
     }
 }
 

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -397,19 +397,14 @@ impl RpcCommonOps for TendermintCoin {
     }
 }
 
-#[derive(PartialEq)]
+#[derive(Default, PartialEq)]
 pub enum TendermintWalletConnectionType {
     Wc(kdf_walletconnect::WcTopic),
     WcLedger(kdf_walletconnect::WcTopic),
     KeplrLedger,
     Keplr,
+    #[default]
     Native,
-}
-
-impl Default for TendermintWalletConnectionType {
-    fn default() -> Self {
-        Self::Native
-    }
 }
 
 pub struct TendermintCoinImpl {

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -1012,7 +1012,7 @@ impl MakerSwap {
     }
 
     async fn wait_for_taker_payment(&self) -> Result<(Option<MakerSwapCommand>, Vec<MakerSwapEvent>), String> {
-        const PAYMENT_MSG_INTERVAL_SEC: f64 = 600.;
+        const PAYMENT_MSG_INTERVAL_SEC: f64 = 15.;
         let payment_data_msg = match self.get_my_payment_data().await {
             Ok(data) => data,
             Err(e) => {

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -1012,6 +1012,7 @@ impl MakerSwap {
     }
 
     async fn wait_for_taker_payment(&self) -> Result<(Option<MakerSwapCommand>, Vec<MakerSwapEvent>), String> {
+        /// Broadcast interval for maker payment message, reduced to ensure the iOS app can re-send or receive it while remaining in the foreground.
         const PAYMENT_MSG_INTERVAL_SEC: f64 = 15.;
         let payment_data_msg = match self.get_my_payment_data().await {
             Ok(data) => data,

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1847,7 +1847,9 @@ impl TakerSwap {
     }
 
     async fn wait_for_taker_payment_spend(&self) -> Result<(Option<TakerSwapCommand>, Vec<TakerSwapEvent>), String> {
-        const BROADCAST_MSG_INTERVAL_SEC: f64 = 15.;
+        const WATCHER_MSG_INTERVAL_SEC: f64 = 600.;
+        /// Broadcast interval for taker payment message, reduced to ensure the iOS app can re-send or receive it while remaining in the foreground.
+        const PAYMENT_MSG_INTERVAL_SEC: f64 = 15.;
 
         let tx_hex = self.r().taker_payment.as_ref().unwrap().tx_hex.clone();
         let mut watcher_broadcast_abort_handle = None;
@@ -1872,7 +1874,7 @@ impl TakerSwap {
                     self.ctx.clone(),
                     watcher_topic(&self.r().data.taker_coin),
                     swpmsg_watcher,
-                    BROADCAST_MSG_INTERVAL_SEC,
+                    WATCHER_MSG_INTERVAL_SEC,
                     Some(htlc_keypair),
                 ));
             }
@@ -1884,7 +1886,7 @@ impl TakerSwap {
             self.ctx.clone(),
             swap_topic(&self.uuid),
             msg,
-            BROADCAST_MSG_INTERVAL_SEC,
+            PAYMENT_MSG_INTERVAL_SEC,
             self.p2p_privkey,
         );
 

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1847,7 +1847,7 @@ impl TakerSwap {
     }
 
     async fn wait_for_taker_payment_spend(&self) -> Result<(Option<TakerSwapCommand>, Vec<TakerSwapEvent>), String> {
-        const BROADCAST_MSG_INTERVAL_SEC: f64 = 600.;
+        const BROADCAST_MSG_INTERVAL_SEC: f64 = 10.;
 
         let tx_hex = self.r().taker_payment.as_ref().unwrap().tx_hex.clone();
         let mut watcher_broadcast_abort_handle = None;

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1847,7 +1847,7 @@ impl TakerSwap {
     }
 
     async fn wait_for_taker_payment_spend(&self) -> Result<(Option<TakerSwapCommand>, Vec<TakerSwapEvent>), String> {
-        const BROADCAST_MSG_INTERVAL_SEC: f64 = 10.;
+        const BROADCAST_MSG_INTERVAL_SEC: f64 = 15.;
 
         let tx_hex = self.r().taker_payment.as_ref().unwrap().tx_hex.clone();
         let mut watcher_broadcast_abort_handle = None;


### PR DESCRIPTION
### Summary

This PR reduces delays for legacy atomic swaps on the iOS platform.

When the Komodo Wallet iOS app transitions to the background, existing network connections may be disrupted. When the user returns the app to the foreground, running swaps should automatically resume and continue exchanging P2P messages.

However, we observed cases where swaps remained stuck in the MakerPaymentReceived or TakerPaymentSpent states for extended periods (sometimes over an hour).

### Root Cause

The issue was caused by an excessively long P2P message re-broadcast interval (600 seconds). Since the default iOS auto-lock timeout is 30 seconds, the app often returned to the background before another broadcast could occur. As a result, p2p messages with payment transactions were not re-sent or received in time.

### Fix

This PR reduces the P2P re-broadcast interval from 600 seconds to 15 seconds, ensuring that at least one re-broadcast happens while the app remains active in the foreground.


