### PR TITLE
chore(docker-tests): don't use port `7000` for MYCOIN

### DIFF
--- a/mm2src/mm2_main/tests/docker_tests_main.rs
+++ b/mm2src/mm2_main/tests/docker_tests_main.rs
@@ -100,8 +100,8 @@ pub fn docker_tests_runner(tests: &[&TestDescAndFn]) {
             (None, None, None)
         };
         let (utxo_node, utxo_node1) = if !disable_utxo {
-            let utxo_node = utxo_asset_docker_node(&docker, "MYCOIN", 7000);
-            let utxo_node1 = utxo_asset_docker_node(&docker, "MYCOIN1", 8000);
+            let utxo_node = utxo_asset_docker_node(&docker, "MYCOIN", 8000);
+            let utxo_node1 = utxo_asset_docker_node(&docker, "MYCOIN1", 8001);
             (Some(utxo_node), Some(utxo_node1))
         } else {
             (None, None)


### PR DESCRIPTION
Since 7000 conflicts with airplay receiver port in macos.

h/t @dimxy 