### PR TITLE
fix(offline-keys): correct z-derivation path formatting in offline HD…

### DIFF
--- a/mm2src/coins/rpc_command/offline_keys.rs
+++ b/mm2src/coins/rpc_command/offline_keys.rs
@@ -354,7 +354,7 @@ async fn offline_hd_keys_export_internal(
 
                 // The derivation path for a Z-coin account correctly stops at the account index.
                 let derivation_path = format!("{base_derivation_path}/{account_index}'");
-                let z_derivation_path = format!("{z_derivation_path_str}/{account_index}");
+                let z_derivation_path = format!("{z_derivation_path_str}/{account_index}'");
 
                 addresses.push(HdAddressInfo {
                     derivation_path,


### PR DESCRIPTION
… keys export

Fixes: https://github.com/KomodoPlatform/komodo-defi-framework/issues/2684