### PR TITLE
feat(legacy-swaps): ban maker if swap negotiation failed

### DIFF
--- a/mm2src/mm2_main/src/lp_ordermatch.rs
+++ b/mm2src/mm2_main/src/lp_ordermatch.rs
@@ -4262,6 +4262,12 @@ async fn handle_timed_out_maker_matches(ctx: MmArc, ordermatch_ctx: &OrdermatchC
     }
 }
 
+/// Taker processes MakerReserved messages.
+/// The messages are sorted by maker prices (ascending) and the first message that matches the taker order is selected.
+///
+/// This function is spawned for each MakerReserved message incoming from different makers
+/// but only one instance will stay running after the received message is added into the pending map.
+/// The running instance waits for a few secs and processes all pending MakerReserved messages.
 async fn process_maker_reserved(ctx: MmArc, from_pubkey: H256Json, reserved_msg: MakerReserved) {
     log::debug!("Processing MakerReserved {:?}", reserved_msg);
     let ordermatch_ctx = OrdermatchContext::from_ctx(&ctx).unwrap();
@@ -4289,7 +4295,8 @@ async fn process_maker_reserved(ctx: MmArc, from_pubkey: H256Json, reserved_msg:
             .or_insert_with(Vec::new);
         pending_for_order.push(reserved_msg);
         if pending_for_order.len() > 1 {
-            // messages will be sorted by price and processed in the first called handler
+            // Cancel second+ process_maker_reserved handlers.
+            // Messages will be sorted by price and processed in the first spawned handler
             return;
         }
     }

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -3295,6 +3295,8 @@ mod taker_swap_tests {
 
         let event = TakerSwapEvent::TakerPaymentWaitForSpendFailed("err".into());
         assert!(event.should_ban_maker());
+        let event = TakerSwapEvent::NegotiateFailed("err".into());
+        assert!(event.should_ban_maker());
     }
 
     #[test]

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -757,7 +757,9 @@ impl TakerSwapEvent {
     fn should_ban_maker(&self) -> bool {
         matches!(
             self,
-            TakerSwapEvent::MakerPaymentValidateFailed(_) | TakerSwapEvent::TakerPaymentWaitForSpendFailed(_)
+            TakerSwapEvent::NegotiateFailed(_)
+                | TakerSwapEvent::MakerPaymentValidateFailed(_)
+                | TakerSwapEvent::TakerPaymentWaitForSpendFailed(_)
         )
     }
 


### PR DESCRIPTION
Adds NegotiateFailed event to the list of legacy swap events when the maker should be banned by KDF if the swap failed.
Implements #2687. 