### PR TITLE
chore(ci): migrate docker image push to gleec organization

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -81,9 +81,9 @@ jobs:
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/dev'
         run: |
           CONTAINER_TAG="dev-$KDF_BUILD_TAG"
-          docker build -t komodoofficial/komodo-defi-framework:"$CONTAINER_TAG" -t komodoofficial/komodo-defi-framework:dev-latest -f .docker/Dockerfile.dev-release .
-          docker push komodoofficial/komodo-defi-framework:"$CONTAINER_TAG"
-          docker push komodoofficial/komodo-defi-framework:dev-latest
+          docker build -t gleec/komodo-defi-framework:"$CONTAINER_TAG" -t gleec/komodo-defi-framework:dev-latest -f .docker/Dockerfile.dev-release .
+          docker push gleec/komodo-defi-framework:"$CONTAINER_TAG"
+          docker push gleec/komodo-defi-framework:dev-latest
 
   mac-x86-64:
     timeout-minutes: 60

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -75,9 +75,9 @@ jobs:
       - name: Build and push container image
         run: |
           export CONTAINER_TAG=$(./target/release/kdf --version | awk '{print $3}')
-          docker build -t komodoofficial/komodo-defi-framework:"$CONTAINER_TAG" -t komodoofficial/komodo-defi-framework:main-latest -f .docker/Dockerfile.release .
-          docker push komodoofficial/komodo-defi-framework:"$CONTAINER_TAG"
-          docker push komodoofficial/komodo-defi-framework:main-latest
+          docker build -t gleec/komodo-defi-framework:"$CONTAINER_TAG" -t gleec/komodo-defi-framework:main-latest -f .docker/Dockerfile.release .
+          docker push gleec/komodo-defi-framework:"$CONTAINER_TAG"
+          docker push gleec/komodo-defi-framework:main-latest
 
   mac-x86-64:
     timeout-minutes: 60

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ docker run -v "$(pwd)":/app -w /app kdf-build-container cargo build
 
 Just like building it on your host system, you will now have the target directory containing the build files.
 
-Alternatively, container images are available on [DockerHub](https://hub.docker.com/r/komodoofficial/komodo-defi-framework)
+Alternatively, container images are available on [DockerHub](https://hub.docker.com/r/gleec/komodo-defi-framework)
 
 ## Building WASM binary
 


### PR DESCRIPTION
## Summary
- Migrate Docker image push from `komodoofficial/komodo-defi-framework` to `gleec/komodo-defi-framework`
- Update dev-build.yml workflow for dev branch builds
- Update release-build.yml workflow for main branch releases
- Update README.md DockerHub link

🤖 Generated with [Claude Code](https://claude.com/claude-code)