### PR TITLE
feat(dex-fee): update fee rate, migrate fee addresses and default netid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,6 +4681,7 @@ dependencies = [
  "db_common",
  "futures 0.3.31",
  "gstuff",
+ "hex",
  "http 0.2.12",
  "kdf_walletconnect",
  "lazy_static",

--- a/mm2src/adex_cli/src/scenarios/init_mm2_cfg.rs
+++ b/mm2src/adex_cli/src/scenarios/init_mm2_cfg.rs
@@ -14,7 +14,7 @@ use super::inquire_extentions::{InquireOption, DEFAULT_DEFAULT_OPTION_BOOL_FORMA
 use crate::helpers;
 use crate::logging::error_anyhow;
 
-const DEFAULT_NET_ID: u16 = 8762;
+const DEFAULT_NET_ID: u16 = 6133;
 const DEFAULT_GID: &str = "adex-cli";
 const DEFAULT_OPTION_PLACEHOLDER: &str = "Tap enter to skip";
 const RPC_PORT_MIN: u16 = 1024;
@@ -128,7 +128,7 @@ impl Mm2Cfg {
     fn inquire_net_id(&mut self) -> Result<()> {
         self.netid = CustomType::<u16>::new("What is the network `mm2` is going to be a part, netid:")
                 .with_default(DEFAULT_NET_ID)
-                .with_help_message(r#"Network ID number, telling the Komodo DeFi Framework which network to join. 8762 is the current main network, though alternative netids can be used for testing or "private" trades"#)
+                .with_help_message(r#"Network ID number, telling the Komodo DeFi Framework which network to join. 6133 is the current main network, though alternative netids can be used for testing or "private" trades"#)
                 .with_placeholder(format!("{DEFAULT_NET_ID}").as_str())
                 .prompt()
                 .map_err(|error|
@@ -283,7 +283,7 @@ impl Mm2Cfg {
                 .with_formatter(DEFAULT_OPTION_BOOL_FORMATTER)
                 .with_default_value_formatter(DEFAULT_DEFAULT_OPTION_BOOL_FORMATTER)
                 .with_default(InquireOption::None)
-                .with_help_message("Runs Komodo DeFi Framework as a seed node mode (acting as a relay for Komodo DeFi Framework clients). Optional, defaults to false. Use of this mode is not reccomended on the main network (8762) as it could result in a pubkey ban if non-compliant. on alternative testing or private networks, at least one seed node is required to relay information to other Komodo DeFi Framework clients using the same netID.")
+                .with_help_message("Runs Komodo DeFi Framework as a seed node mode (acting as a relay for Komodo DeFi Framework clients). Optional, defaults to false. Use of this mode is not reccomended on the main network (6133) as it could result in a pubkey ban if non-compliant. on alternative testing or private networks, at least one seed node is required to relay information to other Komodo DeFi Framework clients using the same netID.")
                 .prompt()
                 .map_err(|error|
                     error_anyhow!("Failed to get i_am_a_seed: {error}")

--- a/mm2src/coins/lightning.rs
+++ b/mm2src/coins/lightning.rs
@@ -205,6 +205,7 @@ impl LightningCoin {
             .find(|chan| chan.user_channel_id == uuid.as_u128())
     }
 
+    #[allow(clippy::result_large_err)] // PaymentError is from external crate
     pub(crate) async fn pay_invoice(
         &self,
         invoice: Invoice,

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -4144,18 +4144,23 @@ impl DexFee {
     }
 
     /// Calculates DEX fee with known taker_pubkey (for some takers dexfee may be zero).
-    pub fn new_with_taker_pubkey(taker_coin: &dyn MmCoin, trade_amount: &MmNumber, taker_pubkey: &[u8]) -> DexFee {
+    pub fn new_with_taker_pubkey(
+        taker_coin: &dyn MmCoin,
+        maker_ticker: &str,
+        trade_amount: &MmNumber,
+        taker_pubkey: &[u8],
+    ) -> DexFee {
         if !taker_coin.is_privacy() && taker_coin.burn_pubkey() == taker_pubkey {
             return DexFee::NoFee; // no dex fee if the taker is the burn pubkey
         }
-        Self::new_from_taker_coin(taker_coin, trade_amount)
+        Self::new_from_taker_coin(taker_coin, maker_ticker, trade_amount)
     }
 
     /// Calculates DEX fee with a threshold based on min tx amount of the taker coin.
     /// With this fn we may calculate the max dex fee amount, when taker_pubkey is not known yet.
-    pub fn new_from_taker_coin(taker_coin: &dyn MmCoin, trade_amount: &MmNumber) -> DexFee {
+    pub fn new_from_taker_coin(taker_coin: &dyn MmCoin, maker_ticker: &str, trade_amount: &MmNumber) -> DexFee {
         // calc dex fee
-        let rate = Self::dex_fee_rate();
+        let rate = Self::dex_fee_rate(taker_coin.ticker(), maker_ticker);
         let dex_fee = trade_amount * &rate;
         let min_tx_amount = MmNumber::from(taker_coin.min_tx_amount());
 
@@ -4173,35 +4178,23 @@ impl DexFee {
         DexFee::Standard(dex_fee)
     }
 
-    /// Returns DEX fee rate (2% flat for all trades).
-    pub fn dex_fee_rate() -> MmNumber {
-        // 2% DEX fee for all trades
-        BigRational::new(2.into(), 100.into()).into()
+    /// Returns DEX fee rate. GLEEC trades get a 50% discount (1% vs 2% base rate).
+    pub fn dex_fee_rate(base: &str, rel: &str) -> MmNumber {
+        #[cfg(any(feature = "for-tests", test))]
+        let fee_discount_tickers: &[&str] = match std::env::var("MYCOIN_FEE_DISCOUNT") {
+            Ok(_) => &["GLEEC", "MYCOIN"],
+            Err(_) => &["GLEEC"],
+        };
+        #[cfg(not(any(feature = "for-tests", test)))]
+        let fee_discount_tickers: &[&str] = &["GLEEC"];
 
-        // --- TICKER-BASED DISCOUNT LOGIC (disabled) ---
-        // To re-enable discounts for specific tickers (e.g., GLEEC):
-        // 1. Change signature to: pub fn dex_fee_rate(base: &str, rel: &str) -> MmNumber
-        // 2. Update call sites.
-        // 3. Adapt the logic below to apply discount on top of 2% base rate.
-        //
-        // Original discount logic (used ~0.129% base, ~0.116% with KMD discount):
-        //
-        // #[cfg(any(feature = "for-tests", test))]
-        // let fee_discount_tickers: &[&str] = match std::env::var("MYCOIN_FEE_DISCOUNT") {
-        //     Ok(_) => &["KMD", "MYCOIN"],
-        //     Err(_) => &["KMD"],
-        // };
-        //
-        // #[cfg(not(any(feature = "for-tests", test)))]
-        // let fee_discount_tickers: &[&str] = &["KMD"];
-        //
-        // if fee_discount_tickers.contains(&base) || fee_discount_tickers.contains(&rel) {
-        //     // 1/777 - 10% = 9/7770
-        //     BigRational::new(9.into(), 7770.into()).into()
-        // } else {
-        //     // 1/777
-        //     BigRational::new(1.into(), 777.into()).into()
-        // }
+        if fee_discount_tickers.contains(&base) || fee_discount_tickers.contains(&rel) {
+            // 1% fee (50% discount)
+            BigRational::new(1.into(), 100.into()).into()
+        } else {
+            // 2% fee (standard rate)
+            BigRational::new(2.into(), 100.into()).into()
+        }
     }
 
     /// Drops the dex fee in KMD by 25%. This cut will be burned during the taker fee payment.
@@ -6492,8 +6485,9 @@ mod tests {
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.0001").into()));
+        let rel = "ETH";
         let amount = 1.into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
         let expected_fee = DexFee::WithBurn {
             fee_amount: amount.clone() * "0.02".into() * "0.75".into(),
             burn_amount: amount * "0.02".into() * "0.25".into(),
@@ -6508,8 +6502,9 @@ mod tests {
         let kmd = TestCoin::new(base);
         TestCoin::should_burn_directly.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.0001").into()));
+        let rel = "ETH";
         let amount = 1.into();
-        let actual_fee = DexFee::new_from_taker_coin(&kmd, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&kmd, rel, &amount);
         let expected_fee = amount.clone() * "0.02".into() * MmNumber::from("0.75");
         let expected_burn_amount = amount * "0.02".into() * MmNumber::from("0.25");
         assert_eq!(
@@ -6530,8 +6525,9 @@ mod tests {
         // With 2% rate: need amount where fee portion (75%) < min_tx_amount
         // fee = amount * 0.02 * 0.75 < 0.00001 => amount < 0.00001 / 0.015 ≈ 0.000667
         // Using amount = 0.0006: total = 0.000012, fee (75%) = 0.000009 < min, gets clamped to min
+        let rel = "BTC";
         let amount = "0.0006".into();
-        let actual_fee = DexFee::new_from_taker_coin(&kmd, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&kmd, rel, &amount);
         // fee gets clamped to min_tx_amount, burn = total - fee = 0.000012 - 0.00001 = 0.000002
         assert_eq!(
             DexFee::WithBurn {
@@ -6548,8 +6544,9 @@ mod tests {
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
+        let rel = "KMD";
         let amount = 1.into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
         let expected_fee = DexFee::WithBurn {
             fee_amount: amount.clone() * "0.02".into() * "0.75".into(),
             burn_amount: amount * "0.02".into() * "0.25".into(),
@@ -6563,9 +6560,10 @@ mod tests {
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
+        let rel = "KMD";
         // 2% of 0.0001 = 0.000002 < min (0.00001)
         let amount: MmNumber = "0.0001".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
         assert_eq!(DexFee::Standard("0.00001".into()), actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
@@ -6575,9 +6573,10 @@ mod tests {
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
+        let rel = "KMD";
         // 2% of 0.001 = 0.00002, fee = 0.000015 > min, burn = 0.000005 < min
         let amount: MmNumber = "0.001".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
         assert_eq!(DexFee::Standard(amount * "0.02".into()), actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
@@ -6586,8 +6585,9 @@ mod tests {
         let erc20 = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(false));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
+        let rel = "BTC";
         let amount: MmNumber = "1".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&erc20, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&erc20, rel, &amount);
         assert_eq!(DexFee::Standard(amount * "0.02".into()), actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
@@ -6596,8 +6596,9 @@ mod tests {
         let nucleus = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.000001").into()));
+        let rel = "IRIS";
         let amount: MmNumber = "0.008".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&nucleus, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&nucleus, rel, &amount);
         let std_fee = amount * "0.02".into();
         let fee_amount = std_fee.clone() * "0.75".into();
         let burn_amount = std_fee - fee_amount.clone();
@@ -6618,7 +6619,8 @@ mod tests {
         TestCoin::dex_pubkey.mock_safe(|_| MockResult::Return(DEX_BURN_ADDR_RAW_PUBKEY.as_slice()));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
         let amount: MmNumber = "0.03".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_with_taker_pubkey(&btc, &amount, DEX_BURN_ADDR_RAW_PUBKEY.as_slice());
+        let rel = "KMD";
+        let actual_fee = DexFee::new_with_taker_pubkey(&btc, rel, &amount, DEX_BURN_ADDR_RAW_PUBKEY.as_slice());
         assert_eq!(DexFee::NoFee, actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
         TestCoin::dex_pubkey.clear_mock();
@@ -6631,24 +6633,43 @@ mod tests {
         let base = "BTC";
         let btc = TestCoin::new(base);
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.0001").into()));
+        let rel = "ETH";
         let amount: MmNumber = 1.into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
         assert_eq!(DexFee::Standard("0.02".into()), actual_fee);
 
         // Large trade amount
         let base = "BTC";
         let btc = TestCoin::new(base);
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
+        let rel = "ETH";
         let amount: MmNumber = "1000".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
         assert_eq!(DexFee::Standard("20".into()), actual_fee);
 
         // Fractional amount with precise 2% calculation
         let base = "BTC";
         let btc = TestCoin::new(base);
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
+        let rel = "ETH";
         let amount: MmNumber = "0.5".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
+        assert_eq!(DexFee::Standard("0.01".into()), actual_fee);
+
+        // GLEEC discount test: 1% fee instead of 2%
+        let gleec = TestCoin::new("GLEEC");
+        TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
+        let rel = "BTC";
+        let amount: MmNumber = 1.into();
+        let actual_fee = DexFee::new_from_taker_coin(&gleec, rel, &amount);
+        assert_eq!(DexFee::Standard("0.01".into()), actual_fee);
+
+        // GLEEC as maker_ticker also gets discount
+        let btc = TestCoin::new("BTC");
+        TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
+        let rel = "GLEEC";
+        let amount: MmNumber = 1.into();
+        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
         assert_eq!(DexFee::Standard("0.01".into()), actual_fee);
 
         TestCoin::min_tx_amount.clear_mock();

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -6487,6 +6487,7 @@ mod tests {
 
     #[test]
     fn test_dex_fee_amount() {
+        // BTC WithBurn, burn enabled by mocking
         let base = "BTC";
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
@@ -6494,21 +6495,23 @@ mod tests {
         let amount = 1.into();
         let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
         let expected_fee = DexFee::WithBurn {
-            fee_amount: amount.clone() / 777u64.into() * "0.75".into(),
-            burn_amount: amount / 777u64.into() * "0.25".into(),
+            fee_amount: amount.clone() * "0.02".into() * "0.75".into(),
+            burn_amount: amount * "0.02".into() * "0.25".into(),
             burn_destination: DexFeeBurnDestination::PreBurnAccount,
         };
         assert_eq!(expected_fee, actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
+        // KMD WithBurn - same 2% rate as other coins (no KMD discount anymore)
+        // KMD uses should_burn_directly() -> KmdOpReturn
         let base = "KMD";
         let kmd = TestCoin::new(base);
-        TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
+        TestCoin::should_burn_directly.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.0001").into()));
         let amount = 1.into();
         let actual_fee = DexFee::new_from_taker_coin(&kmd, &amount);
-        let expected_fee = amount.clone() * (9, 7770).into() * MmNumber::from("0.75");
-        let expected_burn_amount = amount * (9, 7770).into() * MmNumber::from("0.25");
+        let expected_fee = amount.clone() * "0.02".into() * MmNumber::from("0.75");
+        let expected_burn_amount = amount * "0.02".into() * MmNumber::from("0.25");
         assert_eq!(
             DexFee::WithBurn {
                 fee_amount: expected_fee,
@@ -6517,25 +6520,30 @@ mod tests {
             },
             actual_fee
         );
-        TestCoin::should_burn_dex_fee.clear_mock();
+        TestCoin::should_burn_directly.clear_mock();
 
         // check the case when KMD taker fee is close to dust (0.75 of fee < dust)
         let base = "KMD";
         let kmd = TestCoin::new(base);
-        TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
+        TestCoin::should_burn_directly.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
-        let amount = (1001 * 777, 90000000).into();
+        // With 2% rate: need amount where fee portion (75%) < min_tx_amount
+        // fee = amount * 0.02 * 0.75 < 0.00001 => amount < 0.00001 / 0.015 ≈ 0.000667
+        // Using amount = 0.0006: total = 0.000012, fee (75%) = 0.000009 < min, gets clamped to min
+        let amount = "0.0006".into();
         let actual_fee = DexFee::new_from_taker_coin(&kmd, &amount);
+        // fee gets clamped to min_tx_amount, burn = total - fee = 0.000012 - 0.00001 = 0.000002
         assert_eq!(
             DexFee::WithBurn {
                 fee_amount: "0.00001".into(), // equals to min_tx_amount
-                burn_amount: "0.00000001".into(),
+                burn_amount: "0.000002".into(),
                 burn_destination: DexFeeBurnDestination::KmdOpReturn,
             },
             actual_fee
         );
-        TestCoin::should_burn_dex_fee.clear_mock();
+        TestCoin::should_burn_directly.clear_mock();
 
+        // BTC WithBurn with smaller min_tx_amount
         let base = "BTC";
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
@@ -6543,51 +6551,54 @@ mod tests {
         let amount = 1.into();
         let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
         let expected_fee = DexFee::WithBurn {
-            fee_amount: amount.clone() * (9, 7770).into() * "0.75".into(),
-            burn_amount: amount * (9, 7770).into() * "0.25".into(),
+            fee_amount: amount.clone() * "0.02".into() * "0.75".into(),
+            burn_amount: amount * "0.02".into() * "0.25".into(),
             burn_destination: DexFeeBurnDestination::PreBurnAccount,
         };
         assert_eq!(expected_fee, actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
-        // whole dex fee (0.001 * 9 / 7770) less than min tx amount (0.00001)
+        // whole dex fee (amount * 0.02) less than min tx amount (0.00001)
         let base = "BTC";
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
-        let amount: MmNumber = "0.001".parse::<BigDecimal>().unwrap().into();
+        // 2% of 0.0001 = 0.000002 < min (0.00001)
+        let amount: MmNumber = "0.0001".parse::<BigDecimal>().unwrap().into();
         let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
         assert_eq!(DexFee::Standard("0.00001".into()), actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
-        // 75% of dex fee (0.03 * 9/7770 * 0.75) is over the min tx amount (0.00001)
+        // 75% of dex fee is over the min tx amount (0.00001)
         // but non-kmd burn amount is less than the min tx amount
         let base = "BTC";
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
-        let amount: MmNumber = "0.03".parse::<BigDecimal>().unwrap().into();
+        // 2% of 0.001 = 0.00002, fee = 0.000015 > min, burn = 0.000005 < min
+        let amount: MmNumber = "0.001".parse::<BigDecimal>().unwrap().into();
         let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
-        assert_eq!(DexFee::Standard(amount * (9, 7770).into()), actual_fee);
+        assert_eq!(DexFee::Standard(amount * "0.02".into()), actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
         // burning from eth currently not supported
         let base = "USDT-ERC20";
-        let btc = TestCoin::new(base);
+        let erc20 = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(false));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
         let amount: MmNumber = "1".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
-        assert_eq!(DexFee::Standard(amount / "777".into()), actual_fee);
+        let actual_fee = DexFee::new_from_taker_coin(&erc20, &amount);
+        assert_eq!(DexFee::Standard(amount * "0.02".into()), actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
+        // NUCLEUS WithBurn
         let base = "NUCLEUS";
-        let btc = TestCoin::new(base);
+        let nucleus = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.000001").into()));
         let amount: MmNumber = "0.008".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
-        let std_fee = amount / "777".into();
+        let actual_fee = DexFee::new_from_taker_coin(&nucleus, &amount);
+        let std_fee = amount * "0.02".into();
         let fee_amount = std_fee.clone() * "0.75".into();
         let burn_amount = std_fee - fee_amount.clone();
         assert_eq!(
@@ -6611,6 +6622,36 @@ mod tests {
         assert_eq!(DexFee::NoFee, actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
         TestCoin::dex_pubkey.clear_mock();
+
+        // ============================================================================
+        // Production behavior (burn disabled)
+        // ============================================================================
+
+        // Standard 2% fee for BTC (burn disabled in production)
+        let base = "BTC";
+        let btc = TestCoin::new(base);
+        TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.0001").into()));
+        let amount: MmNumber = 1.into();
+        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
+        assert_eq!(DexFee::Standard("0.02".into()), actual_fee);
+
+        // Large trade amount
+        let base = "BTC";
+        let btc = TestCoin::new(base);
+        TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
+        let amount: MmNumber = "1000".parse::<BigDecimal>().unwrap().into();
+        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
+        assert_eq!(DexFee::Standard("20".into()), actual_fee);
+
+        // Fractional amount with precise 2% calculation
+        let base = "BTC";
+        let btc = TestCoin::new(base);
+        TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
+        let amount: MmNumber = "0.5".parse::<BigDecimal>().unwrap().into();
+        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
+        assert_eq!(DexFee::Standard("0.01".into()), actual_fee);
+
+        TestCoin::min_tx_amount.clear_mock();
     }
 }
 

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -4160,7 +4160,7 @@ impl DexFee {
     /// With this fn we may calculate the max dex fee amount, when taker_pubkey is not known yet.
     pub fn new_from_taker_coin(taker_coin: &dyn MmCoin, maker_ticker: &str, trade_amount: &MmNumber) -> DexFee {
         // calc dex fee
-        let rate = Self::dex_fee_rate(taker_coin.ticker(), maker_ticker);
+        let rate = Self::dex_fee_rate();
         let dex_fee = trade_amount * &rate;
         let min_tx_amount = MmNumber::from(taker_coin.min_tx_amount());
 
@@ -4178,23 +4178,35 @@ impl DexFee {
         DexFee::Standard(dex_fee)
     }
 
-    /// Returns dex fee discount if KMD is traded
-    pub fn dex_fee_rate(base: &str, rel: &str) -> MmNumber {
-        #[cfg(any(feature = "for-tests", test))]
-        let fee_discount_tickers: &[&str] = match std::env::var("MYCOIN_FEE_DISCOUNT") {
-            Ok(_) => &["KMD", "MYCOIN"],
-            Err(_) => &["KMD"],
-        };
+    /// Returns DEX fee rate (2% flat for all trades).
+    pub fn dex_fee_rate() -> MmNumber {
+        // 2% DEX fee for all trades
+        BigRational::new(2.into(), 100.into()).into()
 
-        #[cfg(not(any(feature = "for-tests", test)))]
-        let fee_discount_tickers: &[&str] = &["KMD"];
-
-        if fee_discount_tickers.contains(&base) || fee_discount_tickers.contains(&rel) {
-            // 1/777 - 10%
-            BigRational::new(9.into(), 7770.into()).into()
-        } else {
-            BigRational::new(1.into(), 777.into()).into()
-        }
+        // --- TICKER-BASED DISCOUNT LOGIC (disabled) ---
+        // To re-enable discounts for specific tickers (e.g., GLEEC):
+        // 1. Change signature to: pub fn dex_fee_rate(base: &str, rel: &str) -> MmNumber
+        // 2. Update call sites.
+        // 3. Adapt the logic below to apply discount on top of 2% base rate.
+        //
+        // Original discount logic (used ~0.129% base, ~0.116% with KMD discount):
+        //
+        // #[cfg(any(feature = "for-tests", test))]
+        // let fee_discount_tickers: &[&str] = match std::env::var("MYCOIN_FEE_DISCOUNT") {
+        //     Ok(_) => &["KMD", "MYCOIN"],
+        //     Err(_) => &["KMD"],
+        // };
+        //
+        // #[cfg(not(any(feature = "for-tests", test)))]
+        // let fee_discount_tickers: &[&str] = &["KMD"];
+        //
+        // if fee_discount_tickers.contains(&base) || fee_discount_tickers.contains(&rel) {
+        //     // 1/777 - 10% = 9/7770
+        //     BigRational::new(9.into(), 7770.into()).into()
+        // } else {
+        //     // 1/777
+        //     BigRational::new(1.into(), 777.into()).into()
+        // }
     }
 
     /// Drops the dex fee in KMD by 25%. This cut will be burned during the taker fee payment.

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -4144,21 +4144,16 @@ impl DexFee {
     }
 
     /// Calculates DEX fee with known taker_pubkey (for some takers dexfee may be zero).
-    pub fn new_with_taker_pubkey(
-        taker_coin: &dyn MmCoin,
-        maker_ticker: &str,
-        trade_amount: &MmNumber,
-        taker_pubkey: &[u8],
-    ) -> DexFee {
+    pub fn new_with_taker_pubkey(taker_coin: &dyn MmCoin, trade_amount: &MmNumber, taker_pubkey: &[u8]) -> DexFee {
         if !taker_coin.is_privacy() && taker_coin.burn_pubkey() == taker_pubkey {
             return DexFee::NoFee; // no dex fee if the taker is the burn pubkey
         }
-        Self::new_from_taker_coin(taker_coin, maker_ticker, trade_amount)
+        Self::new_from_taker_coin(taker_coin, trade_amount)
     }
 
     /// Calculates DEX fee with a threshold based on min tx amount of the taker coin.
     /// With this fn we may calculate the max dex fee amount, when taker_pubkey is not known yet.
-    pub fn new_from_taker_coin(taker_coin: &dyn MmCoin, maker_ticker: &str, trade_amount: &MmNumber) -> DexFee {
+    pub fn new_from_taker_coin(taker_coin: &dyn MmCoin, trade_amount: &MmNumber) -> DexFee {
         // calc dex fee
         let rate = Self::dex_fee_rate();
         let dex_fee = trade_amount * &rate;
@@ -6496,9 +6491,8 @@ mod tests {
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.0001").into()));
-        let rel = "ETH";
         let amount = 1.into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
         let expected_fee = DexFee::WithBurn {
             fee_amount: amount.clone() / 777u64.into() * "0.75".into(),
             burn_amount: amount / 777u64.into() * "0.25".into(),
@@ -6511,9 +6505,8 @@ mod tests {
         let kmd = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.0001").into()));
-        let rel = "ETH";
         let amount = 1.into();
-        let actual_fee = DexFee::new_from_taker_coin(&kmd, rel, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&kmd, &amount);
         let expected_fee = amount.clone() * (9, 7770).into() * MmNumber::from("0.75");
         let expected_burn_amount = amount * (9, 7770).into() * MmNumber::from("0.25");
         assert_eq!(
@@ -6531,9 +6524,8 @@ mod tests {
         let kmd = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
-        let rel = "BTC";
         let amount = (1001 * 777, 90000000).into();
-        let actual_fee = DexFee::new_from_taker_coin(&kmd, rel, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&kmd, &amount);
         assert_eq!(
             DexFee::WithBurn {
                 fee_amount: "0.00001".into(), // equals to min_tx_amount
@@ -6548,9 +6540,8 @@ mod tests {
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
-        let rel = "KMD";
         let amount = 1.into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
         let expected_fee = DexFee::WithBurn {
             fee_amount: amount.clone() * (9, 7770).into() * "0.75".into(),
             burn_amount: amount * (9, 7770).into() * "0.25".into(),
@@ -6564,9 +6555,8 @@ mod tests {
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
-        let rel = "KMD";
         let amount: MmNumber = "0.001".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
         assert_eq!(DexFee::Standard("0.00001".into()), actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
@@ -6576,9 +6566,8 @@ mod tests {
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
-        let rel = "KMD";
         let amount: MmNumber = "0.03".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
         assert_eq!(DexFee::Standard(amount * (9, 7770).into()), actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
@@ -6587,9 +6576,8 @@ mod tests {
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(false));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
-        let rel = "BTC";
         let amount: MmNumber = "1".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
         assert_eq!(DexFee::Standard(amount / "777".into()), actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
 
@@ -6597,9 +6585,8 @@ mod tests {
         let btc = TestCoin::new(base);
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.000001").into()));
-        let rel = "IRIS";
         let amount: MmNumber = "0.008".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_from_taker_coin(&btc, rel, &amount);
+        let actual_fee = DexFee::new_from_taker_coin(&btc, &amount);
         let std_fee = amount / "777".into();
         let fee_amount = std_fee.clone() * "0.75".into();
         let burn_amount = std_fee - fee_amount.clone();
@@ -6619,9 +6606,8 @@ mod tests {
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         TestCoin::dex_pubkey.mock_safe(|_| MockResult::Return(DEX_BURN_ADDR_RAW_PUBKEY.as_slice()));
         TestCoin::min_tx_amount.mock_safe(|_| MockResult::Return(MmNumber::from("0.00001").into()));
-        let rel = "KMD";
         let amount: MmNumber = "0.03".parse::<BigDecimal>().unwrap().into();
-        let actual_fee = DexFee::new_with_taker_pubkey(&btc, rel, &amount, DEX_BURN_ADDR_RAW_PUBKEY.as_slice());
+        let actual_fee = DexFee::new_with_taker_pubkey(&btc, &amount, DEX_BURN_ADDR_RAW_PUBKEY.as_slice());
         assert_eq!(DexFee::NoFee, actual_fee);
         TestCoin::should_burn_dex_fee.clear_mock();
         TestCoin::dex_pubkey.clear_mock();

--- a/mm2src/coins/qrc20/qrc20_tests.rs
+++ b/mm2src/coins/qrc20/qrc20_tests.rs
@@ -347,7 +347,7 @@ fn test_validate_fee() {
     // wrong dex address
     <Qrc20Coin as SwapOps>::dex_pubkey.mock_safe(|_| {
         MockResult::Return(Box::leak(Box::new(
-            hex::decode("03bc2c7ba671bae4a6fc835244c9762b41647b9827d4780a89a949b984a8ddcc05").unwrap(),
+            hex::decode("0348685437335ec43ba6211caf848576ca3d34abbe9e089f861471b4ed9ee9bbd0").unwrap(),
         )))
     });
     let err = block_on(coin.validate_fee(ValidateFeeArgs {
@@ -1141,7 +1141,7 @@ fn test_send_contract_calls_recoverable_tx() {
 
     let tx = TransactionEnum::UtxoTx("010000000160fd74b5714172f285db2b36f0b391cd6883e7291441631c8b18f165b0a4635d020000006a47304402205d409e141111adbc4f185ae856997730de935ac30a0d2b1ccb5a6c4903db8171022024fc59bbcfdbba283556d7eeee4832167301dc8e8ad9739b7865f67b9676b226012103693bff1b39e8b5a306810023c29b95397eb395530b106b1820ea235fd81d9ce9ffffffff020000000000000000625403a08601012844a9059cbb000000000000000000000000ca1e04745e8ca0c60d8c5881531d51bec470743f00000000000000000000000000000000000000000000000000000000000f424014d362e096e873eb7907e205fadc6175c6fec7bc44c200ada205000000001976a9149e032d4b0090a11dc40fe6c47601499a35d55fbb88acfe967d5f".into());
 
-    let fee_addr = hex::decode("03bc2c7ba671bae4a6fc835244c9762b41647b9827d4780a89a949b984a8ddcc05").unwrap();
+    let fee_addr = hex::decode("0348685437335ec43ba6211caf848576ca3d34abbe9e089f861471b4ed9ee9bbd0").unwrap();
     let to_address = coin.contract_address_from_raw_pubkey(&fee_addr).unwrap();
     let amount = BigDecimal::try_from(0.2).unwrap();
     let amount = u256_from_big_decimal(&amount, coin.utxo.decimals).unwrap();

--- a/mm2src/coins/qrc20/qrc20_tests.rs
+++ b/mm2src/coins/qrc20/qrc20_tests.rs
@@ -347,7 +347,7 @@ fn test_validate_fee() {
     // wrong dex address
     <Qrc20Coin as SwapOps>::dex_pubkey.mock_safe(|_| {
         MockResult::Return(Box::leak(Box::new(
-            hex::decode("0348685437335ec43ba6211caf848576ca3d34abbe9e089f861471b4ed9ee9bbd0").unwrap(),
+            hex::decode("03bc2c7ba671bae4a6fc835244c9762b41647b9827d4780a89a949b984a8ddcc05").unwrap(),
         )))
     });
     let err = block_on(coin.validate_fee(ValidateFeeArgs {
@@ -1141,7 +1141,7 @@ fn test_send_contract_calls_recoverable_tx() {
 
     let tx = TransactionEnum::UtxoTx("010000000160fd74b5714172f285db2b36f0b391cd6883e7291441631c8b18f165b0a4635d020000006a47304402205d409e141111adbc4f185ae856997730de935ac30a0d2b1ccb5a6c4903db8171022024fc59bbcfdbba283556d7eeee4832167301dc8e8ad9739b7865f67b9676b226012103693bff1b39e8b5a306810023c29b95397eb395530b106b1820ea235fd81d9ce9ffffffff020000000000000000625403a08601012844a9059cbb000000000000000000000000ca1e04745e8ca0c60d8c5881531d51bec470743f00000000000000000000000000000000000000000000000000000000000f424014d362e096e873eb7907e205fadc6175c6fec7bc44c200ada205000000001976a9149e032d4b0090a11dc40fe6c47601499a35d55fbb88acfe967d5f".into());
 
-    let fee_addr = hex::decode("0348685437335ec43ba6211caf848576ca3d34abbe9e089f861471b4ed9ee9bbd0").unwrap();
+    let fee_addr = hex::decode("03bc2c7ba671bae4a6fc835244c9762b41647b9827d4780a89a949b984a8ddcc05").unwrap();
     let to_address = coin.contract_address_from_raw_pubkey(&fee_addr).unwrap();
     let amount = BigDecimal::try_from(0.2).unwrap();
     let amount = u256_from_big_decimal(&amount, coin.utxo.decimals).unwrap();

--- a/mm2src/coins/qrc20/qrc20_tests.rs
+++ b/mm2src/coins/qrc20/qrc20_tests.rs
@@ -7,6 +7,7 @@ use keys::Address;
 use mm2_core::mm_ctx::MmCtxBuilder;
 use mm2_number::bigdecimal::Zero;
 use mm2_test_helpers::electrums::tqtum_electrums;
+use mm2_test_helpers::for_tests::DEX_FEE_ADDR_RAW_PUBKEY_LEGACY;
 use rpc::v1::types::ToTxHash;
 use std::convert::TryFrom;
 use std::mem::discriminant;
@@ -321,6 +322,7 @@ fn test_wait_for_confirmations_excepted() {
 #[test]
 fn test_validate_fee() {
     // priv_key of qXxsj5RtciAby9T7m98AgAATL4zTi4UwDG
+    // TODO: Update test fixtures with transactions to new DEX fee address once swaps exist
 
     use common::DEX_FEE_ADDR_RAW_PUBKEY;
     let priv_key = [
@@ -330,10 +332,14 @@ fn test_validate_fee() {
     let (_ctx, coin) = qrc20_coin_for_test(priv_key, None);
 
     // QRC20 transfer tx "f97d3a43dbea0993f1b7a6a299377d4ee164c84935a1eb7d835f70c9429e6a1d"
+    // This tx was sent to the OLD dex fee address, so we mock dex_pubkey to return the legacy address
     let tx = TransactionEnum::UtxoTx("010000000160fd74b5714172f285db2b36f0b391cd6883e7291441631c8b18f165b0a4635d020000006a47304402205d409e141111adbc4f185ae856997730de935ac30a0d2b1ccb5a6c4903db8171022024fc59bbcfdbba283556d7eeee4832167301dc8e8ad9739b7865f67b9676b226012103693bff1b39e8b5a306810023c29b95397eb395530b106b1820ea235fd81d9ce9ffffffff020000000000000000625403a08601012844a9059cbb000000000000000000000000ca1e04745e8ca0c60d8c5881531d51bec470743f00000000000000000000000000000000000000000000000000000000000f424014d362e096e873eb7907e205fadc6175c6fec7bc44c200ada205000000001976a9149e032d4b0090a11dc40fe6c47601499a35d55fbb88acfe967d5f".into());
     let sender_pub = hex::decode("03693bff1b39e8b5a306810023c29b95397eb395530b106b1820ea235fd81d9ce9").unwrap();
 
     let amount = BigDecimal::from_str("0.01").unwrap();
+
+    // Mock to use legacy fee address for this historical tx fixture
+    <Qrc20Coin as SwapOps>::dex_pubkey.mock_safe(|_| MockResult::Return(DEX_FEE_ADDR_RAW_PUBKEY_LEGACY.as_slice()));
 
     let result = block_on(coin.validate_fee(ValidateFeeArgs {
         fee_tx: &tx,
@@ -344,12 +350,12 @@ fn test_validate_fee() {
     }));
     assert!(result.is_ok());
 
-    // wrong dex address
-    <Qrc20Coin as SwapOps>::dex_pubkey.mock_safe(|_| {
-        MockResult::Return(Box::leak(Box::new(
-            hex::decode("03bc2c7ba671bae4a6fc835244c9762b41647b9827d4780a89a949b984a8ddcc05").unwrap(),
-        )))
-    });
+    // wrong dex address - use a completely different pubkey
+    let wrong_pubkey: &'static [u8] = &[
+        3, 188, 44, 123, 166, 113, 186, 228, 166, 252, 131, 82, 68, 201, 118, 43, 65, 100, 123, 152, 39, 212, 120, 10,
+        137, 169, 73, 185, 132, 168, 221, 204, 5,
+    ];
+    <Qrc20Coin as SwapOps>::dex_pubkey.mock_safe(move |_| MockResult::Return(wrong_pubkey));
     let err = block_on(coin.validate_fee(ValidateFeeArgs {
         fee_tx: &tx,
         expected_sender: &sender_pub,
@@ -364,7 +370,9 @@ fn test_validate_fee() {
         ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("QRC20 Fee tx was sent to wrong address")),
         _ => panic!("Expected `WrongPaymentTx` wrong receiver address, found {:?}", err),
     }
-    <Qrc20Coin as SwapOps>::dex_pubkey.clear_mock();
+
+    // Restore legacy mock for remaining tests with the historical tx fixture
+    <Qrc20Coin as SwapOps>::dex_pubkey.mock_safe(|_| MockResult::Return(DEX_FEE_ADDR_RAW_PUBKEY_LEGACY.as_slice()));
 
     let err = block_on(coin.validate_fee(ValidateFeeArgs {
         fee_tx: &tx,
@@ -413,6 +421,8 @@ fn test_validate_fee() {
         },
         _ => panic!("Expected `WrongPaymentTx` invalid fee value, found {:?}", err),
     }
+
+    <Qrc20Coin as SwapOps>::dex_pubkey.clear_mock();
 
     // QTUM tx "8a51f0ffd45f34974de50f07c5bf2f0949da4e88433f8f75191953a442cf9310"
     let tx = TransactionEnum::UtxoTx("020000000113640281c9332caeddd02a8dd0d784809e1ad87bda3c972d89d5ae41f5494b85010000006a47304402207c5c904a93310b8672f4ecdbab356b65dd869a426e92f1064a567be7ccfc61ff02203e4173b9467127f7de4682513a21efb5980e66dbed4da91dff46534b8e77c7ef012102baefe72b3591de2070c0da3853226b00f082d72daa417688b61cb18c1d543d1afeffffff020001b2c4000000001976a9149e032d4b0090a11dc40fe6c47601499a35d55fbb88acbc4dd20c2f0000001976a9144208fa7be80dcf972f767194ad365950495064a488ac76e70800".into());

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -4394,6 +4394,7 @@ pub mod tests {
     use common::{block_on, wait_until_ms, DEX_FEE_ADDR_RAW_PUBKEY};
     use cosmrs::proto::cosmos::tx::v1beta1::{GetTxRequest, GetTxResponse};
     use crypto::privkey::key_pair_from_seed;
+    use mm2_test_helpers::for_tests::DEX_FEE_ADDR_RAW_PUBKEY_LEGACY;
     use mocktopus::mocking::{MockResult, Mockable};
     use std::{mem::discriminant, num::NonZeroUsize};
 
@@ -4735,8 +4736,14 @@ pub mod tests {
         assert_eq!(hex::encode_upper(hash.0), expected_spend_hash);
     }
 
+    // TODO: Update test fixtures with transactions to new DEX fee address once swaps exist.
+    // This test uses historical tx fixtures sent to the OLD dex fee address.
+    // We mock dex_pubkey() to return the legacy pubkey for address derivation.
     #[test]
     fn validate_taker_fee_test() {
+        // Mock dex_pubkey to return legacy pubkey for historical tx fixtures
+        <TendermintCoin as SwapOps>::dex_pubkey
+            .mock_safe(|_| MockResult::Return(DEX_FEE_ADDR_RAW_PUBKEY_LEGACY.as_slice()));
         let nodes = vec![RpcNode::for_test(IRIS_TESTNET_RPC_URL)];
 
         let protocol_conf = get_iris_protocol();
@@ -4926,11 +4933,18 @@ pub mod tests {
         )
         .unwrap();
         TendermintCoin::request_tx.clear_mock();
+        <TendermintCoin as SwapOps>::dex_pubkey.clear_mock();
     }
 
+    // This test uses historical tx fixtures sent to the OLD dex fee/burn addresses.
+    // Mock dex_pubkey to return legacy pubkey for historical tx fixture validation.
     #[test]
     fn validate_taker_fee_with_burn_test() {
         const NUCLEUS_TEST_SEED: &str = "nucleus test seed";
+
+        // Mock dex_pubkey to return legacy pubkey for historical tx fixtures
+        <TendermintCoin as SwapOps>::dex_pubkey
+            .mock_safe(|_| MockResult::Return(DEX_FEE_ADDR_RAW_PUBKEY_LEGACY.as_slice()));
 
         let ctx = mm2_core::mm_ctx::MmCtxBuilder::default().into_mm_arc();
         let conf = TendermintConf {
@@ -4989,6 +5003,10 @@ pub mod tests {
             .compat(),
         )
         .unwrap();
+
+        // Clean up mocks
+        TendermintCoin::request_tx.clear_mock();
+        <TendermintCoin as SwapOps>::dex_pubkey.clear_mock();
     }
 
     #[test]

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -4394,7 +4394,7 @@ pub mod tests {
     use common::{block_on, wait_until_ms, DEX_FEE_ADDR_RAW_PUBKEY};
     use cosmrs::proto::cosmos::tx::v1beta1::{GetTxRequest, GetTxResponse};
     use crypto::privkey::key_pair_from_seed;
-    use mm2_test_helpers::for_tests::DEX_FEE_ADDR_RAW_PUBKEY_LEGACY;
+    use mm2_test_helpers::for_tests::{DEX_BURN_ADDR_RAW_PUBKEY_LEGACY, DEX_FEE_ADDR_RAW_PUBKEY_LEGACY};
     use mocktopus::mocking::{MockResult, Mockable};
     use std::{mem::discriminant, num::NonZeroUsize};
 
@@ -4937,14 +4937,16 @@ pub mod tests {
     }
 
     // This test uses historical tx fixtures sent to the OLD dex fee/burn addresses.
-    // Mock dex_pubkey to return legacy pubkey for historical tx fixture validation.
+    // Mock dex_pubkey and burn_pubkey to return legacy pubkeys for historical tx fixture validation.
     #[test]
     fn validate_taker_fee_with_burn_test() {
         const NUCLEUS_TEST_SEED: &str = "nucleus test seed";
 
-        // Mock dex_pubkey to return legacy pubkey for historical tx fixtures
+        // Mock dex_pubkey and burn_pubkey to return legacy pubkeys for historical tx fixtures
         <TendermintCoin as SwapOps>::dex_pubkey
             .mock_safe(|_| MockResult::Return(DEX_FEE_ADDR_RAW_PUBKEY_LEGACY.as_slice()));
+        <TendermintCoin as SwapOps>::burn_pubkey
+            .mock_safe(|_| MockResult::Return(DEX_BURN_ADDR_RAW_PUBKEY_LEGACY.as_slice()));
 
         let ctx = mm2_core::mm_ctx::MmCtxBuilder::default().into_mm_arc();
         let conf = TendermintConf {
@@ -5007,6 +5009,7 @@ pub mod tests {
         // Clean up mocks
         TendermintCoin::request_tx.clear_mock();
         <TendermintCoin as SwapOps>::dex_pubkey.clear_mock();
+        <TendermintCoin as SwapOps>::burn_pubkey.clear_mock();
     }
 
     #[test]

--- a/mm2src/coins/tendermint/tendermint_coin.rs
+++ b/mm2src/coins/tendermint/tendermint_coin.rs
@@ -1899,7 +1899,7 @@ impl TendermintCoin {
                     .await
             );
 
-            let timeout = expires_at.checked_sub(now_sec()).unwrap_or_default();
+            let timeout = expires_at.saturating_sub(now_sec());
             let (_tx_id, tx_raw) = try_tx_s!(
                 coin.common_send_raw_tx_bytes(
                     tx_payload.clone(),
@@ -4053,10 +4053,7 @@ impl SwapOps for TendermintCoin {
         let htlc_id = self.calculate_htlc_id(htlc.sender(), htlc.to(), &amount, maker_spends_payment_args.secret_hash);
 
         let claim_htlc_tx = try_tx_s!(self.gen_claim_htlc_tx(htlc_id, maker_spends_payment_args.secret));
-        let timeout = maker_spends_payment_args
-            .time_lock
-            .checked_sub(now_sec())
-            .unwrap_or_default();
+        let timeout = maker_spends_payment_args.time_lock.saturating_sub(now_sec());
         let coin = self.clone();
 
         let current_block = try_tx_s!(self.current_block().compat().await);
@@ -4108,10 +4105,7 @@ impl SwapOps for TendermintCoin {
 
         let htlc_id = self.calculate_htlc_id(htlc.sender(), htlc.to(), &amount, taker_spends_payment_args.secret_hash);
 
-        let timeout = taker_spends_payment_args
-            .time_lock
-            .checked_sub(now_sec())
-            .unwrap_or_default();
+        let timeout = taker_spends_payment_args.time_lock.saturating_sub(now_sec());
         let claim_htlc_tx = try_tx_s!(self.gen_claim_htlc_tx(htlc_id, taker_spends_payment_args.secret));
         let coin = self.clone();
 

--- a/mm2src/coins/test_coin.rs
+++ b/mm2src/coins/test_coin.rs
@@ -155,7 +155,9 @@ impl MarketCoinOps for TestCoin {
     }
 
     fn should_burn_directly(&self) -> bool {
-        &self.ticker == "KMD"
+        // &self.ticker == "KMD"
+        // Burn disabled - all fees go to DEX fee address
+        false
     }
 
     fn should_burn_dex_fee(&self) -> bool {

--- a/mm2src/coins/utxo/rpc_clients.rs
+++ b/mm2src/coins/utxo/rpc_clients.rs
@@ -822,6 +822,7 @@ impl JsonRpcBatchClient for NativeClientImpl {}
 #[async_trait]
 #[cfg_attr(test, mockable)]
 impl UtxoRpcClientOps for NativeClient {
+    #[allow(clippy::result_large_err)]
     fn list_unspent(&self, address: &Address, decimals: u8) -> UtxoRpcFut<Vec<UnspentInfo>> {
         let fut = self
             .list_unspent_impl(0, i32::MAX, vec![address.to_string()])
@@ -835,6 +836,7 @@ impl UtxoRpcClientOps for NativeClient {
         Box::new(fut)
     }
 
+    #[allow(clippy::result_large_err)]
     fn list_unspent_group(&self, addresses: Vec<Address>, decimals: u8) -> UtxoRpcFut<UnspentMap> {
         let mut addresses_str = Vec::with_capacity(addresses.len());
         let mut addresses_map = HashMap::with_capacity(addresses.len());

--- a/mm2src/coins/utxo/rpc_clients/electrum_rpc/client.rs
+++ b/mm2src/coins/utxo/rpc_clients/electrum_rpc/client.rs
@@ -538,6 +538,7 @@ impl ElectrumClient {
     /// https://electrumx.readthedocs.io/en/latest/protocol-methods.html#blockchain-scripthash-listunspent
     /// It can return duplicates sometimes: https://github.com/artemii235/SuperNET/issues/269
     /// We should remove them to build valid transactions
+    #[allow(clippy::result_large_err)]
     pub fn scripthash_list_unspent(&self, hash: &str) -> RpcRes<Vec<ElectrumUnspent>> {
         let request_fut = Box::new(rpc_func!(self, "blockchain.scripthash.listunspent", hash).and_then(
             move |unspents: Vec<ElectrumUnspent>| {
@@ -763,6 +764,7 @@ impl ElectrumClient {
         Ok((merkle_branch, header, height))
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn retrieve_headers_from(
         &self,
         server_address: &str,
@@ -1105,6 +1107,7 @@ impl UtxoRpcClientOps for ElectrumClient {
         Box::new(fut.boxed().compat())
     }
 
+    #[allow(clippy::result_large_err)]
     fn get_median_time_past(&self, starting_block: u64, count: NonZeroU64) -> UtxoRpcFut<u32> {
         let from = if starting_block <= count.get() {
             0

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -3485,9 +3485,12 @@ pub fn is_asset_chain(coin: &UtxoCoinFields) -> bool {
     coin.conf.asset_chain
 }
 
+/// Returns whether DEX fee should be split with burn address.
+/// Currently disabled - all fees go to DEX fee address.
+// TODO: If we ever fix this back to true we need to check negotiation version was added
 pub const fn should_burn_dex_fee() -> bool {
     false
-} // TODO: fix back to true when negotiation version added
+}
 
 pub async fn get_raw_transaction(coin: &UtxoCoinFields, req: RawTransactionRequest) -> RawTransactionResult {
     let hash = H256Json::from_str(&req.tx_hash).map_to_mm(|e| RawTransactionError::InvalidHashError(e.to_string()))?;

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -3487,6 +3487,7 @@ pub fn is_asset_chain(coin: &UtxoCoinFields) -> bool {
 
 /// Returns whether DEX fee should be split with burn address.
 /// Currently disabled - all fees go to DEX fee address.
+// TODO: If we ever change this back to true, we need to check negotiation version was added
 pub const fn should_burn_dex_fee() -> bool {
     false
 }

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -3487,7 +3487,6 @@ pub fn is_asset_chain(coin: &UtxoCoinFields) -> bool {
 
 /// Returns whether DEX fee should be split with burn address.
 /// Currently disabled - all fees go to DEX fee address.
-// TODO: If we ever fix this back to true we need to check negotiation version was added
 pub const fn should_burn_dex_fee() -> bool {
     false
 }

--- a/mm2src/coins/utxo/utxo_common.rs
+++ b/mm2src/coins/utxo/utxo_common.rs
@@ -4583,6 +4583,7 @@ where
 /// [`GetUtxoMapOps::get_mature_unspent_ordered_map`] implementation.
 /// Returns available mature and immature unspents in ascending order for every given `addresses`
 /// + `RecentlySpentOutPoints` MutexGuard for further interaction (e.g. to add new transaction to it).
+#[allow(clippy::result_large_err)]
 pub async fn get_mature_unspent_ordered_map<T>(
     coin: &T,
     addresses: Vec<Address>,

--- a/mm2src/coins/utxo/utxo_standard.rs
+++ b/mm2src/coins/utxo/utxo_standard.rs
@@ -962,7 +962,9 @@ impl MarketCoinOps for UtxoStandardCoin {
     }
 
     fn should_burn_directly(&self) -> bool {
-        &self.utxo_arc.conf.ticker == "KMD"
+        // &self.utxo_arc.conf.ticker == "KMD"
+        // Burn disabled - all fees go to DEX fee address
+        false
     }
 
     fn should_burn_dex_fee(&self) -> bool {

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -54,6 +54,7 @@ use mm2_core::mm_ctx::MmCtxBuilder;
 use mm2_number::bigdecimal::{BigDecimal, Signed};
 use mm2_number::MmNumber;
 use mm2_test_helpers::electrums::doc_electrums;
+use mm2_test_helpers::for_tests::DEX_FEE_ADDR_RAW_PUBKEY_LEGACY;
 use mm2_test_helpers::for_tests::{
     electrum_servers_rpc, mm_ctx_with_custom_db, DOC_ELECTRUM_ADDRS, MARTY_ELECTRUM_ADDRS, T_BCH_ELECTRUMS,
 };
@@ -2837,16 +2838,22 @@ fn test_get_sender_trade_fee_dynamic_tx_fee() {
     assert_eq!(fee1, fee3);
 }
 
-// validate an old tx with no output with the burn account
-// TODO: remove when we disable such old style txns
+// Validate an old tx sent to the legacy DEX fee address (no burn output).
+// TODO: Update test fixtures with transactions to new DEX fee address once swaps exist
 #[test]
 fn test_validate_old_fee_tx() {
     let rpc_client = electrum_client_for_test(MARTY_ELECTRUM_ADDRS, ChainVariant::MORTY);
     let coin = utxo_coin_for_test(UtxoRpcClientEnum::Electrum(rpc_client), None, false);
+    // This tx was sent to the OLD dex fee address, so we mock dex_pubkey to return the legacy address
     let tx_bytes = hex::decode("0400008085202f8901033aedb3c3c02fc76c15b393c7b1f638cfa6b4a1d502e00d57ad5b5305f12221000000006a473044022074879aabf38ef943eba7e4ce54c444d2d6aa93ac3e60ea1d7d288d7f17231c5002205e1671a62d8c031ac15e0e8456357e54865b7acbf49c7ebcba78058fd886b4bd012103242d9cb2168968d785f6914c494c303ff1c27ba0ad882dbc3c15cfa773ea953cffffffff0210270000000000001976a914ca1e04745e8ca0c60d8c5881531d51bec470743f88ac4802d913000000001976a914902053231ef0541a7628c11acac40d30f2a127bd88ac008e3765000000000000000000000000000000").unwrap();
     let taker_fee_tx = coin.tx_enum_from_bytes(&tx_bytes).unwrap();
     let amount: MmNumber = "0.0001".parse::<BigDecimal>().unwrap().into();
     let dex_fee = DexFee::Standard(amount);
+
+    // Mock to use legacy fee address for this historical tx fixture
+    <UtxoStandardCoin as SwapOps>::dex_pubkey
+        .mock_safe(|_| MockResult::Return(DEX_FEE_ADDR_RAW_PUBKEY_LEGACY.as_slice()));
+
     let validate_fee_args = ValidateFeeArgs {
         fee_tx: &taker_fee_tx,
         expected_sender: &hex::decode("03242d9cb2168968d785f6914c494c303ff1c27ba0ad882dbc3c15cfa773ea953c").unwrap(),
@@ -2857,6 +2864,8 @@ fn test_validate_old_fee_tx() {
     let result = block_on(coin.validate_fee(validate_fee_args));
     log!("result: {:?}", result);
     assert!(result.is_ok());
+
+    <UtxoStandardCoin as SwapOps>::dex_pubkey.clear_mock();
 }
 
 #[test]
@@ -2905,8 +2914,9 @@ fn test_validate_fee_min_block() {
     }
 }
 
-#[test]
 // https://github.com/KomodoPlatform/atomicDEX-API/issues/857
+// TODO: Update test fixtures with transactions to new DEX fee address once swaps exist
+#[test]
 fn test_validate_fee_bch_70_bytes_signature() {
     let rpc_client = electrum_client_for_test(
         &[
@@ -2918,10 +2928,16 @@ fn test_validate_fee_bch_70_bytes_signature() {
     );
     let coin = utxo_coin_for_test(UtxoRpcClientEnum::Electrum(rpc_client), None, false);
     // https://blockchair.com/bitcoin-cash/transaction/ccee05a6b5bbc6f50d2a65a5a3a04690d3e2d81082ad57d3ab471189f53dd70d
+    // This tx was sent to the OLD dex fee address, so we mock dex_pubkey to return the legacy address
     let tx_bytes = hex::decode("0100000002cae89775f264e50f14238be86a7184b7f77bfe26f54067b794c546ec5eb9c91a020000006b483045022100d6ed080f722a0637a37552382f462230cc438984bc564bdb4b7094f06cfa38fa022062304a52602df1fbb3bebac4f56e1632ad456f62d9031f4983f07e546c8ec4d8412102ae7dc4ef1b49aadeff79cfad56664105f4d114e1716bc4f930cb27dbd309e521ffffffff11f386a6fe8f0431cb84f549b59be00f05e78f4a8a926c5e023a0d5f9112e8200000000069463043021f17eb93ed20a6f2cd357eabb41a4ec6329000ddc6d5b42ecbe642c5d41b206a022026bc4920c4ce3af751283574baa8e4a3efd4dad0d8fe6ba3ddf5d75628d36fda412102ae7dc4ef1b49aadeff79cfad56664105f4d114e1716bc4f930cb27dbd309e521ffffffff0210270000000000001976a914ca1e04745e8ca0c60d8c5881531d51bec470743f88ac57481c00000000001976a914bac11ce4cd2b1df2769c470d09b54f86df737e3c88ac035b4a60").unwrap();
     let taker_fee_tx = coin.tx_enum_from_bytes(&tx_bytes).unwrap();
     let amount: BigDecimal = "0.0001".parse().unwrap();
     let sender_pub = hex::decode("02ae7dc4ef1b49aadeff79cfad56664105f4d114e1716bc4f930cb27dbd309e521").unwrap();
+
+    // Mock to use legacy fee address for this historical tx fixture
+    <UtxoStandardCoin as SwapOps>::dex_pubkey
+        .mock_safe(|_| MockResult::Return(DEX_FEE_ADDR_RAW_PUBKEY_LEGACY.as_slice()));
+
     let validate_fee_args = ValidateFeeArgs {
         fee_tx: &taker_fee_tx,
         expected_sender: &sender_pub,
@@ -2930,6 +2946,8 @@ fn test_validate_fee_bch_70_bytes_signature() {
         uuid: &[],
     };
     block_on(coin.validate_fee(validate_fee_args)).unwrap();
+
+    <UtxoStandardCoin as SwapOps>::dex_pubkey.clear_mock();
 }
 
 #[test]

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -135,8 +135,9 @@ macro_rules! try_ztx_s {
 }
 
 const DEX_FEE_OVK: OutgoingViewingKey = OutgoingViewingKey([7; 32]);
-const DEX_FEE_Z_ADDR: &str = "zs1rp6426e9r6jkq2nsanl66tkd34enewrmr0uvj0zelhkcwmsy0uvxz2fhm9eu9rl3ukxvgzy2v9f";
-const DEX_BURN_Z_ADDR: &str = "zs1ntx28kyurgvsc7rxgkdhasz8p6wzv63nqpcayvnh7c4r6cs4wfkz8ztkwazjzdsxkgaq6erscyl";
+const DEX_FEE_Z_ADDR: &str = "zs18egqw99pw5846jfrqntu4neup4hjjchx874j6krmeq88yh4adws9djmuplg5hfx9f0wdsscgr5j";
+/// Burn disabled - using same address as fee address
+const DEX_BURN_Z_ADDR: &str = "zs18egqw99pw5846jfrqntu4neup4hjjchx874j6krmeq88yh4adws9djmuplg5hfx9f0wdsscgr5j";
 cfg_native!(
     #[cfg(test)]
     const DOWNLOAD_URL: &str = "https://komodoplatform.com/downloads";

--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -138,6 +138,7 @@ const DEX_FEE_OVK: OutgoingViewingKey = OutgoingViewingKey([7; 32]);
 const DEX_FEE_Z_ADDR: &str = "zs18egqw99pw5846jfrqntu4neup4hjjchx874j6krmeq88yh4adws9djmuplg5hfx9f0wdsscgr5j";
 /// Burn disabled - using same address as fee address
 const DEX_BURN_Z_ADDR: &str = "zs18egqw99pw5846jfrqntu4neup4hjjchx874j6krmeq88yh4adws9djmuplg5hfx9f0wdsscgr5j";
+
 cfg_native!(
     #[cfg(test)]
     const DOWNLOAD_URL: &str = "https://komodoplatform.com/downloads";
@@ -749,6 +750,21 @@ impl ZCoin {
             return Err(format!("invalid memo {memo:?}, expected {expected_memo:?}"));
         }
         Ok(true)
+    }
+}
+
+/// Methods used for DEX fee validation that can be mocked in tests
+/// to return legacy addresses for historical transaction fixtures.
+#[cfg_attr(test, mockable)]
+impl ZCoin {
+    /// Returns the DEX fee z-address for fee validation.
+    fn dex_fee_addr(&self) -> PaymentAddress {
+        self.z_fields.dex_fee_addr.clone()
+    }
+
+    /// Returns the DEX burn z-address for fee validation.
+    fn dex_burn_addr(&self) -> PaymentAddress {
+        self.z_fields.dex_burn_addr.clone()
     }
 }
 
@@ -1610,12 +1626,14 @@ impl SwapOps for ZCoin {
 
         let mut fee_output_valid = false;
         let mut burn_output_valid = false;
+        let dex_fee_addr = self.dex_fee_addr();
+        let dex_burn_addr = self.dex_burn_addr();
         for shielded_out in z_tx.shielded_outputs.iter() {
             if self
                 .validate_dex_fee_output(
                     shielded_out,
                     &DEX_FEE_OVK,
-                    &self.z_fields.dex_fee_addr,
+                    &dex_fee_addr,
                     block_height,
                     fee_amount_sat,
                     &expected_memo,
@@ -1633,7 +1651,7 @@ impl SwapOps for ZCoin {
                     .validate_dex_fee_output(
                         shielded_out,
                         &DEX_FEE_OVK,
-                        &self.z_fields.dex_burn_addr,
+                        &dex_burn_addr,
                         block_height,
                         burn_amount_sat,
                         &expected_memo,

--- a/mm2src/coins/z_coin/z_unit_tests.rs
+++ b/mm2src/coins/z_coin/z_unit_tests.rs
@@ -30,7 +30,7 @@ const GITHUB_CLIENT_USER_AGENT: &str = "mm2";
 /// Used to test WithBurn validation with different fee and burn addresses.
 const DEX_FEE_Z_ADDR_LEGACY: &str = "zs1rp6426e9r6jkq2nsanl66tkd34enewrmr0uvj0zelhkcwmsy0uvxz2fhm9eu9rl3ukxvgzy2v9f";
 /// Legacy DEX burn z-address for unit test fixtures.
-const DEX_BURN_Z_ADDR_LEGACY: &str = "zs1w6nkameazc5gujm69350syl5w8tgvyaphums3pw8eytzy5knj9kdg0wnkmnh8kzlwydxqhczkel";
+const DEX_BURN_Z_ADDR_LEGACY: &str = "zs1ntx28kyurgvsc7rxgkdhasz8p6wzv63nqpcayvnh7c4r6cs4wfkz8ztkwazjzdsxkgaq6erscyl";
 
 /// Download zcash params from komodo repo
 async fn fetch_and_save_params(param: &str, fname: &Path) -> Result<(), String> {

--- a/mm2src/coins/z_coin/z_unit_tests.rs
+++ b/mm2src/coins/z_coin/z_unit_tests.rs
@@ -26,6 +26,12 @@ use zcash_primitives::transaction::components::amount::DEFAULT_FEE;
 
 const GITHUB_CLIENT_USER_AGENT: &str = "mm2";
 
+/// Legacy DEX fee z-address for unit test fixtures.
+/// Used to test WithBurn validation with different fee and burn addresses.
+const DEX_FEE_Z_ADDR_LEGACY: &str = "zs1rp6426e9r6jkq2nsanl66tkd34enewrmr0uvj0zelhkcwmsy0uvxz2fhm9eu9rl3ukxvgzy2v9f";
+/// Legacy DEX burn z-address for unit test fixtures.
+const DEX_BURN_Z_ADDR_LEGACY: &str = "zs1w6nkameazc5gujm69350syl5w8tgvyaphums3pw8eytzy5knj9kdg0wnkmnh8kzlwydxqhczkel";
+
 /// Download zcash params from komodo repo
 async fn fetch_and_save_params(param: &str, fname: &Path) -> Result<(), String> {
     let url = Url::parse(&format!("{DOWNLOAD_URL}/")).unwrap().join(param).unwrap();
@@ -285,60 +291,104 @@ fn test_interpret_memo_string() {
     assert_eq!(actual, expected);
 }
 
+/// Tests ZCoin DEX fee validation with Standard and WithBurn fees.
+/// Uses mocking to set legacy addresses (different fee and burn addresses)
+/// so we can properly test the WithBurn validation logic.
 #[tokio::test]
 async fn test_validate_zcoin_dex_fee() {
     let (_ctx, coin) = z_coin_from_spending_key_for_unit_test("secret-extended-key-main1qvqstxphqyqqpqqnh3hstqpdjzkpadeed6u7fz230jmm2mxl0aacrtu9vt7a7rmr2w5az5u79d24t0rudak3newknrz5l0m3dsd8m4dffqh5xwyldc5qwz8pnalrnhlxdzf900x83jazc52y25e9hvyd4kepaze6nlcvk8sd8a4qjh3e9j5d6730t7ctzhhrhp0zljjtwuptadnksxf8a8y5axwdhass5pjaxg0hzhg7z25rx0rll7a6txywl32s6cda0s5kexr03uqdtelwe").await;
 
+    // Decode legacy addresses for testing WithBurn (different fee and burn addresses)
+    let consensus_params = coin.consensus_params();
+    let hrp = consensus_params.hrp_sapling_payment_address();
+    let legacy_fee_addr = decode_payment_address(hrp, DEX_FEE_Z_ADDR_LEGACY)
+        .expect("valid z address format")
+        .expect("valid z address");
+    let legacy_burn_addr = decode_payment_address(hrp, DEX_BURN_Z_ADDR_LEGACY)
+        .expect("valid z address format")
+        .expect("valid z address");
+
+    // Mock dex_fee_addr and dex_burn_addr to return legacy addresses
+    let fee_addr_for_mock = legacy_fee_addr.clone();
+    ZCoin::dex_fee_addr.mock_safe(move |_| MockResult::Return(fee_addr_for_mock.clone()));
+    let burn_addr_for_mock = legacy_burn_addr.clone();
+    ZCoin::dex_burn_addr.mock_safe(move |_| MockResult::Return(burn_addr_for_mock.clone()));
+
+    // Test standard fee validation
     let std_fee = DexFee::Standard("0.001".into());
+    assert!(
+        validate_fee_caller(&coin, (legacy_fee_addr.clone(), 100000), None, &std_fee)
+            .await
+            .is_ok()
+    );
+
+    // Test WithBurn fee validation - using different fee and burn addresses
     let with_burn = DexFee::WithBurn {
         fee_amount: "0.0075".into(),
         burn_amount: "0.0025".into(),
         burn_destination: DexFeeBurnDestination::PreBurnAccount,
     };
-    assert!(
-        validate_fee_caller(&coin, (coin.z_fields.dex_fee_addr.clone(), 100000), None, &std_fee)
-            .await
-            .is_ok()
-    );
     assert!(validate_fee_caller(
         &coin,
-        (coin.z_fields.dex_fee_addr.clone(), 750000),
-        Some((coin.z_fields.dex_burn_addr.clone(), 250000)),
+        (legacy_fee_addr.clone(), 750000),
+        Some((legacy_burn_addr.clone(), 250000)),
         &with_burn
     )
     .await
     .is_ok());
-    // try reverted addresses
+
+    // Test reverted addresses - should fail because fee and burn addresses are swapped
     assert!(validate_fee_caller(
         &coin,
-        (coin.z_fields.dex_burn_addr.clone(), 750000),
-        Some((coin.z_fields.dex_fee_addr.clone(), 250000)),
+        (legacy_burn_addr.clone(), 750000),
+        Some((legacy_fee_addr.clone(), 250000)),
         &with_burn
     )
     .await
     .is_err());
+
+    // Test with a completely different address - should fail
     let other_addr = decode_payment_address(
-        coin.z_fields.consensus_params.hrp_sapling_payment_address(),
+        hrp,
         "zs182ht30wnnnr8jjhj2j9v5dkx3qsknnr5r00jfwk2nczdtqy7w0v836kyy840kv2r8xle5gcl549",
     )
     .expect("valid z address format")
     .expect("valid z address");
-    // try invalid dex address
+
+    // Fee sent to wrong address should fail
+    assert!(validate_fee_caller(&coin, (other_addr.clone(), 100000), None, &std_fee)
+        .await
+        .is_err());
+
+    // Invalid dex address in WithBurn should fail
     assert!(validate_fee_caller(
         &coin,
         (other_addr.clone(), 750000),
-        Some((coin.z_fields.dex_burn_addr.clone(), 250000)),
+        Some((legacy_burn_addr.clone(), 250000)),
         &with_burn
     )
     .await
     .is_err());
-    // try invalid burn address
+
+    // Invalid burn address should fail
     assert!(validate_fee_caller(
         &coin,
-        (coin.z_fields.dex_fee_addr.clone(), 750000),
+        (legacy_fee_addr.clone(), 750000),
         Some((other_addr.clone(), 250000)),
         &with_burn
     )
     .await
     .is_err());
+
+    // Test with larger fee amount
+    let large_fee = DexFee::Standard("0.02".into());
+    assert!(
+        validate_fee_caller(&coin, (legacy_fee_addr.clone(), 2000000), None, &large_fee)
+            .await
+            .is_ok()
+    );
+
+    // Clean up mocks
+    ZCoin::dex_fee_addr.clear_mock();
+    ZCoin::dex_burn_addr.clear_mock();
 }

--- a/mm2src/coins_activation/src/bch_with_tokens_activation.rs
+++ b/mm2src/coins_activation/src/bch_with_tokens_activation.rs
@@ -63,6 +63,7 @@ impl TokenInitializer for SlpTokenInitializer {
         platform_params.slp_tokens_requests.clone()
     }
 
+    #[allow(clippy::result_large_err)]
     async fn enable_tokens(
         &self,
         activation_params: Vec<TokenActivationParams<SlpActivationRequest, SlpProtocolConf>>,

--- a/mm2src/common/AGENTS.md
+++ b/mm2src/common/AGENTS.md
@@ -140,9 +140,9 @@ impl HttpStatusCode for MyError {
 
 ```rust
 // DEX fee addresses
-pub const DEX_FEE_ADDR_PUBKEY: &str = "03bc2c7ba671...";
-pub const DEX_BURN_ADDR_PUBKEY: &str = "0369aa10c061...";
-
+pub const DEX_FEE_ADDR_PUBKEY: &str = "0348685437...";
+pub const DEX_BURN_ADDR_PUBKEY: &str = "0348685437..."; // Same as fee (burn disabled)
+```
 // Satoshis conversion
 pub const SATOSHIS: u64 = 100_000_000;
 pub fn sat_to_f(sat: u64) -> f64;

--- a/mm2src/common/AGENTS.md
+++ b/mm2src/common/AGENTS.md
@@ -142,7 +142,6 @@ impl HttpStatusCode for MyError {
 // DEX fee addresses
 pub const DEX_FEE_ADDR_PUBKEY: &str = "0348685437...";
 pub const DEX_BURN_ADDR_PUBKEY: &str = "0348685437..."; // Same as fee (burn disabled)
-```
 // Satoshis conversion
 pub const SATOSHIS: u64 = 100_000_000;
 pub fn sat_to_f(sat: u64) -> f64;

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -220,10 +220,12 @@ pub const APPLICATION_GRPC_WEB_TEXT_PROTO: &str = "application/grpc-web-text+pro
 pub const SATOSHIS: u64 = 100_000_000;
 
 /// Dex fee public key for chains where SECP256K1 is supported
-pub const DEX_FEE_ADDR_PUBKEY: &str = "03bc2c7ba671bae4a6fc835244c9762b41647b9827d4780a89a949b984a8ddcc06";
+pub const DEX_FEE_ADDR_PUBKEY: &str = "0348685437335ec43ba6211caf848576ca3d34abbe9e089f861471b4ed9ee9bbd1";
 /// Public key to collect the burn part of dex fee, for chains where SECP256K1 is supported
-pub const DEX_BURN_ADDR_PUBKEY: &str = "0369aa10c061cd9e085f4adb7399375ba001b54136145cb748eb4c48657be13153";
+/// Burn currently disabled - using same address as fee address in case there is a bug that enables burn (can be re-enabled later)
+pub const DEX_BURN_ADDR_PUBKEY: &str = "0348685437335ec43ba6211caf848576ca3d34abbe9e089f861471b4ed9ee9bbd1";
 
+// TODO: Update ED25519 pubkey for Sia when GUI support is added
 pub const DEX_FEE_PUBKEY_ED25519: &str = "77b0936728f63257b074c7b3fb2c4fad98df345f57de1ec418fc42619e4e29f8";
 
 pub const PROXY_REQUEST_EXPIRATION_SEC: i64 = 15;

--- a/mm2src/derives/enum_derives/src/lib.rs
+++ b/mm2src/derives/enum_derives/src/lib.rs
@@ -144,7 +144,6 @@ pub fn derive(input: TokenStream) -> TokenStream {
 ///     Polygon,
 /// }
 ///
-///#[test]
 ///fn test_enum_variant_list() {
 ///    let all_chains = Chain::variant_list();
 ///    assert_eq!(all_chains, vec![

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -2336,6 +2336,7 @@ mod lp_swap_tests {
     }
 
     #[test]
+    #[ignore] // KMD discount removed - fee is now 2% flat for all trades
     fn test_kmd_taker_dex_fee_calculation() {
         std::env::set_var("MYCOIN_FEE_DISCOUNT", "");
 
@@ -2378,6 +2379,7 @@ mod lp_swap_tests {
     }
 
     #[test]
+    #[ignore] // KMD discount removed - fee is now 2% flat for all trades
     fn test_dex_fee_from_taker_coin_discount() {
         std::env::set_var("MYCOIN_FEE_DISCOUNT", "");
 

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -2342,7 +2342,7 @@ mod lp_swap_tests {
 
         let kmd = coins::TestCoin::new("KMD");
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
-        let (kmd_fee_amount, kmd_burn_amount) = match DexFee::new_from_taker_coin(&kmd, "ETH", &MmNumber::from(6150)) {
+        let (kmd_fee_amount, kmd_burn_amount) = match DexFee::new_from_taker_coin(&kmd, &MmNumber::from(6150)) {
             DexFee::Standard(_) | DexFee::NoFee => {
                 panic!("Wrong variant returned for KMD from `DexFee::new_from_taker_coin`.")
             },
@@ -2356,17 +2356,17 @@ mod lp_swap_tests {
 
         let mycoin = coins::TestCoin::new("MYCOIN");
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
-        let (mycoin_fee_amount, mycoin_burn_amount) =
-            match DexFee::new_from_taker_coin(&mycoin, "ETH", &MmNumber::from(6150)) {
-                DexFee::Standard(_) | DexFee::NoFee => {
-                    panic!("Wrong variant returned for MYCOIN from `DexFee::new_from_taker_coin`.")
-                },
-                DexFee::WithBurn {
-                    fee_amount,
-                    burn_amount,
-                    ..
-                } => (fee_amount, burn_amount),
-            };
+        let (mycoin_fee_amount, mycoin_burn_amount) = match DexFee::new_from_taker_coin(&mycoin, &MmNumber::from(6150))
+        {
+            DexFee::Standard(_) | DexFee::NoFee => {
+                panic!("Wrong variant returned for MYCOIN from `DexFee::new_from_taker_coin`.")
+            },
+            DexFee::WithBurn {
+                fee_amount,
+                burn_amount,
+                ..
+            } => (fee_amount, burn_amount),
+        };
         TestCoin::should_burn_dex_fee.clear_mock();
 
         let expected_mycoin_total_fee = &kmd_fee_amount / &MmNumber::from("0.75");
@@ -2385,23 +2385,22 @@ mod lp_swap_tests {
 
         let mycoin = coins::TestCoin::new("MYCOIN");
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
-        let (mycoin_taker_fee, mycoin_burn_amount) =
-            match DexFee::new_from_taker_coin(&mycoin, "", &MmNumber::from(6150)) {
-                DexFee::Standard(_) | DexFee::NoFee => {
-                    panic!("Wrong variant returned for MYCOIN from `DexFee::new_from_taker_coin`.")
-                },
-                DexFee::WithBurn {
-                    fee_amount,
-                    burn_amount,
-                    ..
-                } => (fee_amount, burn_amount),
-            };
+        let (mycoin_taker_fee, mycoin_burn_amount) = match DexFee::new_from_taker_coin(&mycoin, &MmNumber::from(6150)) {
+            DexFee::Standard(_) | DexFee::NoFee => {
+                panic!("Wrong variant returned for MYCOIN from `DexFee::new_from_taker_coin`.")
+            },
+            DexFee::WithBurn {
+                fee_amount,
+                burn_amount,
+                ..
+            } => (fee_amount, burn_amount),
+        };
         TestCoin::should_burn_dex_fee.clear_mock();
 
         let testcoin = coins::TestCoin::default();
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         let (testcoin_taker_fee, testcoin_burn_amount) =
-            match DexFee::new_from_taker_coin(&testcoin, "", &MmNumber::from(6150)) {
+            match DexFee::new_from_taker_coin(&testcoin, &MmNumber::from(6150)) {
                 DexFee::Standard(_) | DexFee::NoFee => {
                     panic!("Wrong variant returned for TEST coin from `DexFee::new_from_taker_coin`.")
                 },

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -2384,7 +2384,7 @@ mod lp_swap_tests {
     /// Tests that GLEEC trades get a 50% fee discount (1% vs 2% standard rate)
     /// and that the 75/25 fee/burn split is applied on the discounted amount.
     #[test]
-    fn test_gleec_taker_dex_fee_calculation() {
+    fn test_dex_fee_burn_split_with_discount_and_standard_coins() {
         let gleec = coins::TestCoin::new("GLEEC");
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         let trade_amount = MmNumber::from(6150);
@@ -2432,57 +2432,6 @@ mod lp_swap_tests {
         let expected_burn = &total_gleec_fee * &MmNumber::from("0.25");
         assert_eq!(gleec_fee_amount, expected_fee);
         assert_eq!(gleec_burn_amount, expected_burn);
-    }
-
-    /// Tests that MYCOIN gets GLEEC-like discount when MYCOIN_FEE_DISCOUNT env is set.
-    #[test]
-    fn test_dex_fee_from_taker_coin_discount() {
-        std::env::set_var("MYCOIN_FEE_DISCOUNT", "1");
-
-        let mycoin = coins::TestCoin::new("MYCOIN");
-        TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
-        let trade_amount = MmNumber::from(6150);
-        let (mycoin_taker_fee, mycoin_burn_amount) = match DexFee::new_from_taker_coin(&mycoin, "", &trade_amount) {
-            DexFee::Standard(_) | DexFee::NoFee => {
-                panic!("Wrong variant returned for MYCOIN from `DexFee::new_from_taker_coin`.")
-            },
-            DexFee::WithBurn {
-                fee_amount,
-                burn_amount,
-                ..
-            } => (fee_amount, burn_amount),
-        };
-        TestCoin::should_burn_dex_fee.clear_mock();
-
-        // MYCOIN should have 1% rate (discount via env var)
-        let total_mycoin_fee = &mycoin_taker_fee + &mycoin_burn_amount;
-        let expected_total = &trade_amount * &MmNumber::from("0.01");
-        assert_eq!(total_mycoin_fee, expected_total);
-
-        let testcoin = coins::TestCoin::default();
-        TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
-        let (testcoin_taker_fee, testcoin_burn_amount) = match DexFee::new_from_taker_coin(&testcoin, "", &trade_amount)
-        {
-            DexFee::Standard(_) | DexFee::NoFee => {
-                panic!("Wrong variant returned for TEST coin from `DexFee::new_from_taker_coin`.")
-            },
-            DexFee::WithBurn {
-                fee_amount,
-                burn_amount,
-                ..
-            } => (fee_amount, burn_amount),
-        };
-        TestCoin::should_burn_dex_fee.clear_mock();
-
-        // TEST coin should have 2% rate (no discount)
-        let total_testcoin_fee = &testcoin_taker_fee + &testcoin_burn_amount;
-        let expected_total = &trade_amount * &MmNumber::from("0.02");
-        assert_eq!(total_testcoin_fee, expected_total);
-
-        // MYCOIN fee should be half of standard fee
-        assert_eq!(&total_mycoin_fee * &MmNumber::from(2), total_testcoin_fee);
-
-        std::env::remove_var("MYCOIN_FEE_DISCOUNT");
     }
 
     #[test]

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -2335,11 +2335,12 @@ mod lp_swap_tests {
         let _: SavedSwap = json::from_str(include_str!("for_tests/iris_nimda_rick_maker_swap.json")).unwrap();
     }
 
+    /// Tests WithBurn fee calculation when burn is enabled via mocking.
+    /// Verifies that all coins use the same 2% flat fee rate (no KMD discount).
+    ///
+    /// TODO: Add discount test cases when fee discounts are implemented for GLEEC.
     #[test]
-    #[ignore] // KMD discount removed - fee is now 2% flat for all trades
-    fn test_kmd_taker_dex_fee_calculation() {
-        std::env::set_var("MYCOIN_FEE_DISCOUNT", "");
-
+    fn test_with_burn_fee_calculation() {
         let kmd = coins::TestCoin::new("KMD");
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         let (kmd_fee_amount, kmd_burn_amount) = match DexFee::new_from_taker_coin(&kmd, &MmNumber::from(6150)) {
@@ -2369,20 +2370,25 @@ mod lp_swap_tests {
         };
         TestCoin::should_burn_dex_fee.clear_mock();
 
-        let expected_mycoin_total_fee = &kmd_fee_amount / &MmNumber::from("0.75");
-        let expected_kmd_burn_amount = &expected_mycoin_total_fee - &kmd_fee_amount;
-
+        // All coins should have the same fee rate (2% flat, no discounts)
         assert_eq!(kmd_fee_amount, mycoin_fee_amount);
-        assert_eq!(expected_kmd_burn_amount, kmd_burn_amount);
-        // assuming for TestCoin dust is zero
-        assert_eq!(mycoin_burn_amount, kmd_burn_amount);
+        assert_eq!(kmd_burn_amount, mycoin_burn_amount);
+
+        // Verify fee/burn split: 75% fee, 25% burn
+        let total_fee = &kmd_fee_amount + &kmd_burn_amount;
+        let expected_fee = &total_fee * &MmNumber::from("0.75");
+        let expected_burn = &total_fee * &MmNumber::from("0.25");
+        assert_eq!(kmd_fee_amount, expected_fee);
+        assert_eq!(kmd_burn_amount, expected_burn);
     }
 
+    /// Tests that all coins have the same fee rate (no discounts).
+    /// Previously tested MYCOIN_FEE_DISCOUNT env var giving 10% discount.
+    /// Now verifies uniform 2% rate for all coins.
+    ///
+    /// TODO: Add discount test when fee discounts are implemented for GLEEC.
     #[test]
-    #[ignore] // KMD discount removed - fee is now 2% flat for all trades
-    fn test_dex_fee_from_taker_coin_discount() {
-        std::env::set_var("MYCOIN_FEE_DISCOUNT", "");
-
+    fn test_uniform_fee_rate_no_discounts() {
         let mycoin = coins::TestCoin::new("MYCOIN");
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
         let (mycoin_taker_fee, mycoin_burn_amount) = match DexFee::new_from_taker_coin(&mycoin, &MmNumber::from(6150)) {
@@ -2411,8 +2417,10 @@ mod lp_swap_tests {
                 } => (fee_amount, burn_amount),
             };
         TestCoin::should_burn_dex_fee.clear_mock();
-        assert_eq!(testcoin_taker_fee * MmNumber::from("0.90"), mycoin_taker_fee);
-        assert_eq!(testcoin_burn_amount * MmNumber::from("0.90"), mycoin_burn_amount);
+
+        // All coins should have the same fee (no discounts anymore)
+        assert_eq!(testcoin_taker_fee, mycoin_taker_fee);
+        assert_eq!(testcoin_burn_amount, mycoin_burn_amount);
     }
 
     #[test]

--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -2336,14 +2336,13 @@ mod lp_swap_tests {
     }
 
     /// Tests WithBurn fee calculation when burn is enabled via mocking.
-    /// Verifies that all coins use the same 2% flat fee rate (no KMD discount).
-    ///
-    /// TODO: Add discount test cases when fee discounts are implemented for GLEEC.
+    /// Verifies that non-discount coins use the same 2% fee rate and correct 75/25 fee/burn split.
+    /// Uses KMD and RICK (neither is a discount ticker) to avoid env var race with other tests.
     #[test]
     fn test_with_burn_fee_calculation() {
         let kmd = coins::TestCoin::new("KMD");
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
-        let (kmd_fee_amount, kmd_burn_amount) = match DexFee::new_from_taker_coin(&kmd, &MmNumber::from(6150)) {
+        let (kmd_fee_amount, kmd_burn_amount) = match DexFee::new_from_taker_coin(&kmd, "ETH", &MmNumber::from(6150)) {
             DexFee::Standard(_) | DexFee::NoFee => {
                 panic!("Wrong variant returned for KMD from `DexFee::new_from_taker_coin`.")
             },
@@ -2355,12 +2354,12 @@ mod lp_swap_tests {
         };
         TestCoin::should_burn_dex_fee.clear_mock();
 
-        let mycoin = coins::TestCoin::new("MYCOIN");
+        let rick = coins::TestCoin::new("RICK");
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
-        let (mycoin_fee_amount, mycoin_burn_amount) = match DexFee::new_from_taker_coin(&mycoin, &MmNumber::from(6150))
+        let (rick_fee_amount, rick_burn_amount) = match DexFee::new_from_taker_coin(&rick, "ETH", &MmNumber::from(6150))
         {
             DexFee::Standard(_) | DexFee::NoFee => {
-                panic!("Wrong variant returned for MYCOIN from `DexFee::new_from_taker_coin`.")
+                panic!("Wrong variant returned for RICK from `DexFee::new_from_taker_coin`.")
             },
             DexFee::WithBurn {
                 fee_amount,
@@ -2370,9 +2369,9 @@ mod lp_swap_tests {
         };
         TestCoin::should_burn_dex_fee.clear_mock();
 
-        // All coins should have the same fee rate (2% flat, no discounts)
-        assert_eq!(kmd_fee_amount, mycoin_fee_amount);
-        assert_eq!(kmd_burn_amount, mycoin_burn_amount);
+        // All non-discount coins should have the same fee rate (2%)
+        assert_eq!(kmd_fee_amount, rick_fee_amount);
+        assert_eq!(kmd_burn_amount, rick_burn_amount);
 
         // Verify fee/burn split: 75% fee, 25% burn
         let total_fee = &kmd_fee_amount + &kmd_burn_amount;
@@ -2382,16 +2381,68 @@ mod lp_swap_tests {
         assert_eq!(kmd_burn_amount, expected_burn);
     }
 
-    /// Tests that all coins have the same fee rate (no discounts).
-    /// Previously tested MYCOIN_FEE_DISCOUNT env var giving 10% discount.
-    /// Now verifies uniform 2% rate for all coins.
-    ///
-    /// TODO: Add discount test when fee discounts are implemented for GLEEC.
+    /// Tests that GLEEC trades get a 50% fee discount (1% vs 2% standard rate)
+    /// and that the 75/25 fee/burn split is applied on the discounted amount.
     #[test]
-    fn test_uniform_fee_rate_no_discounts() {
+    fn test_gleec_taker_dex_fee_calculation() {
+        let gleec = coins::TestCoin::new("GLEEC");
+        TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
+        let trade_amount = MmNumber::from(6150);
+        let (gleec_fee_amount, gleec_burn_amount) = match DexFee::new_from_taker_coin(&gleec, "ETH", &trade_amount) {
+            DexFee::Standard(_) | DexFee::NoFee => {
+                panic!("Wrong variant returned for GLEEC from `DexFee::new_from_taker_coin`.")
+            },
+            DexFee::WithBurn {
+                fee_amount,
+                burn_amount,
+                ..
+            } => (fee_amount, burn_amount),
+        };
+        TestCoin::should_burn_dex_fee.clear_mock();
+
+        // GLEEC should use 1% rate (50% discount)
+        let total_gleec_fee = &gleec_fee_amount + &gleec_burn_amount;
+        let expected_total = &trade_amount * &MmNumber::from("0.01"); // 1%
+        assert_eq!(total_gleec_fee, expected_total);
+
+        // Non-GLEEC should use 2% rate
+        let rick = coins::TestCoin::new("RICK");
+        TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
+        let (rick_fee_amount, rick_burn_amount) = match DexFee::new_from_taker_coin(&rick, "ETH", &trade_amount) {
+            DexFee::Standard(_) | DexFee::NoFee => {
+                panic!("Wrong variant returned for RICK from `DexFee::new_from_taker_coin`.")
+            },
+            DexFee::WithBurn {
+                fee_amount,
+                burn_amount,
+                ..
+            } => (fee_amount, burn_amount),
+        };
+        TestCoin::should_burn_dex_fee.clear_mock();
+
+        let total_rick_fee = &rick_fee_amount + &rick_burn_amount;
+        let expected_total = &trade_amount * &MmNumber::from("0.02"); // 2%
+        assert_eq!(total_rick_fee, expected_total);
+
+        // Verify GLEEC fee is half of standard fee
+        assert_eq!(&total_gleec_fee * &MmNumber::from(2), total_rick_fee);
+
+        // Verify fee/burn split: 75% fee, 25% burn
+        let expected_fee = &total_gleec_fee * &MmNumber::from("0.75");
+        let expected_burn = &total_gleec_fee * &MmNumber::from("0.25");
+        assert_eq!(gleec_fee_amount, expected_fee);
+        assert_eq!(gleec_burn_amount, expected_burn);
+    }
+
+    /// Tests that MYCOIN gets GLEEC-like discount when MYCOIN_FEE_DISCOUNT env is set.
+    #[test]
+    fn test_dex_fee_from_taker_coin_discount() {
+        std::env::set_var("MYCOIN_FEE_DISCOUNT", "1");
+
         let mycoin = coins::TestCoin::new("MYCOIN");
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
-        let (mycoin_taker_fee, mycoin_burn_amount) = match DexFee::new_from_taker_coin(&mycoin, &MmNumber::from(6150)) {
+        let trade_amount = MmNumber::from(6150);
+        let (mycoin_taker_fee, mycoin_burn_amount) = match DexFee::new_from_taker_coin(&mycoin, "", &trade_amount) {
             DexFee::Standard(_) | DexFee::NoFee => {
                 panic!("Wrong variant returned for MYCOIN from `DexFee::new_from_taker_coin`.")
             },
@@ -2403,24 +2454,35 @@ mod lp_swap_tests {
         };
         TestCoin::should_burn_dex_fee.clear_mock();
 
+        // MYCOIN should have 1% rate (discount via env var)
+        let total_mycoin_fee = &mycoin_taker_fee + &mycoin_burn_amount;
+        let expected_total = &trade_amount * &MmNumber::from("0.01");
+        assert_eq!(total_mycoin_fee, expected_total);
+
         let testcoin = coins::TestCoin::default();
         TestCoin::should_burn_dex_fee.mock_safe(|_| MockResult::Return(true));
-        let (testcoin_taker_fee, testcoin_burn_amount) =
-            match DexFee::new_from_taker_coin(&testcoin, &MmNumber::from(6150)) {
-                DexFee::Standard(_) | DexFee::NoFee => {
-                    panic!("Wrong variant returned for TEST coin from `DexFee::new_from_taker_coin`.")
-                },
-                DexFee::WithBurn {
-                    fee_amount,
-                    burn_amount,
-                    ..
-                } => (fee_amount, burn_amount),
-            };
+        let (testcoin_taker_fee, testcoin_burn_amount) = match DexFee::new_from_taker_coin(&testcoin, "", &trade_amount)
+        {
+            DexFee::Standard(_) | DexFee::NoFee => {
+                panic!("Wrong variant returned for TEST coin from `DexFee::new_from_taker_coin`.")
+            },
+            DexFee::WithBurn {
+                fee_amount,
+                burn_amount,
+                ..
+            } => (fee_amount, burn_amount),
+        };
         TestCoin::should_burn_dex_fee.clear_mock();
 
-        // All coins should have the same fee (no discounts anymore)
-        assert_eq!(testcoin_taker_fee, mycoin_taker_fee);
-        assert_eq!(testcoin_burn_amount, mycoin_burn_amount);
+        // TEST coin should have 2% rate (no discount)
+        let total_testcoin_fee = &testcoin_taker_fee + &testcoin_burn_amount;
+        let expected_total = &trade_amount * &MmNumber::from("0.02");
+        assert_eq!(total_testcoin_fee, expected_total);
+
+        // MYCOIN fee should be half of standard fee
+        assert_eq!(&total_mycoin_fee * &MmNumber::from(2), total_testcoin_fee);
+
+        std::env::remove_var("MYCOIN_FEE_DISCOUNT");
     }
 
     #[test]

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -809,7 +809,6 @@ impl MakerSwap {
         let taker_amount = MmNumber::from(self.taker_amount.clone());
         let dex_fee = DexFee::new_with_taker_pubkey(
             self.taker_coin.deref(),
-            &self.r().data.maker_coin,
             &taker_amount,
             self.r().other_taker_coin_htlc_pub.to_vec().as_ref(),
         );

--- a/mm2src/mm2_main/src/lp_swap/maker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap.rs
@@ -809,6 +809,7 @@ impl MakerSwap {
         let taker_amount = MmNumber::from(self.taker_amount.clone());
         let dex_fee = DexFee::new_with_taker_pubkey(
             self.taker_coin.deref(),
+            &self.r().data.maker_coin,
             &taker_amount,
             self.r().other_taker_coin_htlc_pub.to_vec().as_ref(),
         );

--- a/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
@@ -474,27 +474,25 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
 
     /// Calculate dex fee while taker pub is not known yet
     fn dex_fee(&self) -> DexFee {
-        // Set DexFee::NoFee for swaps with KMD coin.
-        if self.maker_coin.ticker() == "KMD" || self.taker_coin.ticker() == "KMD" {
-            DexFee::NoFee
-        } else {
-            DexFee::new_from_taker_coin(&self.taker_coin, self.maker_coin.ticker(), &self.taker_volume)
-        }
+        // NOTE: To enable NoFee for a specific coin (e.g., GLEEC), uncomment and update:
+        // if self.maker_coin.ticker() == "GLEEC" || self.taker_coin.ticker() == "GLEEC" {
+        //     return DexFee::NoFee;
+        // }
+        DexFee::new_from_taker_coin(&self.taker_coin, self.maker_coin.ticker(), &self.taker_volume)
     }
 
     /// Calculate updated dex fee when taker pub is already received
     fn dex_fee_updated(&self, taker_pub: &[u8]) -> DexFee {
-        // Set DexFee::NoFee for swaps with KMD coin.
-        if self.maker_coin.ticker() == "KMD" || self.taker_coin.ticker() == "KMD" {
-            DexFee::NoFee
-        } else {
-            DexFee::new_with_taker_pubkey(
-                &self.taker_coin,
-                self.maker_coin.ticker(),
-                &self.taker_volume,
-                taker_pub,
-            )
-        }
+        // NOTE: To enable NoFee for a specific coin (e.g., GLEEC), uncomment and update:
+        // if self.maker_coin.ticker() == "GLEEC" || self.taker_coin.ticker() == "GLEEC" {
+        //     return DexFee::NoFee;
+        // }
+        DexFee::new_with_taker_pubkey(
+            &self.taker_coin,
+            self.maker_coin.ticker(),
+            &self.taker_volume,
+            taker_pub,
+        )
     }
 }
 

--- a/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
@@ -472,22 +472,29 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
         self.secret_hash()
     }
 
-    /// Calculate dex fee while taker pub is not known yet
+    /// Calculate dex fee while taker pub is not known yet.
+    /// GLEEC pairs get a 1% discount rate (applied inside dex_fee_rate).
     fn dex_fee(&self) -> DexFee {
-        // NOTE: To enable NoFee for a specific coin (e.g., GLEEC), uncomment and update:
+        // NOTE: To fully exempt a specific coin from dex fees, uncomment below:
         // if self.maker_coin.ticker() == "GLEEC" || self.taker_coin.ticker() == "GLEEC" {
         //     return DexFee::NoFee;
         // }
-        DexFee::new_from_taker_coin(&self.taker_coin, &self.taker_volume)
+        DexFee::new_from_taker_coin(&self.taker_coin, self.maker_coin.ticker(), &self.taker_volume)
     }
 
-    /// Calculate updated dex fee when taker pub is already received
+    /// Calculate updated dex fee when taker pub is already received.
+    /// GLEEC pairs get a 1% discount rate (applied inside dex_fee_rate).
     fn dex_fee_updated(&self, taker_pub: &[u8]) -> DexFee {
-        // NOTE: To enable NoFee for a specific coin (e.g., GLEEC), uncomment and update:
+        // NOTE: To fully exempt a specific coin from dex fees, uncomment below:
         // if self.maker_coin.ticker() == "GLEEC" || self.taker_coin.ticker() == "GLEEC" {
         //     return DexFee::NoFee;
         // }
-        DexFee::new_with_taker_pubkey(&self.taker_coin, &self.taker_volume, taker_pub)
+        DexFee::new_with_taker_pubkey(
+            &self.taker_coin,
+            self.maker_coin.ticker(),
+            &self.taker_volume,
+            taker_pub,
+        )
     }
 }
 

--- a/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/maker_swap_v2.rs
@@ -478,7 +478,7 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
         // if self.maker_coin.ticker() == "GLEEC" || self.taker_coin.ticker() == "GLEEC" {
         //     return DexFee::NoFee;
         // }
-        DexFee::new_from_taker_coin(&self.taker_coin, self.maker_coin.ticker(), &self.taker_volume)
+        DexFee::new_from_taker_coin(&self.taker_coin, &self.taker_volume)
     }
 
     /// Calculate updated dex fee when taker pub is already received
@@ -487,12 +487,7 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
         // if self.maker_coin.ticker() == "GLEEC" || self.taker_coin.ticker() == "GLEEC" {
         //     return DexFee::NoFee;
         // }
-        DexFee::new_with_taker_pubkey(
-            &self.taker_coin,
-            self.maker_coin.ticker(),
-            &self.taker_volume,
-            taker_pub,
-        )
+        DexFee::new_with_taker_pubkey(&self.taker_coin, &self.taker_volume, taker_pub)
     }
 }
 

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -2919,7 +2919,7 @@ pub fn max_taker_vol_from_available(
     rel: &str,
     min_tx_amount: &MmNumber,
 ) -> Result<MmNumber, MmError<MaxTakerVolumeLessThanDust>> {
-    let dex_fee_rate = DexFee::dex_fee_rate(base, rel);
+    let dex_fee_rate = DexFee::dex_fee_rate();
     let threshold_coef = &(&MmNumber::from(1) + &dex_fee_rate) / &dex_fee_rate;
     let max_vol = if available > min_tx_amount * &threshold_coef {
         available / (MmNumber::from(1) + dex_fee_rate)

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1063,6 +1063,7 @@ impl TakerSwap {
         let stage = FeeApproxStage::StartSwap;
         let dex_fee = DexFee::new_with_taker_pubkey(
             self.taker_coin.deref(),
+            self.maker_coin.ticker(),
             &self.taker_amount,
             &self.my_taker_coin_htlc_pub().0,
         );
@@ -1400,6 +1401,7 @@ impl TakerSwap {
         }
         let dex_fee = DexFee::new_with_taker_pubkey(
             self.taker_coin.deref(),
+            &self.r().data.maker_coin,
             &self.taker_amount,
             &self.my_taker_coin_htlc_pub().0,
         );
@@ -2543,6 +2545,7 @@ impl AtomicSwap for TakerSwap {
         // if taker fee is not sent yet it must be virtually locked
         let taker_fee = DexFee::new_with_taker_pubkey(
             self.taker_coin.deref(),
+            &self.r().data.maker_coin,
             &self.taker_amount,
             &self.my_taker_coin_htlc_pub().0,
         );
@@ -2687,6 +2690,7 @@ pub async fn taker_swap_trade_preimage(
 
     let dex_fee = DexFee::new_with_taker_pubkey(
         my_coin.deref(),
+        other_coin_ticker,
         &my_coin_volume,
         &my_coin.derive_htlc_pubkey(&[]), // passing empty unique_data because we need only the permanent pubkey here (not derived from the unique data)
     );
@@ -2765,9 +2769,8 @@ pub async fn taker_swap_trade_preimage(
 #[derive(Deserialize)]
 struct MaxTakerVolRequest {
     coin: String,
-    /// Deprecated: Previously used for KMD discount calculation.
-    /// Fee is now 2% flat for all trades. Kept for backward compatibility.
-    #[allow(dead_code)]
+    /// Used for GLEEC fee discount calculation.
+    /// When trading with GLEEC, the fee rate is 1% instead of 2%.
     trade_with: Option<String>,
 }
 
@@ -2778,7 +2781,8 @@ pub async fn max_taker_vol(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, S
         Ok(None) => return ERR!("No such coin: {}", req.coin),
         Err(err) => return ERR!("!lp_coinfind({}): {}", req.coin, err),
     };
-    let fut = calc_max_taker_vol(&ctx, &coin, FeeApproxStage::TradePreimageMax);
+    let other_coin = req.trade_with.as_ref().unwrap_or(&req.coin);
+    let fut = calc_max_taker_vol(&ctx, &coin, other_coin, FeeApproxStage::TradePreimageMax);
     let max_vol = match fut.await {
         Ok(max_vol) => max_vol,
         Err(e) if e.get_inner().not_sufficient_balance() => {
@@ -2851,7 +2855,12 @@ pub async fn max_taker_vol(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, S
 /// ```
 /// can be solved as in the first case.
 ///
-pub async fn calc_max_taker_vol(ctx: &MmArc, coin: &MmCoinEnum, stage: FeeApproxStage) -> CheckBalanceResult<MmNumber> {
+pub async fn calc_max_taker_vol(
+    ctx: &MmArc,
+    coin: &MmCoinEnum,
+    other_coin: &str,
+    stage: FeeApproxStage,
+) -> CheckBalanceResult<MmNumber> {
     let my_coin = coin.ticker();
     let balance: MmNumber = coin.my_spendable_balance().compat().await.map_mm_err()?.into();
     let locked = get_locked_amount(ctx, my_coin);
@@ -2867,7 +2876,7 @@ pub async fn calc_max_taker_vol(ctx: &MmArc, coin: &MmCoinEnum, stage: FeeApprox
     let max_vol = if my_coin == max_trade_fee.coin {
         // second case
         let max_possible_2 = &max_possible - &max_trade_fee.amount;
-        let max_dex_fee = DexFee::new_from_taker_coin(coin.deref(), &max_possible_2); // taker_pubkey is not known yet so we get max dex fee to calc max volume
+        let max_dex_fee = DexFee::new_from_taker_coin(coin.deref(), other_coin, &max_possible_2); // taker_pubkey is not known yet so we get max dex fee to calc max volume
         let max_fee_to_send_taker_fee = coin
             .get_fee_to_send_taker_fee(max_dex_fee.clone(), stage)
             .await
@@ -2883,7 +2892,7 @@ pub async fn calc_max_taker_vol(ctx: &MmArc, coin: &MmCoinEnum, stage: FeeApprox
             max_dex_fee.total_spend_amount().to_fraction(),
             max_fee_to_send_taker_fee.amount.to_fraction()
         );
-        max_taker_vol_from_available(min_max_possible, &min_tx_amount)
+        max_taker_vol_from_available(min_max_possible, my_coin, other_coin, &min_tx_amount)
             .mm_err(|e| CheckBalanceError::from_max_taker_vol_error(e, my_coin.to_owned(), locked.to_decimal()))?
     } else {
         // first case
@@ -2892,7 +2901,7 @@ pub async fn calc_max_taker_vol(ctx: &MmArc, coin: &MmCoinEnum, stage: FeeApprox
             balance.to_fraction(),
             locked.to_fraction()
         );
-        max_taker_vol_from_available(max_possible, &min_tx_amount)
+        max_taker_vol_from_available(max_possible, my_coin, other_coin, &min_tx_amount)
             .mm_err(|e| CheckBalanceError::from_max_taker_vol_error(e, my_coin.to_owned(), locked.to_decimal()))?
     };
     // do not check if `max_vol < min_tx_amount`, because it is checked within `max_taker_vol_from_available` already
@@ -2908,9 +2917,11 @@ pub struct MaxTakerVolumeLessThanDust {
 #[allow(clippy::result_large_err)]
 pub fn max_taker_vol_from_available(
     available: MmNumber,
+    base: &str,
+    rel: &str,
     min_tx_amount: &MmNumber,
 ) -> Result<MmNumber, MmError<MaxTakerVolumeLessThanDust>> {
-    let dex_fee_rate = DexFee::dex_fee_rate();
+    let dex_fee_rate = DexFee::dex_fee_rate(base, rel);
     let threshold_coef = &(&MmNumber::from(1) + &dex_fee_rate) / &dex_fee_rate;
     let max_vol = if available > min_tx_amount * &threshold_coef {
         available / (MmNumber::from(1) + dex_fee_rate)
@@ -2934,7 +2945,7 @@ pub async fn create_taker_swap_default_params(
     volume: MmNumber,
     stage: FeeApproxStage,
 ) -> CheckBalanceResult<TakerSwapPreparedParams> {
-    let dex_fee = DexFee::new_from_taker_coin(my_coin, &volume); // taker_pubkey is not known yet so we get max dexfee to estimate max swap amount
+    let dex_fee = DexFee::new_from_taker_coin(my_coin, other_coin.ticker(), &volume); // taker_pubkey is not known yet so we get max dexfee to estimate max swap amount
     let fee_to_send_dex_fee = my_coin
         .get_fee_to_send_taker_fee(dex_fee.clone(), stage)
         .await
@@ -3366,19 +3377,17 @@ mod taker_swap_tests {
         assert!(!swap.is_recoverable());
     }
 
-    /// Tests max_taker_vol_from_available with 2% flat fee rate.
+    /// Tests max_taker_vol_from_available with 2% standard fee rate and 1% GLEEC discount rate.
     ///
-    /// With 2% fee rate:
+    /// With 2% fee rate (standard):
     /// - fee = max(vol * 0.02, min_tx_amount)
     /// - available = vol + fee
+    /// - boundary: vol * 0.02 == min_tx_amount => vol == 0.0005 => available == 0.00051
     ///
-    /// Note: Prior to the 2% flat fee rate change, this test had KMD-specific
-    /// test cases because KMD had a discounted fee rate (9/7770 vs 1/777).
-    /// The KMD discount was removed, so all coins now use the same 2% rate
-    /// and the KMD-specific test paths were removed.
-    ///
-    /// TODO: When GLEEC discount (50% off) is implemented, restore coin-specific
-    /// test paths similar to the original `is_kmd` pattern.
+    /// With 1% fee rate (GLEEC discount):
+    /// - fee = max(vol * 0.01, min_tx_amount)
+    /// - available = vol + fee
+    /// - boundary: vol * 0.01 == min_tx_amount => vol == 0.001 => available == 0.00101
     #[test]
     fn test_max_taker_vol_from_available() {
         let min_tx_amount = MmNumber::from("0.00001");
@@ -3393,21 +3402,21 @@ mod taker_swap_tests {
             ("99999999999999999999999999999999999999999999999999999", false),
             ("0.00051000000000000000000000000000000000000000000000002", false),
             ("0.00051000000000000000000000000000000000000000000000001", false),
-            // TODO: Enable GLEEC tests when discount is implemented (1% rate, boundary at 0.00101)
-            // ("0.00102", true),
-            // ("0.00101000000000000000000000000000000000000000000000001", true),
+            // GLEEC discount (1% rate, boundary at 0.00101)
+            ("0.00102", true),
+            ("0.00101000000000000000000000000000000000000000000000001", true),
         ];
         for (available, is_gleec) in source {
             let available = MmNumber::from(available);
             // no matter base or rel is GLEEC
-            let base = if is_gleec { "GLEEC" } else { "RICK" };
-            let max_taker_vol =
-                max_taker_vol_from_available(available.clone(), &min_tx_amount).expect("!max_taker_vol_from_available");
+            let base = if is_gleec { "RICK" } else { "MORTY" };
+            let max_taker_vol = max_taker_vol_from_available(available.clone(), "RICK", "MORTY", &min_tx_amount)
+                .expect("!max_taker_vol_from_available");
 
             let coin = TestCoin::new(base);
             let mock_min_tx_amount = min_tx_amount.clone();
             TestCoin::min_tx_amount.mock_safe(move |_| MockResult::Return(mock_min_tx_amount.clone().into()));
-            let dex_fee = DexFee::new_from_taker_coin(&coin, &max_taker_vol).total_spend_amount();
+            let dex_fee = DexFee::new_from_taker_coin(&coin, "MORTY", &max_taker_vol).total_spend_amount();
             assert!(min_tx_amount < dex_fee);
             assert!(min_tx_amount <= max_taker_vol);
             assert_eq!(max_taker_vol + dex_fee, available);
@@ -3415,9 +3424,9 @@ mod taker_swap_tests {
 
         // For these `availables` the dex_fee must be the same as min_tx_amount
         let source = vec![
-            // TODO: Enable GLEEC tests when discount is implemented (1% rate, boundary at 0.00101)
-            // ("0.00101", true),
-            // ("0.00100999999999999999999999999999999999999999999999999", true),
+            // GLEEC discount (1% rate, boundary at 0.00101)
+            ("0.00101", true),
+            ("0.00100999999999999999999999999999999999999999999999999", true),
             ("0.00051", false),
             ("0.00050999999999999999999999999999999999999999999999999", false),
             ("0.0003", false),
@@ -3427,13 +3436,13 @@ mod taker_swap_tests {
             let available = MmNumber::from(available);
             // no matter base or rel is GLEEC
             let base = if is_gleec { "GLEEC" } else { "RICK" };
-            let max_taker_vol =
-                max_taker_vol_from_available(available.clone(), &min_tx_amount).expect("!max_taker_vol_from_available");
+            let max_taker_vol = max_taker_vol_from_available(available.clone(), base, "MORTY", &min_tx_amount)
+                .expect("!max_taker_vol_from_available");
 
             let coin = TestCoin::new(base);
             let mock_min_tx_amount = min_tx_amount.clone();
             TestCoin::min_tx_amount.mock_safe(move |_| MockResult::Return(mock_min_tx_amount.clone().into()));
-            let dex_fee = DexFee::new_from_taker_coin(&coin, &max_taker_vol).fee_amount();
+            let dex_fee = DexFee::new_from_taker_coin(&coin, "MORTY", &max_taker_vol).fee_amount(); // returns Standard dex_fee (default for TestCoin)
             println!(
                 "available={:?} max_taker_vol={:?} dex_fee={:?}",
                 available.to_decimal(),
@@ -3445,9 +3454,9 @@ mod taker_swap_tests {
             assert_eq!(max_taker_vol + dex_fee, available);
         }
 
-        // These `availables` must return an error (not enough for min vol + min fee)
+        // These `availables` must return an error
         let availables = vec![
-            "0.00002", // exactly 2*min - vol would be min but that leaves nothing for fee
+            "0.00002",
             "0.000019",
             "0.000011",
             "0.00001000000000000000000000000000000000000000000000001",
@@ -3459,7 +3468,7 @@ mod taker_swap_tests {
         ];
         for available in availables {
             let available = MmNumber::from(available);
-            max_taker_vol_from_available(available.clone(), &min_tx_amount)
+            max_taker_vol_from_available(available.clone(), "GLEEC", "MORTY", &min_tx_amount)
                 .expect_err("!max_taker_vol_from_available success but should be error");
         }
 

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -1063,7 +1063,6 @@ impl TakerSwap {
         let stage = FeeApproxStage::StartSwap;
         let dex_fee = DexFee::new_with_taker_pubkey(
             self.taker_coin.deref(),
-            self.maker_coin.ticker(),
             &self.taker_amount,
             &self.my_taker_coin_htlc_pub().0,
         );
@@ -1401,7 +1400,6 @@ impl TakerSwap {
         }
         let dex_fee = DexFee::new_with_taker_pubkey(
             self.taker_coin.deref(),
-            &self.r().data.maker_coin,
             &self.taker_amount,
             &self.my_taker_coin_htlc_pub().0,
         );
@@ -2545,7 +2543,6 @@ impl AtomicSwap for TakerSwap {
         // if taker fee is not sent yet it must be virtually locked
         let taker_fee = DexFee::new_with_taker_pubkey(
             self.taker_coin.deref(),
-            &self.r().data.maker_coin,
             &self.taker_amount,
             &self.my_taker_coin_htlc_pub().0,
         );
@@ -2690,7 +2687,6 @@ pub async fn taker_swap_trade_preimage(
 
     let dex_fee = DexFee::new_with_taker_pubkey(
         my_coin.deref(),
-        other_coin_ticker,
         &my_coin_volume,
         &my_coin.derive_htlc_pubkey(&[]), // passing empty unique_data because we need only the permanent pubkey here (not derived from the unique data)
     );
@@ -2769,6 +2765,9 @@ pub async fn taker_swap_trade_preimage(
 #[derive(Deserialize)]
 struct MaxTakerVolRequest {
     coin: String,
+    /// Deprecated: Previously used for KMD discount calculation.
+    /// Fee is now 2% flat for all trades. Kept for backward compatibility.
+    #[allow(dead_code)]
     trade_with: Option<String>,
 }
 
@@ -2779,8 +2778,7 @@ pub async fn max_taker_vol(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, S
         Ok(None) => return ERR!("No such coin: {}", req.coin),
         Err(err) => return ERR!("!lp_coinfind({}): {}", req.coin, err),
     };
-    let other_coin = req.trade_with.as_ref().unwrap_or(&req.coin);
-    let fut = calc_max_taker_vol(&ctx, &coin, other_coin, FeeApproxStage::TradePreimageMax);
+    let fut = calc_max_taker_vol(&ctx, &coin, FeeApproxStage::TradePreimageMax);
     let max_vol = match fut.await {
         Ok(max_vol) => max_vol,
         Err(e) if e.get_inner().not_sufficient_balance() => {
@@ -2853,12 +2851,7 @@ pub async fn max_taker_vol(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, S
 /// ```
 /// can be solved as in the first case.
 ///
-pub async fn calc_max_taker_vol(
-    ctx: &MmArc,
-    coin: &MmCoinEnum,
-    other_coin: &str,
-    stage: FeeApproxStage,
-) -> CheckBalanceResult<MmNumber> {
+pub async fn calc_max_taker_vol(ctx: &MmArc, coin: &MmCoinEnum, stage: FeeApproxStage) -> CheckBalanceResult<MmNumber> {
     let my_coin = coin.ticker();
     let balance: MmNumber = coin.my_spendable_balance().compat().await.map_mm_err()?.into();
     let locked = get_locked_amount(ctx, my_coin);
@@ -2874,7 +2867,7 @@ pub async fn calc_max_taker_vol(
     let max_vol = if my_coin == max_trade_fee.coin {
         // second case
         let max_possible_2 = &max_possible - &max_trade_fee.amount;
-        let max_dex_fee = DexFee::new_from_taker_coin(coin.deref(), other_coin, &max_possible_2); // taker_pubkey is not known yet so we get max dex fee to calc max volume
+        let max_dex_fee = DexFee::new_from_taker_coin(coin.deref(), &max_possible_2); // taker_pubkey is not known yet so we get max dex fee to calc max volume
         let max_fee_to_send_taker_fee = coin
             .get_fee_to_send_taker_fee(max_dex_fee.clone(), stage)
             .await
@@ -2890,7 +2883,7 @@ pub async fn calc_max_taker_vol(
             max_dex_fee.total_spend_amount().to_fraction(),
             max_fee_to_send_taker_fee.amount.to_fraction()
         );
-        max_taker_vol_from_available(min_max_possible, my_coin, other_coin, &min_tx_amount)
+        max_taker_vol_from_available(min_max_possible, &min_tx_amount)
             .mm_err(|e| CheckBalanceError::from_max_taker_vol_error(e, my_coin.to_owned(), locked.to_decimal()))?
     } else {
         // first case
@@ -2899,7 +2892,7 @@ pub async fn calc_max_taker_vol(
             balance.to_fraction(),
             locked.to_fraction()
         );
-        max_taker_vol_from_available(max_possible, my_coin, other_coin, &min_tx_amount)
+        max_taker_vol_from_available(max_possible, &min_tx_amount)
             .mm_err(|e| CheckBalanceError::from_max_taker_vol_error(e, my_coin.to_owned(), locked.to_decimal()))?
     };
     // do not check if `max_vol < min_tx_amount`, because it is checked within `max_taker_vol_from_available` already
@@ -2915,8 +2908,6 @@ pub struct MaxTakerVolumeLessThanDust {
 #[allow(clippy::result_large_err)]
 pub fn max_taker_vol_from_available(
     available: MmNumber,
-    base: &str,
-    rel: &str,
     min_tx_amount: &MmNumber,
 ) -> Result<MmNumber, MmError<MaxTakerVolumeLessThanDust>> {
     let dex_fee_rate = DexFee::dex_fee_rate();
@@ -2943,7 +2934,7 @@ pub async fn create_taker_swap_default_params(
     volume: MmNumber,
     stage: FeeApproxStage,
 ) -> CheckBalanceResult<TakerSwapPreparedParams> {
-    let dex_fee = DexFee::new_from_taker_coin(my_coin, other_coin.ticker(), &volume); // taker_pubkey is not known yet so we get max dexfee to estimate max swap amount
+    let dex_fee = DexFee::new_from_taker_coin(my_coin, &volume); // taker_pubkey is not known yet so we get max dexfee to estimate max swap amount
     let fee_to_send_dex_fee = my_coin
         .get_fee_to_send_taker_fee(dex_fee.clone(), stage)
         .await
@@ -3395,13 +3386,13 @@ mod taker_swap_tests {
             let available = MmNumber::from(available);
             // no matter base or rel is KMD
             let base = if is_kmd { "RICK" } else { "MORTY" };
-            let max_taker_vol = max_taker_vol_from_available(available.clone(), "RICK", "MORTY", &min_tx_amount)
-                .expect("!max_taker_vol_from_available");
+            let max_taker_vol =
+                max_taker_vol_from_available(available.clone(), &min_tx_amount).expect("!max_taker_vol_from_available");
 
             let coin = TestCoin::new(base);
             let mock_min_tx_amount = min_tx_amount.clone();
             TestCoin::min_tx_amount.mock_safe(move |_| MockResult::Return(mock_min_tx_amount.clone().into()));
-            let dex_fee = DexFee::new_from_taker_coin(&coin, "MORTY", &max_taker_vol).total_spend_amount();
+            let dex_fee = DexFee::new_from_taker_coin(&coin, &max_taker_vol).total_spend_amount();
             assert!(min_tx_amount < dex_fee);
             assert!(min_tx_amount <= max_taker_vol);
             assert_eq!(max_taker_vol + dex_fee, available);
@@ -3419,13 +3410,13 @@ mod taker_swap_tests {
             let available = MmNumber::from(available);
             // no matter base or rel is KMD
             let base = if is_kmd { "KMD" } else { "RICK" };
-            let max_taker_vol = max_taker_vol_from_available(available.clone(), base, "MORTY", &min_tx_amount)
-                .expect("!max_taker_vol_from_available");
+            let max_taker_vol =
+                max_taker_vol_from_available(available.clone(), &min_tx_amount).expect("!max_taker_vol_from_available");
 
             let coin = TestCoin::new(base);
             let mock_min_tx_amount = min_tx_amount.clone();
             TestCoin::min_tx_amount.mock_safe(move |_| MockResult::Return(mock_min_tx_amount.clone().into()));
-            let dex_fee = DexFee::new_from_taker_coin(&coin, "MORTY", &max_taker_vol).fee_amount(); // returns Standard dex_fee (default for TestCoin)
+            let dex_fee = DexFee::new_from_taker_coin(&coin, &max_taker_vol).fee_amount(); // returns Standard dex_fee (default for TestCoin)
             println!(
                 "available={:?} max_taker_vol={:?} dex_fee={:?}",
                 available.to_decimal(),
@@ -3450,7 +3441,7 @@ mod taker_swap_tests {
         ];
         for available in availables {
             let available = MmNumber::from(available);
-            max_taker_vol_from_available(available.clone(), "KMD", "MORTY", &min_tx_amount)
+            max_taker_vol_from_available(available.clone(), &min_tx_amount)
                 .expect_err("!max_taker_vol_from_available success but should be error");
         }
     }

--- a/mm2src/mm2_main/src/lp_swap/taker_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap.rs
@@ -3366,26 +3366,41 @@ mod taker_swap_tests {
         assert!(!swap.is_recoverable());
     }
 
+    /// Tests max_taker_vol_from_available with 2% flat fee rate.
+    ///
+    /// With 2% fee rate:
+    /// - fee = max(vol * 0.02, min_tx_amount)
+    /// - available = vol + fee
+    ///
+    /// Note: Prior to the 2% flat fee rate change, this test had KMD-specific
+    /// test cases because KMD had a discounted fee rate (9/7770 vs 1/777).
+    /// The KMD discount was removed, so all coins now use the same 2% rate
+    /// and the KMD-specific test paths were removed.
+    ///
+    /// TODO: When GLEEC discount (50% off) is implemented, restore coin-specific
+    /// test paths similar to the original `is_kmd` pattern.
     #[test]
     fn test_max_taker_vol_from_available() {
         let min_tx_amount = MmNumber::from("0.00001");
 
         // For these `availables` the dex_fee must be greater than min_tx_amount
         let source = vec![
-            ("0.00779", false),
+            ("0.00052", false),
+            ("0.001", false),
             ("0.01", false),
             ("0.0135", false),
             ("1.2000001", false),
             ("99999999999999999999999999999999999999999999999999999", false),
-            ("0.00778000000000000000000000000000000000000000000000002", false),
-            ("0.00778000000000000000000000000000000000000000000000001", false),
-            ("0.00863333333333333333333333333333333333333333333333334", true),
-            ("0.00863333333333333333333333333333333333333333333333333", true),
+            ("0.00051000000000000000000000000000000000000000000000002", false),
+            ("0.00051000000000000000000000000000000000000000000000001", false),
+            // TODO: Enable GLEEC tests when discount is implemented (1% rate, boundary at 0.00101)
+            // ("0.00102", true),
+            // ("0.00101000000000000000000000000000000000000000000000001", true),
         ];
-        for (available, is_kmd) in source {
+        for (available, is_gleec) in source {
             let available = MmNumber::from(available);
-            // no matter base or rel is KMD
-            let base = if is_kmd { "RICK" } else { "MORTY" };
+            // no matter base or rel is GLEEC
+            let base = if is_gleec { "GLEEC" } else { "RICK" };
             let max_taker_vol =
                 max_taker_vol_from_available(available.clone(), &min_tx_amount).expect("!max_taker_vol_from_available");
 
@@ -3398,25 +3413,27 @@ mod taker_swap_tests {
             assert_eq!(max_taker_vol + dex_fee, available);
         }
 
-        // for these `availables` the dex_fee must be the same as min_tx_amount
+        // For these `availables` the dex_fee must be the same as min_tx_amount
         let source = vec![
-            ("0.00863333333333333333333333333333333333333333333333332", true),
-            ("0.00863333333333333333333333333333333333333333333333331", true),
-            ("0.00777999999999999999999999999999999999999999999999999", false),
-            ("0.00777", false),
+            // TODO: Enable GLEEC tests when discount is implemented (1% rate, boundary at 0.00101)
+            // ("0.00101", true),
+            // ("0.00100999999999999999999999999999999999999999999999999", true),
+            ("0.00051", false),
+            ("0.00050999999999999999999999999999999999999999999999999", false),
+            ("0.0003", false),
             ("0.00002001", false),
         ];
-        for (available, is_kmd) in source {
+        for (available, is_gleec) in source {
             let available = MmNumber::from(available);
-            // no matter base or rel is KMD
-            let base = if is_kmd { "KMD" } else { "RICK" };
+            // no matter base or rel is GLEEC
+            let base = if is_gleec { "GLEEC" } else { "RICK" };
             let max_taker_vol =
                 max_taker_vol_from_available(available.clone(), &min_tx_amount).expect("!max_taker_vol_from_available");
 
             let coin = TestCoin::new(base);
             let mock_min_tx_amount = min_tx_amount.clone();
             TestCoin::min_tx_amount.mock_safe(move |_| MockResult::Return(mock_min_tx_amount.clone().into()));
-            let dex_fee = DexFee::new_from_taker_coin(&coin, &max_taker_vol).fee_amount(); // returns Standard dex_fee (default for TestCoin)
+            let dex_fee = DexFee::new_from_taker_coin(&coin, &max_taker_vol).fee_amount();
             println!(
                 "available={:?} max_taker_vol={:?} dex_fee={:?}",
                 available.to_decimal(),
@@ -3428,9 +3445,10 @@ mod taker_swap_tests {
             assert_eq!(max_taker_vol + dex_fee, available);
         }
 
-        // these `availables` must return an error
+        // These `availables` must return an error (not enough for min vol + min fee)
         let availables = vec![
-            "0.00002",
+            "0.00002", // exactly 2*min - vol would be min but that leaves nothing for fee
+            "0.000019",
             "0.000011",
             "0.00001000000000000000000000000000000000000000000000001",
             "0.00001",
@@ -3444,6 +3462,8 @@ mod taker_swap_tests {
             max_taker_vol_from_available(available.clone(), &min_tx_amount)
                 .expect_err("!max_taker_vol_from_available success but should be error");
         }
+
+        TestCoin::min_tx_amount.clear_mock();
     }
 
     #[test]

--- a/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
@@ -489,18 +489,24 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
         }
     }
 
+    /// GLEEC pairs get a 1% discount rate (applied inside dex_fee_rate).
     fn dex_fee(&self) -> DexFee {
-        // NOTE: To enable NoFee for a specific coin (e.g., GLEEC), uncomment and update:
+        // NOTE: To fully exempt a specific coin from dex fees, uncomment below:
         // if self.taker_coin.ticker() == "GLEEC" || self.maker_coin.ticker() == "GLEEC" {
         //     return DexFee::NoFee;
         // }
 
         if let Some(taker_pub) = self.taker_coin.taker_pubkey_bytes() {
             // for dex fee calculation we need only permanent (non-derived for HTLC) taker pubkey here
-            DexFee::new_with_taker_pubkey(&self.taker_coin, &self.taker_volume, taker_pub.as_slice())
+            DexFee::new_with_taker_pubkey(
+                &self.taker_coin,
+                self.maker_coin.ticker(),
+                &self.taker_volume,
+                taker_pub.as_slice(),
+            )
         } else {
             // Return max dex fee (if taker_pub is not known yet)
-            DexFee::new_from_taker_coin(&self.taker_coin, &self.taker_volume)
+            DexFee::new_from_taker_coin(&self.taker_coin, self.maker_coin.ticker(), &self.taker_volume)
         }
     }
 }

--- a/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
@@ -497,15 +497,10 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
 
         if let Some(taker_pub) = self.taker_coin.taker_pubkey_bytes() {
             // for dex fee calculation we need only permanent (non-derived for HTLC) taker pubkey here
-            DexFee::new_with_taker_pubkey(
-                &self.taker_coin,
-                self.maker_coin.ticker(),
-                &self.taker_volume,
-                taker_pub.as_slice(),
-            )
+            DexFee::new_with_taker_pubkey(&self.taker_coin, &self.taker_volume, taker_pub.as_slice())
         } else {
             // Return max dex fee (if taker_pub is not known yet)
-            DexFee::new_from_taker_coin(&self.taker_coin, self.maker_coin.ticker(), &self.taker_volume)
+            DexFee::new_from_taker_coin(&self.taker_coin, &self.taker_volume)
         }
     }
 }

--- a/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
+++ b/mm2src/mm2_main/src/lp_swap/taker_swap_v2.rs
@@ -490,10 +490,10 @@ impl<MakerCoin: MmCoin + MakerCoinSwapOpsV2, TakerCoin: MmCoin + TakerCoinSwapOp
     }
 
     fn dex_fee(&self) -> DexFee {
-        if self.taker_coin.ticker() == "KMD" || self.maker_coin.ticker() == "KMD" {
-            // Set DexFee::NoFee for swaps with KMD coin.
-            return DexFee::NoFee;
-        }
+        // NOTE: To enable NoFee for a specific coin (e.g., GLEEC), uncomment and update:
+        // if self.taker_coin.ticker() == "GLEEC" || self.maker_coin.ticker() == "GLEEC" {
+        //     return DexFee::NoFee;
+        // }
 
         if let Some(taker_pub) = self.taker_coin.taker_pubkey_bytes() {
             // for dex fee calculation we need only permanent (non-derived for HTLC) taker pubkey here

--- a/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
@@ -2710,7 +2710,7 @@ fn test_v2_eth_eth_kickstart_impl(base: &str, rel: &str, maker_price: f64, taker
         rel,
         &alice_rel_balance_0.balance,
         &alice_rel_balance_1.balance,
-        volume * (1.0 + 1.0 / 777.0),
+        volume * 1.02, // 2% DEX fee
         Some(taker_price),
         "sell",
     );

--- a/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
@@ -999,7 +999,8 @@ fn test_get_max_taker_vol_and_trade_with_dynamic_trade_fee(coin: QtumCoin, priv_
     let _taker_payment_tx = block_on(coin.send_taker_payment(taker_payment_args)).expect("!send_taker_payment");
 
     let my_balance = block_on_f01(coin.my_spendable_balance()).expect("!my_balance");
-    let tolerance = BigDecimal::from_str("0.001").unwrap();
+    // Tolerance increased to accommodate 2% dex fee rate (larger fee amount affects gas estimation gaps)
+    let tolerance = BigDecimal::from_str("0.002").unwrap();
     assert!(
         my_balance < tolerance,
         "NOT AN ERROR, but it would be better if the balance remained near zero. \

--- a/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
@@ -931,7 +931,7 @@ fn test_get_max_taker_vol_and_trade_with_dynamic_trade_fee(coin: QtumCoin, priv_
     // - `max_possible_2 = balance - locked_amount - max_trade_fee`, where `locked_amount = 0`
     let max_possible_2 = &qtum_balance - &max_trade_fee;
     // - `max_dex_fee = dex_fee(max_possible_2)`
-    let max_dex_fee = DexFee::new_from_taker_coin(&coin, "MYCOIN", &MmNumber::from(max_possible_2));
+    let max_dex_fee = DexFee::new_from_taker_coin(&coin, &MmNumber::from(max_possible_2));
     log!("max_dex_fee: {:?}", max_dex_fee.fee_amount().to_fraction());
 
     // - `max_fee_to_send_taker_fee = fee_to_send_taker_fee(max_dex_fee)`
@@ -946,10 +946,9 @@ fn test_get_max_taker_vol_and_trade_with_dynamic_trade_fee(coin: QtumCoin, priv_
     // where `available = balance - locked_amount - max_trade_fee - max_fee_to_send_taker_fee`
     let available = &qtum_balance - &max_trade_fee - &max_fee_to_send_taker_fee;
     log!("total_available: {}", available);
-    let expected_max_taker_vol =
-        max_taker_vol_from_available(MmNumber::from(available), "QTUM", "MYCOIN", &qtum_min_tx_amount)
-            .expect("max_taker_vol_from_available");
-    let real_dex_fee = DexFee::new_from_taker_coin(&coin, "MYCOIN", &expected_max_taker_vol).fee_amount();
+    let expected_max_taker_vol = max_taker_vol_from_available(MmNumber::from(available), &qtum_min_tx_amount)
+        .expect("max_taker_vol_from_available");
+    let real_dex_fee = DexFee::new_from_taker_coin(&coin, &expected_max_taker_vol).fee_amount();
     log!("real_max_dex_fee: {:?}", real_dex_fee.to_fraction());
 
     // check if the actual max_taker_vol equals to the expected
@@ -982,7 +981,7 @@ fn test_get_max_taker_vol_and_trade_with_dynamic_trade_fee(coin: QtumCoin, priv_
     let timelock = now_sec() - 200;
     let secret_hash = &[0; 20];
 
-    let dex_fee = DexFee::new_from_taker_coin(&coin, "MYCOIN", &expected_max_taker_vol);
+    let dex_fee = DexFee::new_from_taker_coin(&coin, &expected_max_taker_vol);
     let _taker_fee_tx = block_on(coin.send_taker_fee(dex_fee, &[], timelock)).expect("!send_taker_fee");
     let taker_payment_args = SendPaymentArgs {
         time_lock_duration: 0,

--- a/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/qrc20_tests.rs
@@ -931,7 +931,7 @@ fn test_get_max_taker_vol_and_trade_with_dynamic_trade_fee(coin: QtumCoin, priv_
     // - `max_possible_2 = balance - locked_amount - max_trade_fee`, where `locked_amount = 0`
     let max_possible_2 = &qtum_balance - &max_trade_fee;
     // - `max_dex_fee = dex_fee(max_possible_2)`
-    let max_dex_fee = DexFee::new_from_taker_coin(&coin, &MmNumber::from(max_possible_2));
+    let max_dex_fee = DexFee::new_from_taker_coin(&coin, "MYCOIN", &MmNumber::from(max_possible_2));
     log!("max_dex_fee: {:?}", max_dex_fee.fee_amount().to_fraction());
 
     // - `max_fee_to_send_taker_fee = fee_to_send_taker_fee(max_dex_fee)`
@@ -946,9 +946,10 @@ fn test_get_max_taker_vol_and_trade_with_dynamic_trade_fee(coin: QtumCoin, priv_
     // where `available = balance - locked_amount - max_trade_fee - max_fee_to_send_taker_fee`
     let available = &qtum_balance - &max_trade_fee - &max_fee_to_send_taker_fee;
     log!("total_available: {}", available);
-    let expected_max_taker_vol = max_taker_vol_from_available(MmNumber::from(available), &qtum_min_tx_amount)
-        .expect("max_taker_vol_from_available");
-    let real_dex_fee = DexFee::new_from_taker_coin(&coin, &expected_max_taker_vol).fee_amount();
+    let expected_max_taker_vol =
+        max_taker_vol_from_available(MmNumber::from(available), "QTUM", "MYCOIN", &qtum_min_tx_amount)
+            .expect("max_taker_vol_from_available");
+    let real_dex_fee = DexFee::new_from_taker_coin(&coin, "MYCOIN", &expected_max_taker_vol).fee_amount();
     log!("real_max_dex_fee: {:?}", real_dex_fee.to_fraction());
 
     // check if the actual max_taker_vol equals to the expected
@@ -981,7 +982,7 @@ fn test_get_max_taker_vol_and_trade_with_dynamic_trade_fee(coin: QtumCoin, priv_
     let timelock = now_sec() - 200;
     let secret_hash = &[0; 20];
 
-    let dex_fee = DexFee::new_from_taker_coin(&coin, &expected_max_taker_vol);
+    let dex_fee = DexFee::new_from_taker_coin(&coin, "MYCOIN", &expected_max_taker_vol);
     let _taker_fee_tx = block_on(coin.send_taker_fee(dex_fee, &[], timelock)).expect("!send_taker_fee");
     let taker_payment_args = SendPaymentArgs {
         time_lock_duration: 0,

--- a/mm2src/mm2_main/tests/docker_tests/swap_proto_v2_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_proto_v2_tests.rs
@@ -725,10 +725,12 @@ fn test_v2_swap_utxo_utxo_impl() {
 
     let locked_alice = block_on(get_locked_amount(&mm_alice, MYCOIN1));
     assert_eq!(locked_alice.coin, MYCOIN1);
+    // With 2% fee rate: locked = volume + dex_fee + tx_fees
+    // = 777 + (777 * 0.02) + 0.00000274 = 777 + 15.54 + 0.00000274 = 792.54000274
     let expected: MmNumberMultiRepr = if SET_BURN_PUBKEY_TO_ALICE.get() {
         MmNumber::from("777.00000274").into()
     } else {
-        MmNumber::from("778.00000274").into()
+        MmNumber::from("792.54000274").into()
     };
     assert_eq!(locked_alice.locked_amount, expected);
 
@@ -855,7 +857,8 @@ fn test_v2_swap_utxo_utxo_kickstart() {
     // coins must be virtually locked after kickstart until swap transactions are sent
     let locked_alice = block_on(get_locked_amount(&mm_alice, MYCOIN1));
     assert_eq!(locked_alice.coin, MYCOIN1);
-    let expected: MmNumberMultiRepr = MmNumber::from("778.00000274").into();
+    // With 2% fee rate: locked = volume + dex_fee + tx_fees = 777 + 15.54 + 0.00000274
+    let expected: MmNumberMultiRepr = MmNumber::from("792.54000274").into();
     assert_eq!(locked_alice.locked_amount, expected);
 
     let locked_bob = block_on(get_locked_amount(&mm_bob, MYCOIN));

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests/eth.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests/eth.rs
@@ -61,7 +61,7 @@ fn test_watcher_spends_maker_payment_eth_utxo() {
 
     let coin = TestCoin::new("MYCOIN");
     TestCoin::min_tx_amount.mock_safe(move |_| MockResult::Return(min_tx_amount.clone()));
-    let dex_fee: BigDecimal = DexFee::new_from_taker_coin(&coin, "ETH", &MmNumber::from(mycoin_volume.clone()))
+    let dex_fee: BigDecimal = DexFee::new_from_taker_coin(&coin, &MmNumber::from(mycoin_volume.clone()))
         .fee_amount() // returns Standard fee (default for TestCoin)
         .into();
     let alice_mycoin_reward_sent = balances.alice_acoin_balance_before
@@ -205,7 +205,7 @@ fn test_watcher_spends_maker_payment_erc20_utxo() {
     let min_tx_amount = BigDecimal::from_str("0.00001").unwrap();
     let coin = TestCoin::new("MYCOIN");
     TestCoin::min_tx_amount.mock_safe(move |_| MockResult::Return(min_tx_amount.clone()));
-    let dex_fee: BigDecimal = DexFee::new_from_taker_coin(&coin, "ERC20DEV", &MmNumber::from(mycoin_volume.clone()))
+    let dex_fee: BigDecimal = DexFee::new_from_taker_coin(&coin, &MmNumber::from(mycoin_volume.clone()))
         .fee_amount() // returns Standard fee (default for TestCoin)
         .into();
     let alice_mycoin_reward_sent = balances.alice_acoin_balance_before
@@ -414,7 +414,7 @@ fn test_watcher_validate_taker_fee_eth() {
     let taker_pubkey = taker_keypair.public();
 
     let taker_amount = MmNumber::from((1, 1));
-    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, "ETH", &taker_amount);
+    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, &taker_amount);
     let taker_fee = block_on(taker_coin.send_taker_fee(dex_fee, Uuid::new_v4().as_bytes(), lock_duration)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
@@ -505,7 +505,7 @@ fn test_watcher_validate_taker_fee_erc20() {
     let taker_pubkey = taker_keypair.public();
 
     let taker_amount = MmNumber::from((1, 1));
-    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, "ETH", &taker_amount);
+    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, &taker_amount);
     let taker_fee = block_on(taker_coin.send_taker_fee(dex_fee, Uuid::new_v4().as_bytes(), lock_duration)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests/eth.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests/eth.rs
@@ -61,7 +61,7 @@ fn test_watcher_spends_maker_payment_eth_utxo() {
 
     let coin = TestCoin::new("MYCOIN");
     TestCoin::min_tx_amount.mock_safe(move |_| MockResult::Return(min_tx_amount.clone()));
-    let dex_fee: BigDecimal = DexFee::new_from_taker_coin(&coin, &MmNumber::from(mycoin_volume.clone()))
+    let dex_fee: BigDecimal = DexFee::new_from_taker_coin(&coin, "ETH", &MmNumber::from(mycoin_volume.clone()))
         .fee_amount() // returns Standard fee (default for TestCoin)
         .into();
     let alice_mycoin_reward_sent = balances.alice_acoin_balance_before
@@ -205,7 +205,7 @@ fn test_watcher_spends_maker_payment_erc20_utxo() {
     let min_tx_amount = BigDecimal::from_str("0.00001").unwrap();
     let coin = TestCoin::new("MYCOIN");
     TestCoin::min_tx_amount.mock_safe(move |_| MockResult::Return(min_tx_amount.clone()));
-    let dex_fee: BigDecimal = DexFee::new_from_taker_coin(&coin, &MmNumber::from(mycoin_volume.clone()))
+    let dex_fee: BigDecimal = DexFee::new_from_taker_coin(&coin, "ERC20DEV", &MmNumber::from(mycoin_volume.clone()))
         .fee_amount() // returns Standard fee (default for TestCoin)
         .into();
     let alice_mycoin_reward_sent = balances.alice_acoin_balance_before
@@ -414,7 +414,7 @@ fn test_watcher_validate_taker_fee_eth() {
     let taker_pubkey = taker_keypair.public();
 
     let taker_amount = MmNumber::from((1, 1));
-    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, &taker_amount);
+    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, "ETH", &taker_amount);
     let taker_fee = block_on(taker_coin.send_taker_fee(dex_fee, Uuid::new_v4().as_bytes(), lock_duration)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {
@@ -505,7 +505,7 @@ fn test_watcher_validate_taker_fee_erc20() {
     let taker_pubkey = taker_keypair.public();
 
     let taker_amount = MmNumber::from((1, 1));
-    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, &taker_amount);
+    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, "ETH", &taker_amount);
     let taker_fee = block_on(taker_coin.send_taker_fee(dex_fee, Uuid::new_v4().as_bytes(), lock_duration)).unwrap();
 
     let confirm_payment_input = ConfirmPaymentInput {

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests/utxo.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests/utxo.rs
@@ -367,15 +367,19 @@ fn test_watcher_spends_maker_payment_utxo_utxo() {
 
     let acoin_volume = BigDecimal::from_str("50").unwrap();
     let bcoin_volume = BigDecimal::from_str("2").unwrap();
+    // DEX fee is 2% of taker volume (acoin_volume), paid by Alice (taker)
+    let dex_fee = &acoin_volume * BigDecimal::from_str("0.02").unwrap();
 
+    // Alice spends acoin_volume + dex_fee (as taker, she pays the DEX fee in the taker coin)
     assert_eq!(
         balances.alice_acoin_balance_after.round(0),
-        balances.alice_acoin_balance_before - acoin_volume.clone()
+        balances.alice_acoin_balance_before.clone() - acoin_volume.clone() - dex_fee
     );
     assert_eq!(
         balances.alice_bcoin_balance_after.round(0),
         balances.alice_bcoin_balance_before + bcoin_volume.clone()
     );
+    // Bob receives acoin_volume (no fee on his side)
     assert_eq!(
         balances.bob_acoin_balance_after.round(0),
         balances.bob_acoin_balance_before + acoin_volume
@@ -406,10 +410,16 @@ fn test_watcher_refunds_taker_payment_utxo() {
         Some(60),
     );
 
+    // Alice's a_coin (MYCOIN1) balance is reduced by the DEX fee.
+    // The taker fee is non-refundable even when the swap is refunded.
+    // DEX fee is 2% of acoin_volume (50 MYCOIN1) = 1 MYCOIN1
+    let acoin_volume = BigDecimal::from_str("50").unwrap();
+    let dex_fee = &acoin_volume * BigDecimal::from_str("0.02").unwrap();
     assert_eq!(
         balances.alice_acoin_balance_after.round(0),
-        balances.alice_acoin_balance_before
+        balances.alice_acoin_balance_before.clone() - dex_fee
     );
+    // Alice's b_coin (MYCOIN) balance should be unchanged - she got her taker payment refunded
     assert_eq!(balances.alice_bcoin_balance_after, balances.alice_bcoin_balance_before);
 }
 

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests/utxo.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests/utxo.rs
@@ -443,7 +443,7 @@ fn test_watcher_validate_taker_fee_utxo() {
     let taker_pubkey = taker_coin.my_public_key().unwrap();
 
     let taker_amount = MmNumber::from((10, 1));
-    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, maker_coin.ticker(), &taker_amount);
+    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, &taker_amount);
 
     let taker_fee = block_on(taker_coin.send_taker_fee(dex_fee, Uuid::new_v4().as_bytes(), lock_duration)).unwrap();
 

--- a/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests/utxo.rs
+++ b/mm2src/mm2_main/tests/docker_tests/swap_watcher_tests/utxo.rs
@@ -453,7 +453,7 @@ fn test_watcher_validate_taker_fee_utxo() {
     let taker_pubkey = taker_coin.my_public_key().unwrap();
 
     let taker_amount = MmNumber::from((10, 1));
-    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, &taker_amount);
+    let dex_fee = DexFee::new_from_taker_coin(&taker_coin, maker_coin.ticker(), &taker_amount);
 
     let taker_fee = block_on(taker_coin.send_taker_fee(dex_fee, Uuid::new_v4().as_bytes(), lock_duration)).unwrap();
 

--- a/mm2src/mm2_main/tests/docker_tests/utxo_swaps_v1_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/utxo_swaps_v1_tests.rs
@@ -1634,9 +1634,9 @@ fn test_max_taker_vol_swap() {
     .unwrap();
     assert!(rc.0.is_success(), "!max_taker_vol: {}", rc.1);
     let vol: MaxTakerVolResponse = serde_json::from_str(&rc.1).unwrap();
-    // With 2% fee rate: max_vol = (balance - tx_fee) / 1.02
-    // balance = 50, tx_fee varies, so max_vol ≈ 49.02
-    let expected_vol = MmNumber::from((4999999481u64, 102000000u64));
+    // With 1% fee rate (MYCOIN_FEE_DISCOUNT): max_vol = (balance - tx_fee) / 1.01
+    // balance = 50, tx_fee varies, so max_vol ≈ 49.50
+    let expected_vol = MmNumber::from((4999999481u64, 101000000u64));
 
     let actual_vol = MmNumber::from(vol.result.clone());
     log!("actual vol {}", actual_vol.to_decimal());

--- a/mm2src/mm2_main/tests/docker_tests/utxo_swaps_v1_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/utxo_swaps_v1_tests.rs
@@ -448,7 +448,9 @@ fn test_get_max_taker_vol() {
     .unwrap();
     assert!(rc.0.is_success(), "!max_taker_vol: {}", rc.1);
     let json: MaxTakerVolResponse = serde_json::from_str(&rc.1).unwrap();
-    let expected = MmNumber::from((77699596737u64, 77800000000u64)).to_fraction();
+    // With 2% fee rate: max_vol = (balance - tx_fee) / 1.02
+    // balance = 1, tx_fee varies based on UTXO, so max_vol ≈ 0.98
+    let expected = MmNumber::from((99999481u64, 102000000u64)).to_fraction();
     assert_eq!(json.result, expected);
     assert_eq!(json.coin, "MYCOIN1");
 
@@ -497,8 +499,10 @@ fn test_get_max_taker_vol_dex_fee_min_tx_amount() {
     .unwrap();
     assert!(rc.0.is_success(), "!max_taker_vol: {}", rc.1);
     let json: Json = serde_json::from_str(&rc.1).unwrap();
-    assert_eq!(json["result"]["numer"], Json::from("105331"));
-    assert_eq!(json["result"]["denom"], Json::from("20000000"));
+    // With 2% fee rate: max_vol = (balance - tx_fee) / 1.02
+    // balance = 0.00532845, tx_fee varies based on UTXO
+    assert_eq!(json["result"]["numer"], Json::from("35177"));
+    assert_eq!(json["result"]["denom"], Json::from("6800000"));
 
     let rc = block_on(mm_alice.rpc(&json!({
         "userpass": mm_alice.userpass,
@@ -614,8 +618,10 @@ fn test_get_max_taker_vol_with_kmd() {
     .unwrap();
     assert!(rc.0.is_success(), "!max_taker_vol: {}", rc.1);
     let json: Json = serde_json::from_str(&rc.1).unwrap();
-    assert_eq!(json["result"]["numer"], Json::from("2589865579"));
-    assert_eq!(json["result"]["denom"], Json::from("2593000000"));
+    // With 2% fee rate (KMD discount removed): max_vol = (balance - tx_fee) / 1.02
+    // balance = 1, tx_fee varies based on UTXO, so max_vol ≈ 0.9999
+    assert_eq!(json["result"]["numer"], Json::from("9999481"));
+    assert_eq!(json["result"]["denom"], Json::from("10200000"));
 
     let rc = block_on(mm_alice.rpc(&json!({
         "userpass": mm_alice.userpass,
@@ -1045,7 +1051,9 @@ fn test_locked_amount() {
     let locked_alice = block_on(get_locked_amount(&mm_alice, "MYCOIN1"));
     assert_eq!(locked_alice.coin, "MYCOIN1");
 
-    let expected_result: MmNumberMultiRepr = MmNumber::from("778.00000519").into();
+    // With 2% fee rate: locked = volume + dex_fee + tx_fees
+    // = 777 + (777 * 0.02) + 0.00000519 = 777 + 15.54 + 0.00000519 = 792.54000519
+    let expected_result: MmNumberMultiRepr = MmNumber::from("792.54000519").into();
     assert_eq!(expected_result, locked_alice.locked_amount);
 }
 
@@ -1258,6 +1266,7 @@ fn test_buy_when_coins_locked_by_other_swap() {
     .unwrap();
     assert!(rc.0.is_success(), "!setprice: {}", rc.1);
 
+    // With 2% fee rate: max_vol = (balance - tx_fee) / 1.02 = 49999863/51000000
     let rc = block_on(mm_alice.rpc(&json!({
         "userpass": mm_alice.userpass,
         "method": "buy",
@@ -1265,8 +1274,8 @@ fn test_buy_when_coins_locked_by_other_swap() {
         "rel": "MYCOIN1",
         "price": 1,
         "volume": {
-            "numer":"77699596737",
-            "denom":"77800000000"
+            "numer":"49999863",
+            "denom":"51000000"
         },
     })))
     .unwrap();
@@ -1276,6 +1285,7 @@ fn test_buy_when_coins_locked_by_other_swap() {
     block_on(mm_alice.wait_for_log(22., |log| log.contains("Entering the taker_swap_loop MYCOIN/MYCOIN1"))).unwrap();
     thread::sleep(Duration::from_secs(6));
 
+    // Second buy should fail because coins are locked by first swap
     let rc = block_on(mm_alice.rpc(&json!({
         "userpass": mm_alice.userpass,
         "method": "buy",
@@ -1283,8 +1293,8 @@ fn test_buy_when_coins_locked_by_other_swap() {
         "rel": "MYCOIN1",
         "price": 1,
         "volume": {
-            "numer":"77699599999",
-            "denom":"77800000000"
+            "numer":"49999864",
+            "denom":"51000000"
         },
     })))
     .unwrap();
@@ -1347,6 +1357,7 @@ fn test_sell_when_coins_locked_by_other_swap() {
     .unwrap();
     assert!(rc.0.is_success(), "!setprice: {}", rc.1);
 
+    // With 2% fee rate: max_vol = (balance - tx_fee) / 1.02 = 49999863/51000000
     let rc = block_on(mm_alice.rpc(&json!({
         "userpass": mm_alice.userpass,
         "method": "sell",
@@ -1354,8 +1365,8 @@ fn test_sell_when_coins_locked_by_other_swap() {
         "rel": "MYCOIN",
         "price": 1,
         "volume": {
-            "numer":"77699596737",
-            "denom":"77800000000"
+            "numer":"49999863",
+            "denom":"51000000"
         },
     })))
     .unwrap();
@@ -1365,6 +1376,7 @@ fn test_sell_when_coins_locked_by_other_swap() {
     block_on(mm_alice.wait_for_log(22., |log| log.contains("Entering the taker_swap_loop MYCOIN/MYCOIN1"))).unwrap();
     thread::sleep(Duration::from_secs(6));
 
+    // Second sell should fail because coins are locked by first swap
     let rc = block_on(mm_alice.rpc(&json!({
         "userpass": mm_alice.userpass,
         "method": "sell",
@@ -1372,8 +1384,8 @@ fn test_sell_when_coins_locked_by_other_swap() {
         "rel": "MYCOIN",
         "price": 1,
         "volume": {
-            "numer":"77699599999",
-            "denom":"77800000000"
+            "numer":"49999864",
+            "denom":"51000000"
         },
     })))
     .unwrap();
@@ -1406,6 +1418,7 @@ fn test_buy_max() {
 
     log!("{:?}", block_on(enable_native(&mm_alice, "MYCOIN", &[], None)));
     log!("{:?}", block_on(enable_native(&mm_alice, "MYCOIN1", &[], None)));
+    // With 2% fee rate: max_vol = (balance - tx_fee) / 1.02 = 99999481/102000000
     let rc = block_on(mm_alice.rpc(&json!({
         "userpass": mm_alice.userpass,
         "method": "buy",
@@ -1413,13 +1426,14 @@ fn test_buy_max() {
         "rel": "MYCOIN1",
         "price": 1,
         "volume": {
-            "numer":"77699596737",
-            "denom":"77800000000"
+            "numer":"99999481",
+            "denom":"102000000"
         },
     })))
     .unwrap();
     assert!(rc.0.is_success(), "!buy: {}", rc.1);
 
+    // Slightly more than max should fail
     let rc = block_on(mm_alice.rpc(&json!({
         "userpass": mm_alice.userpass,
         "method": "buy",
@@ -1427,8 +1441,8 @@ fn test_buy_max() {
         "rel": "MYCOIN1",
         "price": 1,
         "volume": {
-            "numer":"77699596738",
-            "denom":"77800000000"
+            "numer":"99999482",
+            "denom":"102000000"
         },
     })))
     .unwrap();
@@ -1620,7 +1634,9 @@ fn test_max_taker_vol_swap() {
     .unwrap();
     assert!(rc.0.is_success(), "!max_taker_vol: {}", rc.1);
     let vol: MaxTakerVolResponse = serde_json::from_str(&rc.1).unwrap();
-    let expected_vol = MmNumber::from((1294999865579, 25930000000));
+    // With 2% fee rate: max_vol = (balance - tx_fee) / 1.02
+    // balance = 50, tx_fee varies, so max_vol ≈ 49.02
+    let expected_vol = MmNumber::from((4999999481u64, 102000000u64));
 
     let actual_vol = MmNumber::from(vol.result.clone());
     log!("actual vol {}", actual_vol.to_decimal());
@@ -1883,10 +1899,12 @@ fn test_taker_trade_preimage() {
 
     let base_coin_fee = TradeFeeForTest::new("MYCOIN", "0.00000274", false);
     let rel_coin_fee = TradeFeeForTest::new("MYCOIN1", "0.00000992", true);
-    let taker_fee = TradeFeeForTest::new("MYCOIN", "0.01", false);
+    // With 2% fee rate: dex_fee = 7.77 * 0.02 = 0.1554
+    let taker_fee = TradeFeeForTest::new("MYCOIN", "0.1554", false);
     let fee_to_send_taker_fee = TradeFeeForTest::new("MYCOIN", "0.00000245", false);
 
-    let my_coin_total_fee = TotalTradeFeeForTest::new("MYCOIN", "0.01000519", "0.01000519");
+    // total = taker_fee + base_coin_fee + fee_to_send_taker_fee = 0.1554 + 0.00000274 + 0.00000245 = 0.15540519
+    let my_coin_total_fee = TotalTradeFeeForTest::new("MYCOIN", "0.15540519", "0.15540519");
     let my_coin1_total_fee = TotalTradeFeeForTest::new("MYCOIN1", "0.00000992", "0");
 
     let expected = TradePreimageResult::TakerPreimage(TakerPreimage {
@@ -1916,12 +1934,13 @@ fn test_taker_trade_preimage() {
     actual.result.sort_total_fees();
 
     let base_coin_fee = TradeFeeForTest::new("MYCOIN", "0.00000496", true);
-    let rel_coin_fee = TradeFeeForTest::new("MYCOIN1", "0.00000548", false); // fee to send taker payment
-    let taker_fee = TradeFeeForTest::new("MYCOIN1", "0.02", false);
+    let rel_coin_fee = TradeFeeForTest::new("MYCOIN1", "0.00000548", false); // fee to send taker payment     // With 2% fee rate: buy 7.77 MYCOIN at price 2 = spend 15.54 MYCOIN1, dex_fee = 15.54 * 0.02 = 0.3108
+    let taker_fee = TradeFeeForTest::new("MYCOIN1", "0.3108", false);
     let fee_to_send_taker_fee = TradeFeeForTest::new("MYCOIN1", "0.0000049", false);
 
     let my_coin_total_fee = TotalTradeFeeForTest::new("MYCOIN", "0.00000496", "0");
-    let my_coin1_total_fee = TotalTradeFeeForTest::new("MYCOIN1", "0.02001038", "0.02001038"); // taker_fee + rel_coin_fee + fee_to_send_taker_fee
+    // total = taker_fee + rel_coin_fee + fee_to_send_taker_fee = 0.3108 + 0.00000548 + 0.0000049 = 0.31081038
+    let my_coin1_total_fee = TotalTradeFeeForTest::new("MYCOIN1", "0.31081038", "0.31081038");
 
     let expected = TradePreimageResult::TakerPreimage(TakerPreimage {
         base_coin_fee,
@@ -2058,10 +2077,10 @@ fn test_trade_preimage_not_sufficient_balance() {
     assert!(!rc.0.is_success(), "trade_preimage success, but should fail: {}", rc.1);
     let available = MmNumber::from("7.77009773").to_decimal();
     // `required = volume + fee_to_send_taker_payment + dex_fee + fee_to_send_dex_fee`,
-    // where `volume = 7.77`, `fee_to_send_taker_payment = 0.00000393, fee_to_send_dex_fee = 0.00000422`, `dex_fee = 0.01`.
-    // Please note `dex_fee = 7.77 / 777` with dex_fee = 0.01
-    // required = 7.77 + 0.01 (dex_fee) + (0.00000393 + 0.00000422) = 7.78000815
-    let required = MmNumber::from("7.78000815");
+    // where `volume = 7.77`, `fee_to_send_taker_payment = 0.00000393, fee_to_send_dex_fee = 0.00000422`.
+    // With 2% fee rate: dex_fee = 7.77 * 0.02 = 0.1554
+    // required = 7.77 + 0.1554 (dex_fee) + (0.00000393 + 0.00000422) = 7.92540815
+    let required = MmNumber::from("7.92540815");
     expect_not_sufficient_balance(&rc.1, available, required.to_decimal(), Some(BigDecimal::from(0)));
 }
 

--- a/mm2src/mm2_main/tests/docker_tests/z_coin_docker_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/z_coin_docker_tests.rs
@@ -2,7 +2,6 @@ use bitcrypto::dhash160;
 use coins::z_coin::{
     z_coin_from_conf_and_params_with_docker, z_send_dex_fee, ZCoin, ZcoinActivationParams, ZcoinRpcMode,
 };
-use coins::DexFeeBurnDestination;
 use coins::{
     coin_errors::ValidatePaymentError, CoinProtocol, DexFee, PrivKeyBuildPolicy, RefundPaymentArgs, SendPaymentArgs,
     SpendPaymentArgs, SwapOps, SwapTxTypeWithSecretHash, ValidateFeeArgs,
@@ -176,6 +175,7 @@ async fn zombie_coin_send_standard_dex_fee() {
     drop(_lock)
 }
 
+/// Tests sending a ZCoin DEX fee with Standard fee (burn disabled).
 #[tokio::test(flavor = "current_thread")]
 async fn zombie_coin_send_dex_fee() {
     let _lock = GEN_TX_LOCK_MUTEX_ADDR2.lock().await;
@@ -183,16 +183,14 @@ async fn zombie_coin_send_dex_fee() {
 
     assert!(coin.is_sapling_state_synced().await);
 
-    let dex_fee = DexFee::WithBurn {
-        fee_amount: "0.0075".into(),
-        burn_amount: "0.0025".into(),
-        burn_destination: DexFeeBurnDestination::PreBurnAccount,
-    };
-    let tx = z_send_dex_fee(&coin, dex_fee, &[1; 16]).await.unwrap();
+    let tx = z_send_dex_fee(&coin, DexFee::Standard("0.02".into()), &[1; 16])
+        .await
+        .unwrap();
     log!("dex fee tx {}", tx.txid());
     drop(_lock);
 }
 
+/// Tests ZCoin DEX fee validation with Standard fees (burn disabled).
 #[tokio::test(flavor = "current_thread")]
 async fn zombie_coin_validate_dex_fee() {
     let _lock = GEN_TX_LOCK_MUTEX.lock().await;
@@ -200,20 +198,14 @@ async fn zombie_coin_validate_dex_fee() {
 
     assert!(coin.is_sapling_state_synced().await);
 
-    let tx = z_send_dex_fee(
-        &coin,
-        DexFee::WithBurn {
-            fee_amount: "0.0075".into(),
-            burn_amount: "0.0025".into(),
-            burn_destination: DexFeeBurnDestination::PreBurnAccount,
-        },
-        &[1; 16],
-    )
-    .await
-    .unwrap();
+    // Test standard dex fee (burn is disabled)
+    let tx = z_send_dex_fee(&coin, DexFee::Standard("0.02".into()), &[1; 16])
+        .await
+        .unwrap();
     log!("dex fee tx {}", tx.txid());
     let tx = tx.into();
 
+    // Invalid amount should return an error
     let validate_fee_args = ValidateFeeArgs {
         fee_tx: &tx,
         expected_sender: &[],
@@ -221,7 +213,6 @@ async fn zombie_coin_validate_dex_fee() {
         min_block_number: 12000,
         uuid: &[1; 16],
     };
-    // Invalid amount should return an error
     let err = coin.validate_fee(validate_fee_args).await.unwrap_err().into_inner();
     match err {
         ValidatePaymentError::WrongPaymentTx(err) => assert!(err.contains("invalid amount")),
@@ -229,11 +220,7 @@ async fn zombie_coin_validate_dex_fee() {
     }
 
     // Invalid memo should return an error
-    let expected_fee = DexFee::WithBurn {
-        fee_amount: "0.0075".into(),
-        burn_amount: "0.0025".into(),
-        burn_destination: DexFeeBurnDestination::PreBurnAccount,
-    };
+    let expected_fee = DexFee::Standard("0.02".into());
 
     let validate_fee_args = ValidateFeeArgs {
         fee_tx: &tx,
@@ -249,7 +236,7 @@ async fn zombie_coin_validate_dex_fee() {
         _ => panic!("Expected `WrongPaymentTx`: {:?}", err),
     }
 
-    // Success validation
+    // Success validation with correct amount and memo
     let validate_fee_args = ValidateFeeArgs {
         fee_tx: &tx,
         expected_sender: &[],
@@ -259,15 +246,14 @@ async fn zombie_coin_validate_dex_fee() {
     };
     coin.validate_fee(validate_fee_args).await.unwrap();
 
-    // Test old standard dex fee with no burn output
-    // TODO: disable when the upgrade transition period ends
+    // Test with different fee amount
     let tx_2 = z_send_dex_fee(&coin, DexFee::Standard("0.00879999".into()), &[1; 16])
         .await
         .unwrap();
     log!("dex fee tx {}", tx_2.txid());
     let tx_2 = tx_2.into();
 
-    // Success validation
+    // Wrong expected amount should fail
     let validate_fee_args = ValidateFeeArgs {
         fee_tx: &tx_2,
         expected_sender: &[],
@@ -281,7 +267,7 @@ async fn zombie_coin_validate_dex_fee() {
         _ => panic!("Expected `WrongPaymentTx`: {:?}", err),
     }
 
-    // Success validation
+    // Correct expected amount should succeed
     let expected_std_fee = DexFee::Standard("0.00879999".into());
     let validate_fee_args = ValidateFeeArgs {
         fee_tx: &tx_2,

--- a/mm2src/mm2_p2p/AGENTS.md
+++ b/mm2src/mm2_p2p/AGENTS.md
@@ -120,7 +120,7 @@ P2PContext::new(cmd_tx, keypair).store_to_mm_arc(&ctx);
 - **Mesh maintenance**: Relays maintain `mesh_n_low..mesh_n_high` connections (4-12 for relays, 2-6 for light)
 - **Dial cooldown**: Recently dialed peers are skipped for 5 minutes (`DIAL_RETRY_DELAY = 300s`)
 - **Message size**: Max ~1MB per message (`MAX_BUFFER_SIZE = 1024 * 1024 - 100`)
-- **Default netid**: 8762 (`DEFAULT_NETID`)
+- **Default netid**: 6133 (`DEFAULT_NETID`)
 - **Announce interval**: Peer address announcements every 600s
 
 ## Request-Response Pattern

--- a/mm2src/mm2_p2p/src/behaviours/atomicdex.rs
+++ b/mm2src/mm2_p2p/src/behaviours/atomicdex.rs
@@ -61,7 +61,7 @@ const CONNECTED_RELAYS_CHECK_INTERVAL: Duration = Duration::from_secs(30);
 const ANNOUNCE_INTERVAL: Duration = Duration::from_secs(600);
 const ANNOUNCE_INITIAL_DELAY: Duration = Duration::from_secs(60);
 const CHANNEL_BUF_SIZE: usize = 1024 * 8;
-const DEFAULT_NETID: u16 = 8762;
+const DEFAULT_NETID: u16 = 6133;
 
 /// Used in time validation logic for each peer which runs immediately  after the
 /// `ConnectionEstablished` event.
@@ -79,7 +79,8 @@ lazy_static! {
 }
 
 pub const DEPRECATED_NETID_LIST: &[u16] = &[
-    7777, // TODO: keep it inaccessible until Q2 of 2024.
+    7777, // Deprecated since netid migration to 8762
+    8762, // Deprecated since netid migration to 6133
 ];
 
 /// The structure is the same as `PeerResponse`,

--- a/mm2src/mm2_test_helpers/Cargo.toml
+++ b/mm2src/mm2_test_helpers/Cargo.toml
@@ -13,6 +13,7 @@ common = { path = "../common" }
 crypto = { path = "../crypto" }
 db_common = { path = "../db_common" }
 futures = { version = "0.3", package = "futures", features = ["compat", "async-await", "thread-pool"] }
+hex = "0.4.2"
 http = "0.2"
 lazy_static = "1.4"
 mm2_core = { path = "../mm2_core" }

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -168,6 +168,16 @@ pub const TAKER_ERROR_EVENTS: [&str; 17] = [
     "TakerPaymentRefundFinished",
 ];
 
+/// Legacy DEX fee public key - used in tests to validate historical transactions
+/// that were sent to the old fee address before the fee update.
+pub const DEX_FEE_ADDR_PUBKEY_LEGACY: &str = "03bc2c7ba671bae4a6fc835244c9762b41647b9827d4780a89a949b984a8ddcc06";
+
+lazy_static! {
+    /// Legacy DEX fee raw pubkey bytes for test fixtures
+    pub static ref DEX_FEE_ADDR_RAW_PUBKEY_LEGACY: Vec<u8> =
+        hex::decode(DEX_FEE_ADDR_PUBKEY_LEGACY).expect("DEX_FEE_ADDR_PUBKEY_LEGACY is expected to be a hexadecimal string");
+}
+
 pub const RICK: &str = "RICK";
 pub const RICK_ELECTRUM_ADDRS: &[&str] = &[
     "electrum1.cipig.net:10017",

--- a/mm2src/mm2_test_helpers/src/for_tests.rs
+++ b/mm2src/mm2_test_helpers/src/for_tests.rs
@@ -171,11 +171,17 @@ pub const TAKER_ERROR_EVENTS: [&str; 17] = [
 /// Legacy DEX fee public key - used in tests to validate historical transactions
 /// that were sent to the old fee address before the fee update.
 pub const DEX_FEE_ADDR_PUBKEY_LEGACY: &str = "03bc2c7ba671bae4a6fc835244c9762b41647b9827d4780a89a949b984a8ddcc06";
+/// Legacy DEX burn public key - used in tests to validate historical transactions
+/// that were sent to the old burn address before the fee update.
+pub const DEX_BURN_ADDR_PUBKEY_LEGACY: &str = "0369aa10c061cd9e085f4adb7399375ba001b54136145cb748eb4c48657be13153";
 
 lazy_static! {
     /// Legacy DEX fee raw pubkey bytes for test fixtures
     pub static ref DEX_FEE_ADDR_RAW_PUBKEY_LEGACY: Vec<u8> =
         hex::decode(DEX_FEE_ADDR_PUBKEY_LEGACY).expect("DEX_FEE_ADDR_PUBKEY_LEGACY is expected to be a hexadecimal string");
+    /// Legacy DEX burn raw pubkey bytes for test fixtures
+    pub static ref DEX_BURN_ADDR_RAW_PUBKEY_LEGACY: Vec<u8> =
+        hex::decode(DEX_BURN_ADDR_PUBKEY_LEGACY).expect("DEX_BURN_ADDR_PUBKEY_LEGACY is expected to be a hexadecimal string");
 }
 
 pub const RICK: &str = "RICK";


### PR DESCRIPTION
## Summary

Updates the global DEX fee configuration:
- Change fee rate from ~0.129% (1/777) to 2% for standard trades
- **GLEEC fee discount**: 1% fee rate (50% off) when either base or rel is GLEEC
- Update DEX fee pubkey to `0348685437335ec43ba6211caf848576ca3d34abbe9e089f861471b4ed9ee9bbd1`
- Update Z-address for ZCash/ARRR shielded fee collection
- Disable burn feature (preserve code for future re-enablement)
- Remove KMD fee discount/exemption, replace with GLEEC discount

### Netid Migration

- Change default netid from `8762` to `6133` ("GLEE" in leet-speak)
- Add `8762` to deprecated netid list (same pattern as `7777` → `8762` migration)
- Update `adex_cli` default and help messages

### Breaking Changes

⚠️ **This release is incompatible with older client versions.**

- Swaps between clients running different versions will fail validation (fee address mismatch)
- Clients on netid 8762 will not connect to clients on netid 6133
- All GUIs and clients must be updated together when this is deployed

### Addresses Derived from New Pubkey

| Chain | Address |
|-------|---------|
| GLEEC | `RR1RS8UFiufoLe9hwZgSBTjutiZvKV62v5` |
| BTC | `1GjEMcay85sEGdnWUPhK5wQi8T7KkBvQG2` |
| EVM | `0x2CA50934E704624e3e035056d066C887abc123bd` |

Z-Address: `zs18egqw99pw5846jfrqntu4neup4hjjchx874j6krmeq88yh4adws9djmuplg5hfx9f0wdsscgr5j`

### TODOs

- [x] **Netid change**: Deploying the new fee pubkey requires a netid change so old and new clients don't mix on the same network
- [ ] **SIA DEX fee address**: Add SIA dex fee address once SIA is released (in GUI SIA PR / test wallet)

### Fee Discount

The `dex_fee_rate(base, rel)` function applies a ticker-based discount:
- **Standard rate**: 2% for all trades
- **GLEEC discount**: 1% when either base or rel is GLEEC (50% off)
- In test mode, `MYCOIN_FEE_DISCOUNT` env var adds MYCOIN to the discount list

The `MaxTakerVolRequest.trade_with` field is restored to active use for pair-aware fee calculation.

---

## Test Updates

All tests have been updated to work with the new configuration:

### Fee Rate Changes (2% standard, 1% GLEEC discount)
- `test_dex_fee_amount` - Updated expected values for 2% rate, added GLEEC discount cases
- `test_max_taker_vol_from_available` - Updated max volume calculations with GLEEC boundary values
- `test_with_burn_fee_calculation` - Verifies 2% rate and 75/25 burn split for non-discount coins
- `test_gleec_taker_dex_fee_calculation` - Verifies 1% GLEEC discount with burn split
- `test_dex_fee_from_taker_coin_discount` - Verifies MYCOIN_FEE_DISCOUNT env var behavior
- Docker tests (`utxo_swaps_v1_tests`, `swap_proto_v2_tests`) - Updated fee expectations

### V2 Swap NoFee
- NoFee branches for GLEEC in V2 maker/taker swaps are commented out with NOTE comments for future reference, replaced by the discount-based fee calculation

### Address Validation Tests
Tests that validate historical transaction fixtures now mock the DEX fee address to return the legacy pubkey:
- `qrc20_tests::test_validate_fee`
- `tendermint_coin::validate_taker_fee_test` / `validate_taker_fee_with_burn_test`
- `utxo_tests::test_validate_old_fee_tx` / `test_validate_fee_bch_70_bytes_signature`
- `z_unit_tests::test_validate_zcoin_dex_fee`

### ZCoin Changes
- Added mockable `dex_fee_addr()` and `dex_burn_addr()` methods for test mocking
- Docker tests now use `Standard` fees (burn disabled)
- Unit tests use mocking to test `WithBurn` validation with legacy addresses

### Swap Watcher Tests
- Updated balance assertions to account for non-refundable 2% DEX fee

### Legacy Constants
- Moved `DEX_FEE_ADDR_PUBKEY_LEGACY` and `DEX_FEE_ADDR_RAW_PUBKEY_LEGACY` to `mm2_test_helpers` crate

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)