### PR TITLE
chore(release): bump kdf version to 3.0.0-beta and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,51 @@
+## v3.0.0-beta - 2026-03-06
+
+### Features:
+
+**TRON Wallet-Only Support**:
+- Added initial TRON blockchain integration with HD wallet activation, TRC20 token support, transaction signing, fee estimation, and withdrawals. [#2467](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2467) [#2712](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2712) [#2714](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2714)
+
+**WalletConnect**:
+- Implemented BTC/UTXO transaction signing and legacy swap (v1) support via WalletConnect. [#2566](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2566)
+
+**UTXO**:
+- Added RXD `ForkIdRxd` sighash signing path for Radiant chain support. [#2713](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2713)
+
+---
+
+### Enhancements/Fixes:
+
+**EVM / ETH**:
+- Added SafeERC20 V1 USDT support and docker tests. [#2711](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2711)
+
+---
+
+### Other Changes:
+
+**Infrastructure / CI**:
+- Migrated service endpoints to gleec.com. [#2704](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2704)
+- Migrated docker image push to GLEEC organization. [#2705](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2705)
+- Split docker tests into feature-gated parallel suites. [#2707](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2707)
+- Removed review reminder bot. [#2706](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2706)
+
+**Documentation**:
+- Added AGENTS.md documentation across key crates. [#2465](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2465)
+
+**Legal**:
+- Updated LICENSE IP ownership.
+
+---
+
+### NB - Backwards compatibility breaking changes:
+
+**P2P Network**:
+- Default P2P netid changed from 8762 to 6133 as part of GLEEC rebranding; netid 8762 added to the deprecated list. Nodes on the old default netid will no longer discover peers on the new default. [#2710](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2710)
+
+**Dex Fees**:
+- Dex fee rate updated to 2% with a 1% discount for GLEEC; fee collection addresses migrated to GLEEC. [#2710](https://github.com/KomodoPlatform/komodo-defi-framework/pull/2710)
+
+---
+
 ## v2.6.0-beta - 2025-11-28
 
 ### Features:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "mm2_bin_lib"
-version = "2.6.0-beta"
+version = "3.0.0-beta"
 dependencies = [
  "chrono",
  "common",

--- a/mm2src/mm2_bin_lib/Cargo.toml
+++ b/mm2src/mm2_bin_lib/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "mm2_bin_lib"
-version = "2.6.0-beta"
+version = "3.0.0-beta"
 authors = ["James Lee", "Artem Pikulin", "Artem Grinblat", "Omar S.", "Onur Ozkan", "Alina Sharon", "Caglar Kaya", "Cipi", "Sergey Boiko", "Samuel Onoja", "Roman Sztergbaum", "Kadan Stadelmann <ca333@komodoplatform.com>", "Dimxy", "Omer Yacine", "DeckerSU", "dragonhound <smk@komodoplatform>", "Guru Charan Gupta", "Devin AI"]
 edition = "2018"
 default-run = "kdf"


### PR DESCRIPTION
## Summary
- Bumps KDF version from `2.6.0-beta` to `3.0.0-beta` in `mm2_bin_lib/Cargo.toml` and `Cargo.lock`
- Adds `v3.0.0-beta - 2026-03-06` changelog section covering all PRs merged since v2.6.0-beta

## Changes covered in changelog

**Features:** TRON wallet-only support (#2467, #2712, #2714), WalletConnect BTC/UTXO signing & swaps (#2566), RXD ForkIdRxd sighash (#2713)

**Enhancements/Fixes:** SafeERC20 V1 USDT support (#2711)

**Breaking Changes:** Default netid 8762→6133, dex fee rate to 2% with GLEEC discount, fee addresses migrated (#2710)

**Other:** gleec.com endpoint migration (#2704), docker image push migration (#2705), AGENTS.md docs (#2465), docker test split (#2707), review bot removal (#2706), LICENSE update

## Test plan
- [x] `cargo check -p mm2_bin_lib` passes
- [x] Verify changelog formatting renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)