### PR TITLE
chore(dex-fee): update DEX fee addresses to new GLEEC keys

### DIFF
--- a/mm2src/coins/z_coin.rs
+++ b/mm2src/coins/z_coin.rs
@@ -135,9 +135,9 @@ macro_rules! try_ztx_s {
 }
 
 const DEX_FEE_OVK: OutgoingViewingKey = OutgoingViewingKey([7; 32]);
-const DEX_FEE_Z_ADDR: &str = "zs18egqw99pw5846jfrqntu4neup4hjjchx874j6krmeq88yh4adws9djmuplg5hfx9f0wdsscgr5j";
+const DEX_FEE_Z_ADDR: &str = "zs1lgdrlg6kv6lmf0n9ps2uhj6sc8rdn30vx44qzu7hqa5ms4a4fwytlr8yuwrqyvhk6l6r5fevw50";
 /// Burn disabled - using same address as fee address
-const DEX_BURN_Z_ADDR: &str = "zs18egqw99pw5846jfrqntu4neup4hjjchx874j6krmeq88yh4adws9djmuplg5hfx9f0wdsscgr5j";
+const DEX_BURN_Z_ADDR: &str = "zs1lgdrlg6kv6lmf0n9ps2uhj6sc8rdn30vx44qzu7hqa5ms4a4fwytlr8yuwrqyvhk6l6r5fevw50";
 
 cfg_native!(
     #[cfg(test)]

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -220,10 +220,10 @@ pub const APPLICATION_GRPC_WEB_TEXT_PROTO: &str = "application/grpc-web-text+pro
 pub const SATOSHIS: u64 = 100_000_000;
 
 /// Dex fee public key for chains where SECP256K1 is supported
-pub const DEX_FEE_ADDR_PUBKEY: &str = "0348685437335ec43ba6211caf848576ca3d34abbe9e089f861471b4ed9ee9bbd1";
+pub const DEX_FEE_ADDR_PUBKEY: &str = "03a778d9bd346fa704cf3e2508cd074d93a1bbc1e504fbecbb0a8d48e7cccbbf5c";
 /// Public key to collect the burn part of dex fee, for chains where SECP256K1 is supported
 /// Burn currently disabled - using same address as fee address in case there is a bug that enables burn (can be re-enabled later)
-pub const DEX_BURN_ADDR_PUBKEY: &str = "0348685437335ec43ba6211caf848576ca3d34abbe9e089f861471b4ed9ee9bbd1";
+pub const DEX_BURN_ADDR_PUBKEY: &str = "03a778d9bd346fa704cf3e2508cd074d93a1bbc1e504fbecbb0a8d48e7cccbbf5c";
 
 // TODO: Update ED25519 pubkey for Sia when GUI support is added
 pub const DEX_FEE_PUBKEY_ED25519: &str = "77b0936728f63257b074c7b3fb2c4fad98df345f57de1ec418fc42619e4e29f8";


### PR DESCRIPTION
## Summary
- Updates DEX fee/burn compressed pubkey (`DEX_FEE_ADDR_PUBKEY`, `DEX_BURN_ADDR_PUBKEY`) to new GLEEC key
- Updates ARRR shielded fee/burn z-addresses (`DEX_FEE_Z_ADDR`, `DEX_BURN_Z_ADDR`) to new GLEEC key

### New addresses derived from the updated pubkey:
- **GLEEC**: `RTi1jm4tmXKq69cUSHYhrEdci5VoSiWRSm`
- **ETH**: `0x345218DfB195a97B40421f457C300A6cdA93F8a3`
- **ARRR**: `zs1lgdrlg6kv6lmf0n9ps2uhj6sc8rdn30vx44qzu7hqa5ms4a4fwytlr8yuwrqyvhk6l6r5fevw50`

🤖 Generated with [Claude Code](https://claude.com/claude-code)