### PR TITLE
fix(mm2_main): restore lightning build by enabling coins/utxo-walletconnect feature

### DIFF
--- a/mm2src/mm2_main/Cargo.toml
+++ b/mm2src/mm2_main/Cargo.toml
@@ -76,7 +76,7 @@ cfg-if.workspace = true
 chain = { path = "../mm2_bitcoin/chain", default-features = false }
 chrono.workspace = true
 clap.workspace = true
-coins = { path = "../coins", default-features = false }
+coins = { path = "../coins", default-features = false, features = ["utxo-walletconnect"] }
 coins_activation = { path = "../coins_activation", default-features = false }
 common = { path = "../common" }
 compatible-time.workspace = true


### PR DESCRIPTION
### Summary
mm2_main currently depends on `coins` with `default-features = false`, which disables coins’ default `utxo-walletconnect` feature.
That feature enables `chain/ext-bitcoin`, which provides `From<chain::Transaction/BlockHeader> for bitcoin::...` chain::Transaction/BlockHeader for bitcoin::... conversions used by lightning code paths.

As a result, cargo build -p mm2_main on dev fails with conversion errors in:
* ln_events.rs
* ln_platform.rs
 
This PR applies the minimal wiring fix by explicitly enabling `coins/utxo-walletconnect` in `mm2_main` dependency configuration.

### Root cause
Feature-coupling gap introduced when mm2_main switched to:
```coins = { path = "../coins", default-features = false }```
without explicitly enabling the feature that brings required `chain/ext-bitcoin` interop for lightning compile paths.
Most likely, it was part of the commit f86c911a63 (merged Jan 12, 2026 via PR #2566).

### Fix
In `Cargo.toml`:
```coins = { path = "../coins", default-features = false, features = ["utxo-walletconnect"] }```

### Verification
* Before fix: `cargo build -p mm2_main` fails with:
  * E0277 missing `From<chain::BlockHeader> for bitcoin::BlockHeader` chain::BlockHeader for bitcoin::BlockHeader
  * E0277 missing `From<chain::Transaction> for bitcoin::Transaction` chain::Transaction for bitcoin::Transaction
  * E0308 mismatched tx type conversion
* After fix: cargo build -p mm2_main passes locally.
 
### Known tradeoff
The goal of this PR was to prepare a fix as **the quickest, minimal and low-risk resolution of the problem**:
* One-line dependency feature wiring change.
* No Rust logic changes.
* No API changes.
* Restores expected conversion impl availability in current architecture.

However, this fix keeps the current coupling where lightning compile viability depends on `utxo-walletconnect` enabling `chain/ext-bitcoin`.
A later cleanup could introduce a narrower dedicated feature for lightning’s conversion needs.

### Out of scope
* Refactoring feature architecture in `coins`/`chain`
* Decoupling lightning conversion requirements from walletconnect features
* Any runtime behavior changesSummary