### PR TITLE
feat(tron): gasFree gasless TRC-20 transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,12 +125,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android-tzdata"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,11 +852,10 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
@@ -2059,7 +2052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6255,7 +6248,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9451,9 +9444,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-result"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -972,6 +972,7 @@ dependencies = [
  "group 0.8.0",
  "gstuff",
  "hex",
+ "hmac 0.12.1",
  "http 0.2.12",
  "hyper 0.14.26",
  "hyper-rustls 0.24.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ dependencies = [
  "mm2_core",
  "mm2_db",
  "mm2_err_handle",
+ "mm2_eth",
  "mm2_event_stream",
  "mm2_io",
  "mm2_metamask",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ byteorder = "1.3"
 cbc = "0.1.2"
 cc = "1.0"
 cipher = "0.4.4"
-chrono = { version = "0.4.41", default-features = false }
+chrono = { version = "0.4.44", default-features = false }
 cfg-if = "1.0"
 clap = { version = "4.5", default-features = false, features = ["derive", "std"] }
 cosmrs = { version = "0.16", default-features = false }

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -75,6 +75,7 @@ libc.workspace = true
 nom.workspace = true
 mm2_core = { path = "../mm2_core" }
 mm2_err_handle = { path = "../mm2_err_handle" }
+mm2_eth = { path = "../mm2_eth" }
 mm2_event_stream = { path = "../mm2_event_stream" }
 mm2_io = { path = "../mm2_io" }
 mm2_metrics = { path = "../mm2_metrics" }

--- a/mm2src/coins/Cargo.toml
+++ b/mm2src/coins/Cargo.toml
@@ -64,6 +64,7 @@ futures = { workspace = true, features = ["compat", "async-await"] }
 group.workspace = true
 gstuff.workspace = true
 hex.workspace = true
+hmac.workspace = true
 http.workspace = true
 itertools = { workspace = true, features = ["use_std"] }
 jsonrpc-core.workspace = true

--- a/mm2src/coins/coin_balance.rs
+++ b/mm2src/coins/coin_balance.rs
@@ -88,6 +88,7 @@ where
             CoinBalanceReport::Iguana(IguanaWalletBalance {
                 ref address,
                 ref balance,
+                ..
             }) => iter::once((address.clone(), balance.get_total_for_ticker(ticker))).collect(),
             CoinBalanceReport::HD(HDWalletBalance { ref accounts }) => accounts
                 .iter()
@@ -106,10 +107,13 @@ where
 
 /// `IguanaWalletBalance` represents the balance of an Iguana wallet.
 /// The BalanceObject generic parameter can be any type that represents the balance/s of a single address.
+// TODO: `gasfree_address` is TRON-specific; see the same TODO on `HDAddressBalance`.
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct IguanaWalletBalance<BalanceObject> {
     pub address: String,
     pub balance: BalanceObject,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gasfree_address: Option<String>,
 }
 
 /// Represents the balance of an HD wallet.
@@ -140,12 +144,16 @@ pub enum HDAccountBalanceEnum {
 }
 
 /// Represents the balance of a single address in an HD wallet.
+// TODO: `gasfree_address` is TRON-specific but lives on this shared struct used by all coins.
+// Consider refactoring to something more generic like an `AddressMetadata` parameter.
 #[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct HDAddressBalance<BalanceObject> {
     pub address: String,
     pub derivation_path: RpcDerivationPath,
     pub chain: Bip44Chain,
     pub balance: BalanceObject,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gasfree_address: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
@@ -195,9 +203,15 @@ where
                 .iguana_balances()
                 .await
                 .map(|balance| {
+                    // TODO: `gasfree_address` is left as `None` here because this generic blanket
+                    // impl cannot call EthCoin-specific helpers. The sole caller today is UTXO
+                    // tx history, which doesn't need it. If TRON Iguana coins ever call this,
+                    // add an EthCoin override or add a `HDWalletBalanceOps::address_metadata`
+                    // hook.
                     CoinBalanceReport::Iguana(IguanaWalletBalance {
                         address: my_address.to_string(),
                         balance,
+                        gasfree_address: None,
                     })
                 })
                 .mm_err(BalanceError::from),
@@ -248,9 +262,16 @@ where
                 .iguana_balances()
                 .await
                 .map(|balance| {
+                    // TODO: `gasfree_address` is left as `None` here because this generic blanket
+                    // impl cannot call EthCoin-specific helpers. Callers that may reach this
+                    // branch with ETH/TRON (e.g. `init_erc20_token_activation.rs` for single-address
+                    // TRC20 token init) call `EthCoin::enrich_balance_report_with_gasfree`
+                    // on the returned report before serializing it to the user. A cleaner
+                    // long-term fix is an `HDWalletBalanceOps::address_metadata` hook.
                     CoinBalanceReport::Iguana(IguanaWalletBalance {
                         address: my_address.display_address(),
                         balance,
+                        gasfree_address: None,
                     })
                 })
                 .mm_err(EnableCoinBalanceError::from),
@@ -367,6 +388,7 @@ pub trait HDWalletBalanceOps: HDWalletCoinOps {
                 derivation_path: RpcDerivationPath(derivation_path),
                 chain,
                 balance,
+                gasfree_address: None,
             })
             .collect();
         Ok(balances)
@@ -642,6 +664,7 @@ pub mod common_impl {
                 derivation_path: RpcDerivationPath(hd_address.derivation_path().clone()),
                 chain,
                 balance: HDWalletBalanceObject::<Coin>::new(),
+                gasfree_address: None,
             });
             addresses_to_request.push(hd_address.address().clone());
         }

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -118,6 +118,7 @@ use std::str::from_utf8;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
+use tron::gasfree::TronGaslessProviderConfig;
 use web3::types::{
     Action as TraceAction, BlockId, BlockNumber, Bytes, CallRequest, FilterBuilder, Log, Trace, TraceFilterBuilder,
     Transaction as Web3Transaction, TransactionId, U64,
@@ -1081,6 +1082,11 @@ pub struct EthCoinImpl {
     pub(crate) gas_limit_v2: EthGasLimitV2,
     /// If not None, gas limit is obtained from eth_estimateGas and multiplied by this value, for swap transactions
     pub(crate) estimate_gas_mult: Option<f64>,
+    /// TRON GasFree provider for this platform coin. `None` for EVM chains
+    /// or when gasless is not configured. Tokens can access this when withdrawing
+    /// via `platform_coin()`.
+    #[allow(dead_code)]
+    pub(crate) tron_gasless_provider: Option<TronGaslessProviderConfig>,
     /// This spawner is used to spawn coin's related futures that should be aborted on coin deactivation
     /// and on [`MmArc::stop`].
     pub abortable_system: AbortableQueue,
@@ -7215,6 +7221,7 @@ pub async fn eth_coin_from_conf_and_request(
         gas_limit,
         gas_limit_v2,
         estimate_gas_mult,
+        tron_gasless_provider: None,
         abortable_system,
     };
 
@@ -8198,6 +8205,7 @@ impl EthCoin {
             gas_limit: EthGasLimit::default(),
             gas_limit_v2: EthGasLimitV2::default(),
             estimate_gas_mult: None,
+            tron_gasless_provider: self.tron_gasless_provider.clone(),
             abortable_system: self.abortable_system.create_subsystem().unwrap(),
         };
         EthCoin(Arc::new(coin))

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -25,8 +25,8 @@ use super::eth::Action::{Call, Create};
 use super::watcher_common::{validate_watcher_reward, REWARD_GAS_AMOUNT, REWARD_OVERPAY_FACTOR};
 use super::*;
 use crate::coin_balance::{
-    EnableCoinBalanceError, EnabledCoinBalanceParams, HDAccountBalance, HDAddressBalance, HDWalletBalance,
-    HDWalletBalanceOps,
+    BalanceObjectOps, CoinBalanceReport, EnableCoinBalanceError, EnabledCoinBalanceParams, HDAccountBalance,
+    HDAddressBalance, HDWalletBalance, HDWalletBalanceOps,
 };
 use crate::eth::eth_utils::nonce_sequencer::PerNetNonceLocks;
 use crate::eth::web3_transport::websocket_transport::{WebsocketTransport, WebsocketTransportNode};
@@ -118,7 +118,7 @@ use std::str::from_utf8;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
-use tron::gasfree::TronGaslessProviderConfig;
+use tron::gasfree::ResolvedTronGaslessProvider;
 use web3::types::{
     Action as TraceAction, BlockId, BlockNumber, Bytes, CallRequest, FilterBuilder, Log, Trace, TraceFilterBuilder,
     Transaction as Web3Transaction, TransactionId, U64,
@@ -209,6 +209,7 @@ use eth_swap_v2::{extract_id_from_tx_data, EthPaymentType, PaymentMethod, SpendT
 pub mod eth_utils;
 
 pub mod tron;
+use tron::gasfree::compute_gasfree_address_for_network;
 use tron::{normalize_tron_raw_tx_hex, validate_tron_raw_tx_len, TronAddress};
 
 pub mod chain_rpc;
@@ -1085,8 +1086,7 @@ pub struct EthCoinImpl {
     /// TRON GasFree provider for this platform coin. `None` for EVM chains
     /// or when gasless is not configured. Tokens can access this when withdrawing
     /// via `platform_coin()`.
-    #[allow(dead_code)]
-    pub(crate) tron_gasless_provider: Option<TronGaslessProviderConfig>,
+    pub(crate) tron_gasless_provider: Option<ResolvedTronGaslessProvider>,
     /// This spawner is used to spawn coin's related futures that should be aborted on coin deactivation
     /// and on [`MmArc::stop`].
     pub abortable_system: AbortableQueue,
@@ -1159,6 +1159,42 @@ impl EthCoinImpl {
         match &self.rpc_client {
             Some(chain_rpc::ChainRpcClient::Tron(tron)) => Some(tron),
             _ => None,
+        }
+    }
+
+    /// Compute the GasFree receive address for a displayed user address, if applicable.
+    ///
+    /// Returns `Some(base58_address)` when the platform coin is TRON and a GasFree
+    /// provider is configured. Returns `None` otherwise.
+    pub fn compute_gasfree_for_display(&self, user_address: &str) -> Option<String> {
+        let network = match &self.chain_spec {
+            ChainSpec::Tron { network } => network,
+            _ => return None,
+        };
+        // Provider presence gate — `None` means GasFree is not configured for this coin.
+        self.tron_gasless_provider.as_ref()?;
+        // Parse should never fail — callers should pass valid addresses from the coin.
+        let user = TronAddress::from_str(user_address).ok()?;
+        Some(compute_gasfree_address_for_network(network, &user).to_base58())
+    }
+
+    /// Enrich all address entries in a `CoinBalanceReport` with GasFree addresses.
+    /// Handles both HD and Iguana variants. No-op for non-TRON coins or when GasFree is not configured.
+    pub fn enrich_balance_report_with_gasfree<B>(&self, report: &mut CoinBalanceReport<B>)
+    where
+        B: BalanceObjectOps,
+    {
+        match report {
+            CoinBalanceReport::HD(hd) => {
+                for account in &mut hd.accounts {
+                    for addr in &mut account.addresses {
+                        addr.gasfree_address = self.compute_gasfree_for_display(&addr.address);
+                    }
+                }
+            },
+            CoinBalanceReport::Iguana(iguana) => {
+                iguana.gasfree_address = self.compute_gasfree_for_display(&iguana.address);
+            },
         }
     }
 
@@ -7886,7 +7922,9 @@ impl GetNewAddressRpcOps for EthCoin {
         &self,
         params: GetNewAddressParams,
     ) -> MmResult<GetNewAddressResponse<Self::BalanceObject>, GetNewAddressRpcError> {
-        get_new_address::common_impl::get_new_address_rpc_without_conf(self, params).await
+        let mut response = get_new_address::common_impl::get_new_address_rpc_without_conf(self, params).await?;
+        response.new_address.gasfree_address = self.compute_gasfree_for_display(&response.new_address.address);
+        Ok(response)
     }
 
     async fn get_new_address_rpc<ConfirmAddress>(
@@ -7897,7 +7935,9 @@ impl GetNewAddressRpcOps for EthCoin {
     where
         ConfirmAddress: HDConfirmAddress,
     {
-        get_new_address::common_impl::get_new_address_rpc(self, params, confirm_address).await
+        let mut response = get_new_address::common_impl::get_new_address_rpc(self, params, confirm_address).await?;
+        response.new_address.gasfree_address = self.compute_gasfree_for_display(&response.new_address.address);
+        Ok(response)
     }
 }
 
@@ -7909,7 +7949,11 @@ impl AccountBalanceRpcOps for EthCoin {
         &self,
         params: AccountBalanceParams,
     ) -> MmResult<HDAccountBalanceResponse<Self::BalanceObject>, HDAccountBalanceRpcError> {
-        account_balance::common_impl::account_balance_rpc(self, params).await
+        let mut response = account_balance::common_impl::account_balance_rpc(self, params).await?;
+        for addr in &mut response.addresses {
+            addr.gasfree_address = self.compute_gasfree_for_display(&addr.address);
+        }
+        Ok(response)
     }
 }
 
@@ -7921,7 +7965,11 @@ impl InitAccountBalanceRpcOps for EthCoin {
         &self,
         params: InitAccountBalanceParams,
     ) -> MmResult<HDAccountBalance<Self::BalanceObject>, HDAccountBalanceRpcError> {
-        init_account_balance::common_impl::init_account_balance_rpc(self, params).await
+        let mut response = init_account_balance::common_impl::init_account_balance_rpc(self, params).await?;
+        for addr in &mut response.addresses {
+            addr.gasfree_address = self.compute_gasfree_for_display(&addr.address);
+        }
+        Ok(response)
     }
 }
 
@@ -7933,7 +7981,11 @@ impl InitScanAddressesRpcOps for EthCoin {
         &self,
         params: ScanAddressesParams,
     ) -> MmResult<ScanAddressesResponse<Self::BalanceObject>, HDAccountBalanceRpcError> {
-        init_scan_for_new_addresses::common_impl::scan_for_new_addresses_rpc(self, params).await
+        let mut response = init_scan_for_new_addresses::common_impl::scan_for_new_addresses_rpc(self, params).await?;
+        for addr in &mut response.new_addresses {
+            addr.gasfree_address = self.compute_gasfree_for_display(&addr.address);
+        }
+        Ok(response)
     }
 }
 
@@ -7950,7 +8002,12 @@ impl InitCreateAccountRpcOps for EthCoin {
     where
         XPubExtractor: HDXPubExtractor + Send,
     {
-        init_create_account::common_impl::init_create_new_account_rpc(self, params, state, xpub_extractor).await
+        let mut response =
+            init_create_account::common_impl::init_create_new_account_rpc(self, params, state, xpub_extractor).await?;
+        for addr in &mut response.addresses {
+            addr.gasfree_address = self.compute_gasfree_for_display(&addr.address);
+        }
+        Ok(response)
     }
 
     async fn revert_creating_account(&self, account_id: u32) {

--- a/mm2src/coins/eth.rs
+++ b/mm2src/coins/eth.rs
@@ -118,7 +118,7 @@ use std::str::from_utf8;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, Mutex};
-use tron::gasfree::ResolvedTronGaslessProvider;
+use tron::gasfree::{ResolvedTronGaslessProvider, ResolvedTronGaslessTokenConfig};
 use web3::types::{
     Action as TraceAction, BlockId, BlockNumber, Bytes, CallRequest, FilterBuilder, Log, Trace, TraceFilterBuilder,
     Transaction as Web3Transaction, TransactionId, U64,
@@ -1087,6 +1087,8 @@ pub struct EthCoinImpl {
     /// or when gasless is not configured. Tokens can access this when withdrawing
     /// via `platform_coin()`.
     pub(crate) tron_gasless_provider: Option<ResolvedTronGaslessProvider>,
+    /// Token-level TRON GasFree configuration resolved at activation time.
+    pub(crate) tron_gasless_token_config: Option<ResolvedTronGaslessTokenConfig>,
     /// This spawner is used to spawn coin's related futures that should be aborted on coin deactivation
     /// and on [`MmArc::stop`].
     pub abortable_system: AbortableQueue,
@@ -7258,6 +7260,7 @@ pub async fn eth_coin_from_conf_and_request(
         gas_limit_v2,
         estimate_gas_mult,
         tron_gasless_provider: None,
+        tron_gasless_token_config: None,
         abortable_system,
     };
 
@@ -8263,6 +8266,7 @@ impl EthCoin {
             gas_limit_v2: EthGasLimitV2::default(),
             estimate_gas_mult: None,
             tron_gasless_provider: self.tron_gasless_provider.clone(),
+            tron_gasless_token_config: self.tron_gasless_token_config.clone(),
             abortable_system: self.abortable_system.create_subsystem().unwrap(),
         };
         EthCoin(Arc::new(coin))

--- a/mm2src/coins/eth/eth_utils.rs
+++ b/mm2src/coins/eth/eth_utils.rs
@@ -1,8 +1,9 @@
 use super::*;
 use crate::{coin_conf, NumConversError, NumConversResult};
+use bip32::DerivationPath;
 use ethabi::{Function, Token};
 use ethereum_types::{Address, FromDecStrErr, U256};
-use ethkey::{public_to_address, Public};
+use ethkey::{public_to_address, KeyPair, Public};
 use mm2_core::mm_ctx::MmArc;
 use mm2_err_handle::prelude::MapToMmResult;
 use mm2_number::{BigDecimal, MmNumber};
@@ -169,6 +170,26 @@ pub fn wei_from_coins_mm_number(mm_number: &MmNumber, decimals: u8) -> NumConver
 #[allow(unused)]
 pub fn wei_to_coins_mm_number(u256: U256, decimals: u8) -> NumConversResult<MmNumber> {
     Ok(MmNumber::from(u256_to_big_decimal(u256, decimals)?))
+}
+
+/// Derive an HD secp256k1 secret when `derivation_path` is
+/// `Some`, otherwise return a clone of the activated key.
+pub(crate) fn key_pair_from_priv_key_policy(
+    priv_key_policy: &PrivKeyPolicy<KeyPair>,
+    derivation_path: Option<&DerivationPath>,
+) -> Result<KeyPair, String> {
+    match derivation_path {
+        Some(path) => {
+            let raw = priv_key_policy
+                .hd_wallet_derived_priv_key_or_err(path)
+                .map_err(|e| e.to_string())?;
+            KeyPair::from_secret_slice(raw.as_slice()).map_err(|e| e.to_string())
+        },
+        None => priv_key_policy
+            .activated_key_or_err()
+            .cloned()
+            .map_err(|e| e.to_string()),
+    }
 }
 
 pub(super) fn get_conf_param_or_from_plaform_coin<T: DeserializeOwned>(

--- a/mm2src/coins/eth/eth_withdraw.rs
+++ b/mm2src/coins/eth/eth_withdraw.rs
@@ -139,22 +139,13 @@ where
             return MmError::err(WithdrawError::InternalError("no keypair for hw wallet".to_owned()));
         }
 
-        match req.from {
-            Some(ref from) => {
-                let derivation_path = self.get_from_derivation_path(from)?;
-                let raw_priv_key = coin
-                    .priv_key_policy
-                    .hd_wallet_derived_priv_key_or_err(&derivation_path)
-                    .map_mm_err()?;
-                KeyPair::from_secret_slice(raw_priv_key.as_slice())
-                    .map_to_mm(|e| WithdrawError::InternalError(e.to_string()))
-            },
-            None => coin
-                .priv_key_policy
-                .activated_key_or_err()
-                .mm_err(|e| WithdrawError::InternalError(e.to_string()))
-                .cloned(),
-        }
+        let derivation_path = req
+            .from
+            .as_ref()
+            .map(|from| self.get_from_derivation_path(from))
+            .transpose()?;
+        crate::eth::eth_utils::key_pair_from_priv_key_policy(&coin.priv_key_policy, derivation_path.as_ref())
+            .map_to_mm(WithdrawError::InternalError)
     }
 
     /// Gets the derivation path for the address from which the withdrawal is made using the `from` parameter.

--- a/mm2src/coins/eth/eth_withdraw.rs
+++ b/mm2src/coins/eth/eth_withdraw.rs
@@ -2,9 +2,14 @@ use super::{
     u256_from_big_decimal, u256_to_big_decimal, ChainSpec, ChainTaggedAddress, EthCoinType, EthDerivationMethod,
     EthPrivKeyPolicy, Public, WithdrawError, WithdrawRequest, WithdrawResult, ERC20_CONTRACT, H256,
 };
+use crate::eth::tron::gasfree::withdraw::{
+    is_standard_tron_withdraw_unavailable, maybe_build_tron_gasless_withdraw, validate_non_tron_gasless_request,
+    TronGaslessMode,
+};
+use crate::eth::tron::gasfree::GaslessWithdrawError;
 use crate::eth::tron::sign::sign_tron_transaction;
 use crate::eth::tron::withdraw::{
-    build_tron_trc20_withdraw, build_tron_trx_withdraw, validate_tron_fee_policy, TronWithdrawContext,
+    build_standard_tron_withdraw, validate_tron_fee_policy, StandardTronWithdrawParams, TronWithdrawContext,
 };
 use crate::eth::tron::TronAddress;
 use crate::eth::wallet_connect::WcEthTxParams;
@@ -28,6 +33,7 @@ use crypto::hw_rpc_task::HwRpcTaskAwaitingStatus;
 use crypto::trezor::trezor_rpc_task::{TrezorRequestStatuses, TrezorRpcTaskProcessor};
 use crypto::{CryptoCtx, HwRpcError};
 use ethabi::Token;
+use ethereum_types::U256;
 use futures::compat::Future01CompatExt;
 use kdf_walletconnect::{WalletConnectCtx, WalletConnectOps};
 use mm2_core::mm_ctx::MmArc;
@@ -35,6 +41,7 @@ use mm2_err_handle::map_mm_error::MapMmError;
 use mm2_err_handle::mm_error::MmResult;
 use mm2_err_handle::prelude::{MapToMmResult, MmError, MmResultExt, OrMmError};
 use prost::Message;
+use std::convert::TryFrom;
 use std::ops::Deref;
 use std::sync::Arc;
 #[cfg(target_arch = "wasm32")]
@@ -67,6 +74,12 @@ where
     #[allow(clippy::result_large_err)]
     fn on_finishing(&self) -> Result<(), MmError<WithdrawError>>;
 
+    #[allow(clippy::result_large_err)]
+    fn on_fetching_gasless_quote(&self) -> Result<(), MmError<WithdrawError>>;
+
+    #[allow(clippy::result_large_err)]
+    fn on_signing_gasless_authorization(&self) -> Result<(), MmError<WithdrawError>>;
+
     /// Signs the transaction with a Trezor hardware wallet.
     async fn sign_tx_with_trezor(
         &self,
@@ -84,7 +97,7 @@ where
         from_tagged: &ChainTaggedAddress,
         to_tagged: &ChainTaggedAddress,
         tx: TransactionData,
-        amount: ethabi::ethereum_types::U256,
+        amount: U256,
         total_fee: &BigDecimal,
         fee_details: TxFeeDetails,
     ) -> WithdrawResult {
@@ -286,6 +299,7 @@ where
                 "Memo is not yet supported for TRON withdraw (TRON charges 1 TRX burn fee for memo)".to_owned(),
             ));
         }
+        let gasless_mode = TronGaslessMode::try_from(req)?;
 
         // 2. Validate key policy (only Iguana/HDWallet supported for TRON MVP)
         match coin.priv_key_policy {
@@ -314,26 +328,39 @@ where
             .tron_rpc()
             .ok_or_else(|| WithdrawError::InternalError("TRON RPC client is not initialized".to_owned()))?;
 
+        let trc20_contract = match &coin.coin_type {
+            EthCoinType::Eth => None,
+            EthCoinType::Erc20 { token_addr, .. } => Some(TronAddress::from(*token_addr)),
+            EthCoinType::Nft { .. } => {
+                return MmError::err(WithdrawError::ProtocolNotSupported(
+                    "NFT withdraw is not supported for TRON".to_owned(),
+                ))
+            },
+        };
+
+        if gasless_mode == TronGaslessMode::Gasless {
+            let Some(contract_tron) = trc20_contract else {
+                return MmError::err(WithdrawError::Gasless(GaslessWithdrawError::Unavailable));
+            };
+
+            if let Some(details) =
+                maybe_build_tron_gasless_withdraw(self, tron, &from_tagged, &to_tagged, contract_tron, gasless_mode)
+                    .await?
+            {
+                return Ok(details);
+            }
+        }
+
         let my_balance = coin.address_balance(from_tagged).compat().await.map_mm_err()?;
         let my_balance_dec = u256_to_big_decimal(my_balance, coin.decimals).map_mm_err()?;
 
-        if req.max && my_balance.is_zero() {
-            return MmError::err(WithdrawError::ZeroBalanceToWithdrawMax);
-        }
-
         let amount_base_units = if req.max {
+            if my_balance.is_zero() {
+                return MmError::err(WithdrawError::ZeroBalanceToWithdrawMax);
+            }
             my_balance
         } else {
-            let amount = u256_from_big_decimal(&req.amount, coin.decimals).map_mm_err()?;
-            if amount > my_balance {
-                let required_dec = u256_to_big_decimal(amount, coin.decimals).map_mm_err()?;
-                return MmError::err(WithdrawError::NotSufficientBalance {
-                    coin: ticker.to_owned(),
-                    available: my_balance_dec,
-                    required: required_dec,
-                });
-            }
-            amount
+            u256_from_big_decimal(&req.amount, coin.decimals).map_mm_err()?
         };
 
         // 4. Convert addresses to TRON format
@@ -347,7 +374,7 @@ where
         let resources = tron.get_account_resource(&from_tron).await.map_mm_err()?;
         let prices = tron.get_chain_prices().await.map_mm_err()?;
 
-        // 7. Build tx, estimate fees — branching on coin type
+        // 7. Build tx and estimate fees.
         let withdraw_ctx = TronWithdrawContext {
             from: &from_tron,
             to: &to_tron,
@@ -357,24 +384,42 @@ where
             fee_coin: ticker,
             expiration_seconds: req.expiration_seconds,
         };
-        let (raw, tron_fee_details, final_amount) = match &coin.coin_type {
-            EthCoinType::Eth => {
-                build_tron_trx_withdraw(&withdraw_ctx, amount_base_units, my_balance, &my_balance_dec, req.max)?
-            },
-            EthCoinType::Erc20 {
-                token_addr, platform, ..
-            } => {
-                let contract_tron = TronAddress::from(*token_addr);
-                let trc20_ctx = TronWithdrawContext {
-                    fee_coin: platform.as_str(),
-                    ..withdraw_ctx
+        let standard_tron_withdraw_params = StandardTronWithdrawParams {
+            coin_type: &coin.coin_type,
+            ticker,
+            decimals: coin.decimals,
+            balance: my_balance,
+            balance_dec: &my_balance_dec,
+            amount_base_units,
+            is_max: req.max,
+            ctx: &withdraw_ctx,
+            tron,
+        };
+
+        let (raw, tron_fee_details, final_amount) = match build_standard_tron_withdraw(standard_tron_withdraw_params)
+            .await
+        {
+            Ok(prepared) => prepared,
+            Err(standard_fee_route_err) => {
+                if gasless_mode != TronGaslessMode::Auto
+                    || req.max
+                    || !is_standard_tron_withdraw_unavailable(&standard_fee_route_err)
+                {
+                    return Err(standard_fee_route_err);
+                }
+
+                let Some(contract_tron) = trc20_contract else {
+                    return Err(standard_fee_route_err);
                 };
-                build_tron_trc20_withdraw(&trc20_ctx, tron, &contract_tron, amount_base_units).await?
-            },
-            EthCoinType::Nft { .. } => {
-                return MmError::err(WithdrawError::ProtocolNotSupported(
-                    "NFT withdraw is not supported for TRON".to_owned(),
-                ))
+
+                if let Some(details) =
+                    maybe_build_tron_gasless_withdraw(self, tron, &from_tagged, &to_tagged, contract_tron, gasless_mode)
+                        .await?
+                {
+                    return Ok(details);
+                }
+
+                return Err(standard_fee_route_err);
             },
         };
 
@@ -416,6 +461,8 @@ where
         if let ChainSpec::Tron { .. } = coin.chain_spec {
             return self.build_tron_withdraw(from_tagged, to_tagged).await;
         }
+
+        validate_non_tron_gasless_request(&req)?;
 
         // ── EVM withdraw: existing path (unchanged) ──
         let my_balance = coin.address_balance(from_tagged).compat().await.map_mm_err()?;
@@ -603,6 +650,18 @@ impl EthWithdraw for InitEthWithdraw {
             .map_mm_err()
     }
 
+    fn on_fetching_gasless_quote(&self) -> Result<(), MmError<WithdrawError>> {
+        self.task_handle
+            .update_in_progress_status(WithdrawInProgressStatus::FetchingGaslessQuote)
+            .map_mm_err()
+    }
+
+    fn on_signing_gasless_authorization(&self) -> Result<(), MmError<WithdrawError>> {
+        self.task_handle
+            .update_in_progress_status(WithdrawInProgressStatus::SigningGaslessAuthorization)
+            .map_mm_err()
+    }
+
     async fn sign_tx_with_trezor(
         &self,
         derivation_path: &DerivationPath,
@@ -674,6 +733,14 @@ impl EthWithdraw for StandardEthWithdraw {
     }
 
     fn on_finishing(&self) -> Result<(), MmError<WithdrawError>> {
+        Ok(())
+    }
+
+    fn on_fetching_gasless_quote(&self) -> Result<(), MmError<WithdrawError>> {
+        Ok(())
+    }
+
+    fn on_signing_gasless_authorization(&self) -> Result<(), MmError<WithdrawError>> {
         Ok(())
     }
 

--- a/mm2src/coins/eth/for_tests.rs
+++ b/mm2src/coins/eth/for_tests.rs
@@ -94,6 +94,7 @@ fn make_eth_coin(
         gas_limit,
         gas_limit_v2,
         estimate_gas_mult,
+        tron_gasless_provider: None,
         abortable_system: AbortableQueue::default(),
     }))
 }

--- a/mm2src/coins/eth/for_tests.rs
+++ b/mm2src/coins/eth/for_tests.rs
@@ -95,6 +95,7 @@ fn make_eth_coin(
         gas_limit_v2,
         estimate_gas_mult,
         tron_gasless_provider: None,
+        tron_gasless_token_config: None,
         abortable_system: AbortableQueue::default(),
     }))
 }

--- a/mm2src/coins/eth/tron.rs
+++ b/mm2src/coins/eth/tron.rs
@@ -7,6 +7,7 @@ mod address;
 pub mod api;
 pub mod fee;
 pub mod gasfree;
+mod primitives;
 pub(crate) mod proto;
 pub(crate) mod sign;
 pub mod tx_builder;
@@ -20,6 +21,7 @@ mod api_integration_tests;
 
 pub use address::Address as TronAddress;
 pub use api::{BroadcastHexResponse, TaposBlockData, TronApiClient, TronHttpClient, TronHttpNode};
+pub use primitives::{TronSignature, TronTxHash};
 
 use ethabi::Token;
 use ethereum_types::U256;

--- a/mm2src/coins/eth/tron.rs
+++ b/mm2src/coins/eth/tron.rs
@@ -6,6 +6,7 @@
 mod address;
 pub mod api;
 pub mod fee;
+pub mod gasfree;
 pub(crate) mod proto;
 pub(crate) mod sign;
 pub mod tx_builder;
@@ -39,6 +40,17 @@ pub enum Network {
     Mainnet,
     Shasta,
     Nile,
+}
+
+impl Network {
+    /// Numeric chain ID used in TIP-712 typed-data signing.
+    pub fn chain_id(&self) -> u64 {
+        match self {
+            Network::Mainnet => 728126428,
+            Network::Shasta => 2494104990,
+            Network::Nile => 3448148188,
+        }
+    }
 }
 
 /// Hard cap on TRON raw transaction size to prevent oversized-input DoS.

--- a/mm2src/coins/eth/tron/address.rs
+++ b/mm2src/coins/eth/tron/address.rs
@@ -147,8 +147,8 @@ impl<'de> Deserialize<'de> for Address {
     where
         D: Deserializer<'de>,
     {
-        let s = <&str>::deserialize(deserializer)?;
-        Address::from_str(s).map_err(serde::de::Error::custom)
+        let s = String::deserialize(deserializer)?;
+        Address::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 

--- a/mm2src/coins/eth/tron/fee.rs
+++ b/mm2src/coins/eth/tron/fee.rs
@@ -24,6 +24,7 @@ use serde::{Deserialize, Serialize};
 const RESULT_BYTES_OVERHEAD_PER_CONTRACT: u64 = 64;
 /// TRON signatures are 65 bytes (`r || s || v`), used here as estimation placeholder.
 const PLACEHOLDER_SIGNATURE_LEN: usize = 65;
+pub const TRON_GASFREE_PROVIDER_NAME: &str = "gasfree";
 
 /// Fee breakdown for a TRON transaction.
 ///
@@ -37,20 +38,32 @@ pub struct TronTxFeeDetails {
     pub bandwidth_fee: BigDecimal,
     pub energy_fee: BigDecimal,
     pub total_fee: BigDecimal,
-    /// TODO(Commit 9): populated by `build_tron_withdraw` when the gasless branch is taken. Check if it's better to have 2 variants while backward compatible
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub gasless: Option<TronGaslessFeeMeta>,
 }
 
-/// Gasless provider fee metadata for TRC20 withdrawals routed through GasFree.
+/// Fee rail used for TRON gasless fee metadata.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TronGaslessFeeMethod {
+    /// Provider-sponsored TRC20 transfer authorized through GasFree.
+    Gasless,
+}
+
+/// Fee details for TRC20 withdrawals routed through GasFree.
+///
+/// Distinct variant from [`TronTxFeeDetails`] because the user pays the provider
+/// fee in the token itself (no TRX bandwidth/energy) and signs an off-chain
+/// authorization rather than broadcasting on-chain.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct TronGaslessFeeMeta {
-    pub fee_method: String,
-    pub provider: String,
+pub struct TronGaslessFeeDetails {
+    pub coin: String,
+    pub fee_method: TronGaslessFeeMethod,
+    pub provider_name: String,
     pub gasfree_address: String,
     pub transfer_fee: BigDecimal,
     pub activation_fee: BigDecimal,
     pub total_token_fee: BigDecimal,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signed_max_fee: Option<BigDecimal>,
     pub trace_id: Option<String>,
 }
 
@@ -192,7 +205,6 @@ fn estimate_fee_details(
         bandwidth_fee: sun_to_trx_decimal(bandwidth_fee_sun),
         energy_fee: sun_to_trx_decimal(energy_fee_sun),
         total_fee: sun_to_trx_decimal(total_fee_sun),
-        gasless: None,
     }
 }
 

--- a/mm2src/coins/eth/tron/fee.rs
+++ b/mm2src/coins/eth/tron/fee.rs
@@ -37,6 +37,21 @@ pub struct TronTxFeeDetails {
     pub bandwidth_fee: BigDecimal,
     pub energy_fee: BigDecimal,
     pub total_fee: BigDecimal,
+    /// TODO(Commit 9): populated by `build_tron_withdraw` when the gasless branch is taken. Check if it's better to have 2 variants while backward compatible
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gasless: Option<TronGaslessFeeMeta>,
+}
+
+/// Gasless provider fee metadata for TRC20 withdrawals routed through GasFree.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct TronGaslessFeeMeta {
+    pub fee_method: String,
+    pub provider: String,
+    pub gasfree_address: String,
+    pub transfer_fee: BigDecimal,
+    pub activation_fee: BigDecimal,
+    pub total_token_fee: BigDecimal,
+    pub trace_id: Option<String>,
 }
 
 /// Subset of TRON's `AccountResourceMessage` (defined in `api.proto` of the
@@ -177,6 +192,7 @@ fn estimate_fee_details(
         bandwidth_fee: sun_to_trx_decimal(bandwidth_fee_sun),
         energy_fee: sun_to_trx_decimal(energy_fee_sun),
         total_fee: sun_to_trx_decimal(total_fee_sun),
+        gasless: None,
     }
 }
 

--- a/mm2src/coins/eth/tron/gasfree/address.rs
+++ b/mm2src/coins/eth/tron/gasfree/address.rs
@@ -64,6 +64,19 @@ pub fn controller_for_network(network: &Network) -> TronAddress {
     network_artifacts(network).controller
 }
 
+/// Returns the GasFree API path segment for a TRON network.
+///
+/// Mainnet (`tron`) and Nile (`nile`) come from the public protocol spec's base URLs.
+/// Shasta is not listed there, so we mirror the official SDK's network naming and use
+/// `shasta` as the prefix to keep host-only config derivation deterministic.
+pub fn api_path_segment_for_network(network: &Network) -> &'static str {
+    match network {
+        Network::Mainnet => "tron",
+        Network::Nile => "nile",
+        Network::Shasta => "shasta",
+    }
+}
+
 /// Compute the GasFree address for a user on a specific TRON network.
 ///
 /// Infallible: the controller and beacon are hardcoded per network, and

--- a/mm2src/coins/eth/tron/gasfree/address.rs
+++ b/mm2src/coins/eth/tron/gasfree/address.rs
@@ -1,0 +1,210 @@
+//! TRON GasFree CREATE2 address derivation.
+//!
+//! Computes the deterministic GasFree wallet address for a given user EOA
+//! using TRON's CREATE2 formula (0x41 prefix instead of Ethereum's 0xff).
+
+use crate::eth::tron::{Network, TronAddress};
+use bitcrypto::keccak256;
+use ethabi::Token;
+use ethereum_types::H160;
+use lazy_static::lazy_static;
+
+// Network-specific creation code bytecode constants.
+// Source: https://github.com/gasfreeio/gasfree-sdk-js/blob/main/src/constant/common.ts
+lazy_static! {
+    static ref MAINNET_CREATION_CODE: Vec<u8> = hex::decode("60a06040908082526103e5803803809161001982856101d6565b833981019082818303126101d2576100308161020d565b91602091828101519060018060401b0382116101d2570181601f820112156101d25780519061005e8261022a565b9261006b875194856101d6565b8284528483830101116101d25783905f5b8381106101be5750505f9183010152823b1561017a5780516100b3575b50506080525161013c90816102a982396080518160180152f35b8351635c60da1b60e01b81529082826004816001600160a01b0388165afa918215610170575f9261012d575b50905f80838561011c9695519101845af4903d15610124573d6101018161022a565b9061010e885192836101d6565b81525f81943d92013e610245565b505f80610099565b60609250610245565b90918382813d8311610169575b61014481836101d6565b810103126101665750905f8061015d61011c959461020d565b939450506100df565b80fd5b503d61013a565b85513d5f823e3d90fd5b835162461bcd60e51b815260048101839052601b60248201527f626561636f6e2073686f756c64206265206120636f6e747261637400000000006044820152606490fd5b81810183015185820184015285920161007c565b5f80fd5b601f909101601f19168101906001600160401b038211908210176101f957604052565b634e487b7160e01b5f52604160045260245ffd5b516001600160a81b03811681036101d2576001600160a01b031690565b6001600160401b0381116101f957601f01601f191660200190565b9061026c575080511561025a57805190602001fd5b604051630a12f52160e11b8152600490fd5b8151158061029f575b61027d575090565b604051639996b31560e01b81526001600160a01b039091166004820152602490fd5b50803b1561027556fe60806040819052635c60da1b60e01b81526020816004817f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03165afa9081156100ae575f91610056575b506100e8565b6020903d82116100a6575b601f8201601f1916810167ffffffffffffffff8111828210176100925761008c9350604052016100b9565b5f610050565b634e487b7160e01b84526041600452602484fd5b3d9150610061565b6040513d5f823e3d90fd5b602090607f1901126100e4576080516001600160a81b03811681036100e4576001600160a01b031690565b5f80fd5b5f808092368280378136915af43d82803e15610102573d90f35b3d90fdfea26474726f6e58221220309a2919b7a1b203f1a7a1c544a7d671bb94b0adf8a39e4c9b6eeb6d03939ffe64736f6c63430008140033").expect("invalid mainnet creation code hex");
+
+    static ref NILE_CREATION_CODE: Vec<u8> = hex::decode("60a06040908082526103e5803803809161001982856101d6565b833981019082818303126101d2576100308161020d565b91602091828101519060018060401b0382116101d2570181601f820112156101d25780519061005e8261022a565b9261006b875194856101d6565b8284528483830101116101d25783905f5b8381106101be5750505f9183010152823b1561017a5780516100b3575b50506080525161013c90816102a982396080518160180152f35b8351635c60da1b60e01b81529082826004816001600160a01b0388165afa918215610170575f9261012d575b50905f80838561011c9695519101845af4903d15610124573d6101018161022a565b9061010e885192836101d6565b81525f81943d92013e610245565b505f80610099565b60609250610245565b90918382813d8311610169575b61014481836101d6565b810103126101665750905f8061015d61011c959461020d565b939450506100df565b80fd5b503d61013a565b85513d5f823e3d90fd5b835162461bcd60e51b815260048101839052601b60248201527f626561636f6e2073686f756c64206265206120636f6e747261637400000000006044820152606490fd5b81810183015185820184015285920161007c565b5f80fd5b601f909101601f19168101906001600160401b038211908210176101f957604052565b634e487b7160e01b5f52604160045260245ffd5b516001600160a81b03811681036101d2576001600160a01b031690565b6001600160401b0381116101f957601f01601f191660200190565b9061026c575080511561025a57805190602001fd5b604051630a12f52160e11b8152600490fd5b8151158061029f575b61027d575090565b604051639996b31560e01b81526001600160a01b039091166004820152602490fd5b50803b1561027556fe60806040819052635c60da1b60e01b81526020816004817f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03165afa9081156100ae575f91610056575b506100e8565b6020903d82116100a6575b601f8201601f1916810167ffffffffffffffff8111828210176100925761008c9350604052016100b9565b5f610050565b634e487b7160e01b84526041600452602484fd5b3d9150610061565b6040513d5f823e3d90fd5b602090607f1901126100e4576080516001600160a81b03811681036100e4576001600160a01b031690565b5f80fd5b5f808092368280378136915af43d82803e15610102573d90f35b3d90fdfea26474726f6e5822122019fba3a984dfef08920adc4d0e531dbd369df1dec237bfb02ce668f5d8e2704064736f6c63430008140033").expect("invalid nile creation code hex");
+
+    static ref SHASTA_CREATION_CODE: Vec<u8> = hex::decode("60a06040908082526104b8803803809161001982856102a9565b833981019082818303126102a557610030816102e0565b91602091828101519060018060401b0382116102a5570181601f820112156102a55780519061005e826102fd565b9261006b875194856102a9565b8284528483830101116102a55783905f5b8381106102915750505f9183010152823b15610271577fa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d5080546001600160a01b0319166001600160a01b038581169182179092558551635c60da1b60e01b8082529193928582600481885afa918215610267575f92610230575b50813b156102175750508551837f1cf3b03a6cf19fa2baba4df148e9dcabedea7f8a5c07840e207e5c089be95d3e5f80a28251156101f857508390600487518095819382525afa9182156101ee575f926101ab575b50905f8083856101889695519101845af4903d156101a2573d61016d816102fd565b9061017a885192836102a9565b81525f81943d92013e610318565b505b6080525161013c908161037c82396080518160180152f35b60609250610318565b90918382813d83116101e7575b6101c281836102a9565b810103126101e45750905f806101db61018895946102e0565b9394505061014b565b80fd5b503d6101b8565b85513d5f823e3d90fd5b935050505034610208575061018a565b63b398979f60e01b8152600490fd5b8751634c9c8ce360e01b81529116600482015260249150fd5b90918682813d8311610260575b61024781836102a9565b810103126101e45750610259906102e0565b905f6100f6565b503d61023d565b88513d5f823e3d90fd5b8351631933b43b60e21b81526001600160a01b0384166004820152602490fd5b81810183015185820184015285920161007c565b5f80fd5b601f909101601f19168101906001600160401b038211908210176102cc57604052565b634e487b7160e01b5f52604160045260245ffd5b516001600160a81b03811681036102a5576001600160a01b031690565b6001600160401b0381116102cc57601f01601f191660200190565b9061033f575080511561032d57805190602001fd5b604051630a12f52160e11b8152600490fd5b81511580610372575b610350575090565b604051639996b31560e01b81526001600160a01b039091166004820152602490fd5b50803b1561034856fe60806040819052635c60da1b60e01b81526020816004817f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03165afa9081156100ae575f91610056575b506100e8565b6020903d82116100a6575b601f8201601f1916810167ffffffffffffffff8111828210176100925761008c9350604052016100b9565b5f610050565b634e487b7160e01b84526041600452602484fd5b3d9150610061565b6040513d5f823e3d90fd5b602090607f1901126100e4576080516001600160a81b03811681036100e4576001600160a01b031690565b5f80fd5b5f808092368280378136915af43d82803e15610102573d90f35b3d90fdfea26474726f6e58221220b3a0a0f4043f8fe355d62319dafed2ba5d611d7bb6dfe21d6d935af1510ce27964736f6c63430008140033").expect("invalid shasta creation code hex");
+}
+
+/// Per-network GasFree contract artifacts (controller, beacon, creation bytecode).
+/// These are protocol constants from the official GasFree SDKs.
+struct NetworkArtifacts {
+    controller: TronAddress,
+    beacon: TronAddress,
+    creation_code: &'static [u8],
+}
+
+/// Returns the compiled GasFree artifacts for a TRON network.
+///
+/// The creation_code bytecode is hardcoded from the official GasFree JS SDK
+/// (github.com/gasfreeio/gasfree-sdk-js) rather than config-driven, because
+/// this bytecode determines user-visible receive addresses — a bad value would
+/// silently produce wrong addresses.
+fn network_artifacts(network: &Network) -> NetworkArtifacts {
+    match network {
+        Network::Mainnet => NetworkArtifacts {
+            controller: TronAddress::from_base58("TFFAMQLZybALaLb4uxHA9RBE7pxhUAjF3U")
+                .expect("hardcoded mainnet controller"),
+            beacon: TronAddress::from_base58("TSP9UW6FQhT76XD2jWA6ipGMx3yGbjDffP").expect("hardcoded mainnet beacon"),
+            creation_code: &MAINNET_CREATION_CODE,
+        },
+        Network::Nile => NetworkArtifacts {
+            controller: TronAddress::from_base58("THQGuFzL87ZqhxkgqYEryRAd7gqFqL5rdc")
+                .expect("hardcoded nile controller"),
+            beacon: TronAddress::from_base58("TLtCGmaxH3PbuaF6kbybwteZcHptEdgQGC").expect("hardcoded nile beacon"),
+            creation_code: &NILE_CREATION_CODE,
+        },
+        Network::Shasta => NetworkArtifacts {
+            controller: TronAddress::from_base58("TQghdCeVDA6CnuNVTUhfaAyPfTetqZWNpm")
+                .expect("hardcoded shasta controller"),
+            beacon: TronAddress::from_base58("TQ1jvA3nLDMDNbJoMPLzTPoqAg8NvZ5CCW").expect("hardcoded shasta beacon"),
+            creation_code: &SHASTA_CREATION_CODE,
+        },
+    }
+}
+
+/// Returns the hardcoded GasFreeController address for a TRON network.
+///
+/// Used by `resolve_tron_gasless_provider` to derive the `verifying_contract`
+/// stored on `ResolvedTronGaslessProvider`, and internally by CREATE2 derivation.
+pub fn controller_for_network(network: &Network) -> TronAddress {
+    network_artifacts(network).controller
+}
+
+/// Compute the GasFree address for a user on a specific TRON network.
+///
+/// Infallible: the controller and beacon are hardcoded per network, and
+/// `user_address` is a pre-validated `TronAddress`.
+pub fn compute_gasfree_address_for_network(network: &Network, user_address: &TronAddress) -> TronAddress {
+    let artifacts = network_artifacts(network);
+    compute_gasfree_address(
+        &artifacts.controller,
+        &artifacts.beacon,
+        user_address,
+        artifacts.creation_code,
+    )
+}
+
+/// Pure CREATE2 GasFree address derivation.
+///
+/// Algorithm (from official GasFree SDK):
+/// 1. Salt = user's 20-byte EVM address, left-padded to 32 bytes
+/// 2. init_calldata = selector("initialize(address)") || salt
+/// 3. init_code = creation_code || abi.encode(beacon_evm, init_calldata)
+/// 4. init_code_hash = keccak256(init_code)
+/// 5. preimage = 0x41 || controller_20bytes || salt || init_code_hash
+/// 6. result = last 20 bytes of keccak256(preimage) → TronAddress
+fn compute_gasfree_address(
+    controller: &TronAddress,
+    beacon: &TronAddress,
+    user_address: &TronAddress,
+    creation_code: &[u8],
+) -> TronAddress {
+    // Step 1: Salt = 20-byte EVM address right-aligned in 32 bytes
+    let user_evm = user_address.to_evm_address();
+    let mut salt = [0u8; 32];
+    salt[12..].copy_from_slice(user_evm.as_bytes());
+
+    // Step 2: initialize(address) selector + salt as calldata
+    let init_selector = &keccak256(b"initialize(address)")[..4];
+    let mut init_calldata = Vec::with_capacity(4 + 32);
+    init_calldata.extend_from_slice(init_selector);
+    init_calldata.extend_from_slice(&salt);
+
+    // Step 3: ABI-encode constructor args (beacon address, init calldata)
+    let beacon_evm = beacon.to_evm_address();
+    let encoded_args = ethabi::encode(&[
+        Token::Address(H160::from_slice(beacon_evm.as_bytes())),
+        Token::Bytes(init_calldata),
+    ]);
+
+    // Step 4: init_code = creation_code || encoded_args, then hash
+    let mut init_code = Vec::with_capacity(creation_code.len() + encoded_args.len());
+    init_code.extend_from_slice(creation_code);
+    init_code.extend_from_slice(&encoded_args);
+    let init_code_hash = keccak256(&init_code);
+
+    // Step 5: TRON CREATE2 preimage: 0x41 || controller_20 || salt || init_code_hash
+    let controller_evm = controller.to_evm_address();
+    let mut preimage = Vec::with_capacity(1 + 20 + 32 + 32);
+    preimage.push(0x41); // TRON prefix (Ethereum uses 0xff)
+    preimage.extend_from_slice(controller_evm.as_bytes());
+    preimage.extend_from_slice(&salt);
+    preimage.extend_from_slice(&init_code_hash[..]);
+
+    // Step 6: Take last 20 bytes → TRON address
+    let hash = keccak256(&preimage);
+    let evm_addr = H160::from_slice(&hash[12..]);
+    TronAddress::from(evm_addr)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    // --- Nile test vectors from official JS SDK ---
+
+    #[test]
+    fn test_nile_vector_1() {
+        let user = TronAddress::from_str("TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC").unwrap();
+        let result = compute_gasfree_address_for_network(&Network::Nile, &user);
+        assert_eq!(result.to_base58(), "TUGC4eNuEgbaLotwxzzXEck1fRWru6n8ye");
+    }
+
+    #[test]
+    fn test_nile_vector_2() {
+        let user = TronAddress::from_str("TDvSsdrNM5eeXNL3czpa6AxLDHZA9nwe9K").unwrap();
+        let result = compute_gasfree_address_for_network(&Network::Nile, &user);
+        assert_eq!(result.to_base58(), "TLvVuqx74fMy8QMjEsMT4dWwmVbuNwYt8X");
+    }
+
+    #[test]
+    fn test_nile_vector_3() {
+        let user = TronAddress::from_str("TKTX96CBxr5kvhjsDHcqoiPWZageGxoTW3").unwrap();
+        let result = compute_gasfree_address_for_network(&Network::Nile, &user);
+        assert_eq!(result.to_base58(), "TTjqEjsitExzYsoDaR65nd3d2avhsXayfL");
+    }
+
+    // --- Mainnet test vectors from official JS SDK ---
+
+    #[test]
+    fn test_mainnet_vector_1() {
+        let user = TronAddress::from_str("TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC").unwrap();
+        let result = compute_gasfree_address_for_network(&Network::Mainnet, &user);
+        assert_eq!(result.to_base58(), "TBwmA2PtMXC4HiGvfi8xg2jZd5i3y89DjK");
+    }
+
+    #[test]
+    fn test_mainnet_vector_2() {
+        let user = TronAddress::from_str("TDvSsdrNM5eeXNL3czpa6AxLDHZA9nwe9K").unwrap();
+        let result = compute_gasfree_address_for_network(&Network::Mainnet, &user);
+        assert_eq!(result.to_base58(), "TTA7pGKZdpkJwiwuookcfbkdq6kZxysn86");
+    }
+
+    // --- Shasta test vector ---
+
+    #[test]
+    fn test_shasta_vector_1() {
+        let user = TronAddress::from_str("TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC").unwrap();
+        let result = compute_gasfree_address_for_network(&Network::Shasta, &user);
+        assert_eq!(result.to_base58(), "TX5TyYzg9a15HksNfTkKbEqGxa7UEPuJE8");
+    }
+
+    // --- Expected-controller lookup (used by activation-time validation) ---
+
+    #[test]
+    fn test_expected_controller_per_network() {
+        assert_eq!(
+            controller_for_network(&Network::Mainnet).to_base58(),
+            "TFFAMQLZybALaLb4uxHA9RBE7pxhUAjF3U"
+        );
+        assert_eq!(
+            controller_for_network(&Network::Nile).to_base58(),
+            "THQGuFzL87ZqhxkgqYEryRAd7gqFqL5rdc"
+        );
+        assert_eq!(
+            controller_for_network(&Network::Shasta).to_base58(),
+            "TQghdCeVDA6CnuNVTUhfaAyPfTetqZWNpm"
+        );
+    }
+
+    #[test]
+    fn test_initialize_selector() {
+        let selector = &keccak256(b"initialize(address)")[..4];
+        assert_eq!(selector, &[0xc4, 0xd6, 0x6d, 0xe8]);
+    }
+}

--- a/mm2src/coins/eth/tron/gasfree/api_types.rs
+++ b/mm2src/coins/eth/tron/gasfree/api_types.rs
@@ -1,0 +1,608 @@
+use crate::eth::tron::{TronAddress, TronSignature, TronTxHash};
+use ethereum_types::U256;
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use uuid::Uuid;
+
+const GASFREE_PROTOCOL_VERSION: u64 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct GasfreeRequestId(Uuid);
+
+impl GasfreeRequestId {
+    fn try_from_uuid(uuid: Uuid) -> Result<Self, String> {
+        match uuid.get_version_num() {
+            4 => Ok(GasfreeRequestId(uuid)),
+            version => Err(format!("requestId must be a UUIDv4, got version {version}")),
+        }
+    }
+}
+
+impl Serialize for GasfreeRequestId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for GasfreeRequestId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let uuid = deserialize_uuid(deserializer)?;
+        GasfreeRequestId::try_from_uuid(uuid).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct GasfreeSubmitRequest {
+    #[serde(rename = "requestId", default, skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<GasfreeRequestId>,
+    pub token: TronAddress,
+    #[serde(rename = "serviceProvider")]
+    pub service_provider: TronAddress,
+    pub user: TronAddress,
+    pub receiver: TronAddress,
+    #[serde(serialize_with = "serialize_u256_as_string")]
+    pub value: U256,
+    #[serde(rename = "maxFee", serialize_with = "serialize_u256_as_string")]
+    pub max_fee: U256,
+    #[serde(serialize_with = "serialize_u256_as_string")]
+    pub deadline: U256,
+    #[serde(
+        serialize_with = "serialize_u256_as_string",
+        deserialize_with = "deserialize_exact_version_one"
+    )]
+    pub version: U256,
+    #[serde(serialize_with = "serialize_u256_as_string")]
+    pub nonce: U256,
+    #[serde(rename = "sig")]
+    pub signature: TronSignature,
+}
+
+impl GasfreeSubmitRequest {
+    pub fn validate(&self) -> Result<(), String> {
+        validate_version_is_one(&self.version, "version")
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct GasfreeSupportedToken {
+    #[serde(rename = "tokenAddress")]
+    pub token_address: TronAddress,
+    #[serde(rename = "activateFee", deserialize_with = "deserialize_u256")]
+    pub activate_fee: U256,
+    #[serde(rename = "transferFee", deserialize_with = "deserialize_u256")]
+    pub transfer_fee: U256,
+    #[serde(deserialize_with = "deserialize_non_empty_string")]
+    pub symbol: String,
+    #[serde(rename = "decimal", deserialize_with = "deserialize_decimal_u8")]
+    pub decimal: u8,
+    pub supported: bool,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct GasfreeAccountAsset {
+    #[serde(rename = "tokenAddress")]
+    pub token_address: TronAddress,
+    #[serde(rename = "tokenSymbol", deserialize_with = "deserialize_non_empty_string")]
+    pub token_symbol: String,
+    #[serde(rename = "activateFee", deserialize_with = "deserialize_u256")]
+    pub activate_fee: U256,
+    #[serde(rename = "transferFee", deserialize_with = "deserialize_u256")]
+    pub transfer_fee: U256,
+    #[serde(rename = "decimal", deserialize_with = "deserialize_decimal_u8")]
+    pub decimal: u8,
+    #[serde(deserialize_with = "deserialize_u256")]
+    pub frozen: U256,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct GasfreeAccountInfo {
+    #[serde(rename = "accountAddress")]
+    pub account_address: TronAddress,
+    #[serde(rename = "gasFreeAddress")]
+    pub gas_free_address: TronAddress,
+    pub active: bool,
+    #[serde(deserialize_with = "deserialize_u256")]
+    pub nonce: U256,
+    #[serde(rename = "allowSubmit")]
+    pub allow_submit: bool,
+    pub assets: Vec<GasfreeAccountAsset>,
+}
+
+/// Unknown provider states are rejected during deserialization so API drift is surfaced immediately.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub enum GasfreeTransferState {
+    #[serde(rename = "WAITING")]
+    Waiting,
+    #[serde(rename = "INPROGRESS")]
+    InProgress,
+    #[serde(rename = "CONFIRMING")]
+    Confirming,
+    #[serde(rename = "SUCCEED")]
+    Succeed,
+    #[serde(rename = "FAILED")]
+    Failed,
+}
+
+/// Unknown provider states are rejected during deserialization so API drift is surfaced immediately.
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum GasfreeTransactionState {
+    Init,
+    NotOnChain,
+    OnChain,
+    Solidity,
+    OnChainFailed,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct GasfreeSubmitResponse {
+    pub id: Uuid,
+    #[serde(rename = "accountAddress")]
+    pub account_address: TronAddress,
+    #[serde(rename = "gasFreeAddress")]
+    pub gas_free_address: TronAddress,
+    #[serde(rename = "providerAddress")]
+    pub provider_address: TronAddress,
+    #[serde(rename = "targetAddress")]
+    pub target_address: TronAddress,
+    #[serde(rename = "tokenAddress")]
+    pub token_address: TronAddress,
+    #[serde(deserialize_with = "deserialize_u256")]
+    pub amount: U256,
+    #[serde(rename = "maxFee", deserialize_with = "deserialize_u256")]
+    pub max_fee: U256,
+    #[serde(
+        rename = "signature",
+        default,
+        deserialize_with = "deserialize_optional_tron_signature"
+    )]
+    pub signature: Option<TronSignature>,
+    #[serde(deserialize_with = "deserialize_exact_version_one")]
+    pub version: U256,
+    #[serde(deserialize_with = "deserialize_u256")]
+    pub nonce: U256,
+    #[serde(rename = "expiredAt", deserialize_with = "deserialize_u64")]
+    pub expired_at: u64,
+    #[serde(rename = "state")]
+    pub state: GasfreeTransferState,
+    #[serde(rename = "estimatedActivateFee", deserialize_with = "deserialize_u256")]
+    pub estimated_activate_fee: U256,
+    #[serde(
+        rename = "estimatedTransferFee",
+        alias = "estimateTransferFee",
+        deserialize_with = "deserialize_u256"
+    )]
+    pub estimated_transfer_fee: U256,
+    #[serde(rename = "createdAt", default, deserialize_with = "deserialize_option_u64")]
+    pub created_at: Option<u64>,
+    #[serde(rename = "updatedAt", default, deserialize_with = "deserialize_option_u64")]
+    pub updated_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct GasfreeTraceResponse {
+    pub id: Uuid,
+    #[serde(rename = "accountAddress")]
+    pub account_address: TronAddress,
+    #[serde(rename = "gasFreeAddress")]
+    pub gas_free_address: TronAddress,
+    #[serde(rename = "providerAddress")]
+    pub provider_address: TronAddress,
+    #[serde(rename = "targetAddress")]
+    pub target_address: TronAddress,
+    #[serde(rename = "tokenAddress")]
+    pub token_address: TronAddress,
+    #[serde(deserialize_with = "deserialize_u256")]
+    pub amount: U256,
+    #[serde(rename = "state")]
+    pub state: GasfreeTransferState,
+    #[serde(rename = "expiredAt", deserialize_with = "deserialize_u64")]
+    pub expired_at: u64,
+    #[serde(rename = "estimatedActivateFee", deserialize_with = "deserialize_u256")]
+    pub estimated_activate_fee: U256,
+    #[serde(
+        rename = "estimatedTransferFee",
+        alias = "estimateTransferFee",
+        deserialize_with = "deserialize_u256"
+    )]
+    pub estimated_transfer_fee: U256,
+    #[serde(rename = "estimatedTotalFee", deserialize_with = "deserialize_u256")]
+    pub estimated_total_fee: U256,
+    #[serde(rename = "estimatedTotalCost", deserialize_with = "deserialize_u256")]
+    pub estimated_total_cost: U256,
+    #[serde(rename = "txnHash", default, deserialize_with = "deserialize_optional_tron_tx_hash")]
+    pub txn_hash: Option<TronTxHash>,
+    #[serde(rename = "txnBlockNum", default, deserialize_with = "deserialize_option_u64")]
+    pub txn_block_num: Option<u64>,
+    #[serde(rename = "txnBlockTimestamp", default, deserialize_with = "deserialize_option_u64")]
+    pub txn_block_timestamp: Option<u64>,
+    #[serde(rename = "txnState", default)]
+    pub txn_state: Option<GasfreeTransactionState>,
+    #[serde(rename = "txnActivateFee", default, deserialize_with = "deserialize_option_u256")]
+    pub txn_activate_fee: Option<U256>,
+    #[serde(rename = "txnTransferFee", default, deserialize_with = "deserialize_option_u256")]
+    pub txn_transfer_fee: Option<U256>,
+    #[serde(rename = "txnTotalFee", default, deserialize_with = "deserialize_option_u256")]
+    pub txn_total_fee: Option<U256>,
+    #[serde(rename = "txnAmount", default, deserialize_with = "deserialize_option_u256")]
+    pub txn_amount: Option<U256>,
+    #[serde(rename = "txnTotalCost", default, deserialize_with = "deserialize_option_u256")]
+    pub txn_total_cost: Option<U256>,
+    #[serde(deserialize_with = "deserialize_u256")]
+    pub nonce: U256,
+    #[serde(rename = "createdAt", default, deserialize_with = "deserialize_option_u64")]
+    pub created_at: Option<u64>,
+    #[serde(rename = "updatedAt", default, deserialize_with = "deserialize_option_u64")]
+    pub updated_at: Option<u64>,
+    #[serde(rename = "maxFee", default, deserialize_with = "deserialize_option_u256")]
+    pub max_fee: Option<U256>,
+    #[serde(default, deserialize_with = "deserialize_option_exact_version_one")]
+    pub version: Option<U256>,
+    #[serde(default, deserialize_with = "deserialize_optional_tron_signature")]
+    pub signature: Option<TronSignature>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+enum FlexibleInteger {
+    String(String),
+    U64(u64),
+    I64(i64),
+}
+
+fn parse_u256_value(value: FlexibleInteger, field_name: &str) -> Result<U256, String> {
+    match value {
+        FlexibleInteger::String(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return Err(format!("{field_name} must not be empty"));
+            }
+            if trimmed.starts_with('-') {
+                return Err(format!("{field_name} must not be negative"));
+            }
+
+            U256::from_dec_str(trimmed).map_err(|e| format!("Invalid {field_name}: {e}"))
+        },
+        FlexibleInteger::U64(value) => Ok(U256::from(value)),
+        FlexibleInteger::I64(value) => {
+            if value < 0 {
+                Err(format!("{field_name} must not be negative"))
+            } else {
+                Ok(U256::from(value as u64))
+            }
+        },
+    }
+}
+
+fn parse_u64_value(value: FlexibleInteger, field_name: &str) -> Result<u64, String> {
+    match value {
+        FlexibleInteger::String(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                return Err(format!("{field_name} must not be empty"));
+            }
+            if trimmed.starts_with('-') {
+                return Err(format!("{field_name} must not be negative"));
+            }
+            trimmed.parse::<u64>().map_err(|e| format!("Invalid {field_name}: {e}"))
+        },
+        FlexibleInteger::U64(value) => Ok(value),
+        FlexibleInteger::I64(value) => {
+            if value < 0 {
+                Err(format!("{field_name} must not be negative"))
+            } else {
+                Ok(value as u64)
+            }
+        },
+    }
+}
+
+fn validate_version_is_one(value: &U256, field_name: &str) -> Result<(), String> {
+    if *value == U256::from(GASFREE_PROTOCOL_VERSION) {
+        Ok(())
+    } else {
+        Err(format!(
+            "{field_name} must equal {GASFREE_PROTOCOL_VERSION}, got {}",
+            value
+        ))
+    }
+}
+
+fn deserialize_uuid<'de, D>(deserializer: D) -> Result<Uuid, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let raw = String::deserialize(deserializer)?;
+    Uuid::parse_str(raw.trim()).map_err(D::Error::custom)
+}
+
+fn deserialize_u256<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = FlexibleInteger::deserialize(deserializer)?;
+    parse_u256_value(value, "decimal number").map_err(D::Error::custom)
+}
+
+fn deserialize_exact_version_one<'de, D>(deserializer: D) -> Result<U256, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = deserialize_u256(deserializer)?;
+    validate_version_is_one(&value, "version").map_err(D::Error::custom)?;
+    Ok(value)
+}
+
+fn deserialize_option_exact_version_one<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<FlexibleInteger>::deserialize(deserializer)?;
+    value
+        .map(|val| parse_u256_value(val, "version"))
+        .transpose()
+        .and_then(|opt| {
+            opt.map(|version| validate_version_is_one(&version, "version").map(|_| version))
+                .transpose()
+        })
+        .map_err(D::Error::custom)
+}
+
+fn deserialize_option_u256<'de, D>(deserializer: D) -> Result<Option<U256>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<FlexibleInteger>::deserialize(deserializer)?;
+    value
+        .map(|val| parse_u256_value(val, "decimal number"))
+        .transpose()
+        .map_err(D::Error::custom)
+}
+
+fn deserialize_u64<'de, D>(deserializer: D) -> Result<u64, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = FlexibleInteger::deserialize(deserializer)?;
+    parse_u64_value(value, "integer").map_err(D::Error::custom)
+}
+
+fn deserialize_option_u64<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<FlexibleInteger>::deserialize(deserializer)?;
+    value
+        .map(|val| parse_u64_value(val, "integer"))
+        .transpose()
+        .map_err(D::Error::custom)
+}
+
+fn deserialize_decimal_u8<'de, D>(deserializer: D) -> Result<u8, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = deserialize_u64(deserializer)?;
+    if value > u8::MAX as u64 {
+        return Err(D::Error::custom(format!(
+            "decimal value {value} is out of range for u8"
+        )));
+    }
+    Ok(value as u8)
+}
+
+fn deserialize_non_empty_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = String::deserialize(deserializer)?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(D::Error::custom("string must not be empty"));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn deserialize_optional_tron_signature<'de, D>(deserializer: D) -> Result<Option<TronSignature>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    match value {
+        Some(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                TronSignature::from_hex_str(trimmed).map(Some).map_err(D::Error::custom)
+            }
+        },
+        None => Ok(None),
+    }
+}
+
+fn deserialize_optional_tron_tx_hash<'de, D>(deserializer: D) -> Result<Option<TronTxHash>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    match value {
+        Some(value) => {
+            let trimmed = value.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                TronTxHash::from_hex_str(trimmed).map(Some).map_err(D::Error::custom)
+            }
+        },
+        None => Ok(None),
+    }
+}
+
+fn serialize_u256_as_string<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn base_request_payload() -> serde_json::Value {
+        json!({
+            "requestId": "550e8400-e29b-41d4-a716-446655440000",
+            "token": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+            "serviceProvider": "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E",
+            "user": "TUUSMd58eC3fKx3fn7whxJyr1FR56tgaP8",
+            "receiver": "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT",
+            "value": "100000",
+            "maxFee": "2000000",
+            "deadline": "1747909695",
+            "version": "1",
+            "nonce": "8",
+            "sig": "11".repeat(65)
+        })
+    }
+
+    fn base_submit_response_payload() -> serde_json::Value {
+        json!({
+            "id": "6c3ff67e-0bf4-4c09-91ca-0c7c254b01a0",
+            "accountAddress": "TUUSMd58eC3fKx3fn7whxJyr1FR56tgaP8",
+            "gasFreeAddress": "TNER12mMVWruqopsW9FQtKxCGfZcEtb3ER",
+            "providerAddress": "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E",
+            "targetAddress": "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT",
+            "tokenAddress": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+            "amount": 100000,
+            "maxFee": 2000000,
+            "signature": "",
+            "version": 1,
+            "nonce": 8,
+            "expiredAt": 1747909695000u64,
+            "state": "WAITING",
+            "estimatedActivateFee": 0,
+            "estimatedTransferFee": 2000,
+            "createdAt": 1747909635678u64,
+            "updatedAt": 1747909635678u64
+        })
+    }
+
+    fn base_trace_response_payload() -> serde_json::Value {
+        json!({
+            "id": "6c3ff67e-0bf4-4c09-91ca-0c7c254b01a0",
+            "accountAddress": "TUUSMd58eC3fKx3fn7whxJyr1FR56tgaP8",
+            "gasFreeAddress": "TNER12mMVWruqopsW9FQtKxCGfZcEtb3ER",
+            "providerAddress": "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E",
+            "targetAddress": "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT",
+            "tokenAddress": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+            "amount": 100000,
+            "state": "CONFIRMING",
+            "expiredAt": 1747909695000u64,
+            "estimatedActivateFee": 0,
+            "estimatedTransferFee": 2000,
+            "estimatedTotalFee": 2000,
+            "estimatedTotalCost": 102000,
+            "txnHash": "22".repeat(32),
+            "txnBlockNum": 57175988,
+            "txnBlockTimestamp": 1747909638000u64,
+            "txnState": "ON_CHAIN",
+            "txnActivateFee": 0,
+            "txnTransferFee": 2000,
+            "txnTotalFee": 2000,
+            "txnAmount": 100000,
+            "txnTotalCost": 102000,
+            "nonce": 8,
+            "version": 1,
+            "signature": "33".repeat(65)
+        })
+    }
+
+    #[test]
+    fn submit_request_protocol_contract() {
+        let request = GasfreeSubmitRequest {
+            request_id: Some(
+                GasfreeRequestId::try_from_uuid(Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap())
+                    .unwrap(),
+            ),
+            token: "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf".parse().unwrap(),
+            service_provider: "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E".parse().unwrap(),
+            user: "TUUSMd58eC3fKx3fn7whxJyr1FR56tgaP8".parse().unwrap(),
+            receiver: "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT".parse().unwrap(),
+            value: U256::from(100_000u64),
+            max_fee: U256::from(2_000_000u64),
+            deadline: U256::from(1_747_909_695u64),
+            version: U256::from(1u64),
+            nonce: U256::from(8u64),
+            signature: TronSignature::from_hex_str(&"11".repeat(65)).unwrap(),
+        };
+
+        let json = serde_json::to_value(request).unwrap();
+        assert_eq!(json["value"], "100000");
+        assert_eq!(json["maxFee"], "2000000");
+        assert_eq!(json["nonce"], "8");
+        assert_eq!(json["sig"], json!("11".repeat(65).to_lowercase()));
+
+        let invalid_cases = [
+            (
+                "non-v4 requestId",
+                json!("f81d4fae-7dec-11d0-a765-00a0c91e6bf6"),
+                "requestId",
+            ),
+            ("version != 1", json!(2), "version"),
+            ("prefixed signature", json!(format!("0x{}", "11".repeat(65))), "sig"),
+            ("short signature", json!("11".repeat(64)), "sig"),
+            ("long signature", json!("11".repeat(66)), "sig"),
+            ("odd signature", json!("1".repeat(129)), "sig"),
+        ];
+
+        for (label, value, field) in invalid_cases {
+            let mut payload = base_request_payload();
+            payload[field] = value;
+            assert!(
+                serde_json::from_value::<GasfreeSubmitRequest>(payload).is_err(),
+                "expected request rejection for {}",
+                label
+            );
+        }
+    }
+
+    #[test]
+    fn provider_response_protocol_validation() {
+        let mut submit_payload = base_submit_response_payload();
+        submit_payload["version"] = json!(2);
+        assert!(serde_json::from_value::<GasfreeSubmitResponse>(submit_payload).is_err());
+
+        let mut submit_payload = base_submit_response_payload();
+        submit_payload["state"] = json!("UNKNOWN_STATE");
+        assert!(serde_json::from_value::<GasfreeSubmitResponse>(submit_payload).is_err());
+
+        for invalid in [
+            json!(format!("0x{}", "22".repeat(32))),
+            json!("22".repeat(31)),
+            json!("22".repeat(33)),
+            json!("2".repeat(63)),
+        ] {
+            let mut payload = base_trace_response_payload();
+            payload["txnHash"] = invalid;
+            assert!(serde_json::from_value::<GasfreeTraceResponse>(payload).is_err());
+        }
+
+        for invalid in [json!("33".repeat(64)), json!("33".repeat(66)), json!("3".repeat(129))] {
+            let mut payload = base_trace_response_payload();
+            payload["signature"] = invalid;
+            assert!(serde_json::from_value::<GasfreeTraceResponse>(payload).is_err());
+        }
+
+        let mut trace_payload = base_trace_response_payload();
+        trace_payload["txnState"] = json!("MYSTERY");
+        assert!(serde_json::from_value::<GasfreeTraceResponse>(trace_payload).is_err());
+    }
+}

--- a/mm2src/coins/eth/tron/gasfree/api_types.rs
+++ b/mm2src/coins/eth/tron/gasfree/api_types.rs
@@ -1,10 +1,9 @@
+use super::typed_data::GASFREE_PERMIT_VERSION;
 use crate::eth::tron::{TronAddress, TronSignature, TronTxHash};
 use ethereum_types::U256;
 use serde::de::Error as DeError;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use uuid::Uuid;
-
-const GASFREE_PROTOCOL_VERSION: u64 = 1;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct GasfreeRequestId(Uuid);
@@ -304,11 +303,11 @@ fn parse_u64_value(value: FlexibleInteger, field_name: &str) -> Result<u64, Stri
 }
 
 fn validate_version_is_one(value: &U256, field_name: &str) -> Result<(), String> {
-    if *value == U256::from(GASFREE_PROTOCOL_VERSION) {
+    if *value == U256::from(GASFREE_PERMIT_VERSION) {
         Ok(())
     } else {
         Err(format!(
-            "{field_name} must equal {GASFREE_PROTOCOL_VERSION}, got {}",
+            "{field_name} must equal {GASFREE_PERMIT_VERSION}, got {}",
             value
         ))
     }
@@ -322,7 +321,7 @@ where
     Uuid::parse_str(raw.trim()).map_err(D::Error::custom)
 }
 
-fn deserialize_u256<'de, D>(deserializer: D) -> Result<U256, D::Error>
+pub(super) fn deserialize_u256<'de, D>(deserializer: D) -> Result<U256, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -330,7 +329,7 @@ where
     parse_u256_value(value, "decimal number").map_err(D::Error::custom)
 }
 
-fn deserialize_exact_version_one<'de, D>(deserializer: D) -> Result<U256, D::Error>
+pub(super) fn deserialize_exact_version_one<'de, D>(deserializer: D) -> Result<U256, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -445,7 +444,7 @@ where
     }
 }
 
-fn serialize_u256_as_string<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
+pub(super) fn serialize_u256_as_string<S>(value: &U256, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
@@ -455,6 +454,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::eth::tron::gasfree::test_helpers::{base_submit_response_payload, base_trace_response_payload};
     use serde_json::json;
 
     fn base_request_payload() -> serde_json::Value {
@@ -470,58 +470,6 @@ mod tests {
             "version": "1",
             "nonce": "8",
             "sig": "11".repeat(65)
-        })
-    }
-
-    fn base_submit_response_payload() -> serde_json::Value {
-        json!({
-            "id": "6c3ff67e-0bf4-4c09-91ca-0c7c254b01a0",
-            "accountAddress": "TUUSMd58eC3fKx3fn7whxJyr1FR56tgaP8",
-            "gasFreeAddress": "TNER12mMVWruqopsW9FQtKxCGfZcEtb3ER",
-            "providerAddress": "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E",
-            "targetAddress": "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT",
-            "tokenAddress": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
-            "amount": 100000,
-            "maxFee": 2000000,
-            "signature": "",
-            "version": 1,
-            "nonce": 8,
-            "expiredAt": 1747909695000u64,
-            "state": "WAITING",
-            "estimatedActivateFee": 0,
-            "estimatedTransferFee": 2000,
-            "createdAt": 1747909635678u64,
-            "updatedAt": 1747909635678u64
-        })
-    }
-
-    fn base_trace_response_payload() -> serde_json::Value {
-        json!({
-            "id": "6c3ff67e-0bf4-4c09-91ca-0c7c254b01a0",
-            "accountAddress": "TUUSMd58eC3fKx3fn7whxJyr1FR56tgaP8",
-            "gasFreeAddress": "TNER12mMVWruqopsW9FQtKxCGfZcEtb3ER",
-            "providerAddress": "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E",
-            "targetAddress": "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT",
-            "tokenAddress": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
-            "amount": 100000,
-            "state": "CONFIRMING",
-            "expiredAt": 1747909695000u64,
-            "estimatedActivateFee": 0,
-            "estimatedTransferFee": 2000,
-            "estimatedTotalFee": 2000,
-            "estimatedTotalCost": 102000,
-            "txnHash": "22".repeat(32),
-            "txnBlockNum": 57175988,
-            "txnBlockTimestamp": 1747909638000u64,
-            "txnState": "ON_CHAIN",
-            "txnActivateFee": 0,
-            "txnTransferFee": 2000,
-            "txnTotalFee": 2000,
-            "txnAmount": 100000,
-            "txnTotalCost": 102000,
-            "nonce": 8,
-            "version": 1,
-            "signature": "33".repeat(65)
         })
     }
 

--- a/mm2src/coins/eth/tron/gasfree/authorization.rs
+++ b/mm2src/coins/eth/tron/gasfree/authorization.rs
@@ -1,0 +1,134 @@
+use super::api_types::{deserialize_exact_version_one, deserialize_u256, serialize_u256_as_string};
+use super::config::ResolvedTronGaslessProvider;
+use super::error::TronGasfreeError;
+use super::typed_data::{hash_permit_transfer_typed_data, PermitTransferData, GASFREE_PERMIT_VERSION};
+use crate::eth::tron::{TronAddress, TronSignature};
+use crate::PrivKeyPolicy;
+use bip32::DerivationPath;
+use common::now_sec;
+use ethereum_types::U256;
+use ethkey::{public_to_address, sign, KeyPair};
+use mm2_err_handle::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GasfreeSignedAuthorization {
+    pub token: TronAddress,
+    pub service_provider: TronAddress,
+    pub user: TronAddress,
+    pub receiver: TronAddress,
+    #[serde(serialize_with = "serialize_u256_as_string", deserialize_with = "deserialize_u256")]
+    pub value: U256,
+    #[serde(serialize_with = "serialize_u256_as_string", deserialize_with = "deserialize_u256")]
+    pub max_fee: U256,
+    #[serde(serialize_with = "serialize_u256_as_string", deserialize_with = "deserialize_u256")]
+    pub deadline: U256,
+    #[serde(
+        serialize_with = "serialize_u256_as_string",
+        deserialize_with = "deserialize_exact_version_one"
+    )]
+    pub version: U256,
+    #[serde(serialize_with = "serialize_u256_as_string", deserialize_with = "deserialize_u256")]
+    pub nonce: U256,
+    pub sig: TronSignature,
+}
+
+impl fmt::Debug for GasfreeSignedAuthorization {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        struct RedactedSignature;
+
+        impl fmt::Debug for RedactedSignature {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "<redacted>")
+            }
+        }
+
+        f.debug_struct("GasfreeSignedAuthorization")
+            .field("token", &self.token)
+            .field("service_provider", &self.service_provider)
+            .field("user", &self.user)
+            .field("receiver", &self.receiver)
+            .field("value", &self.value)
+            .field("max_fee", &self.max_fee)
+            .field("deadline", &self.deadline)
+            .field("version", &self.version)
+            .field("nonce", &self.nonce)
+            .field("sig", &RedactedSignature)
+            .finish()
+    }
+}
+
+pub fn sign_permit_transfer(
+    provider: &ResolvedTronGaslessProvider,
+    transfer: &PermitTransferData,
+    priv_key_policy: &PrivKeyPolicy<KeyPair>,
+    derivation_path: Option<&DerivationPath>,
+) -> MmResult<GasfreeSignedAuthorization, TronGasfreeError> {
+    let key_pair = crate::eth::eth_utils::key_pair_from_priv_key_policy(priv_key_policy, derivation_path)
+        .map_to_mm(TronGasfreeError::InvalidRequest)?;
+    sign_permit_transfer_with_key_pair(provider, transfer, &key_pair)
+}
+
+fn sign_permit_transfer_with_key_pair(
+    provider: &ResolvedTronGaslessProvider,
+    transfer: &PermitTransferData,
+    key_pair: &KeyPair,
+) -> MmResult<GasfreeSignedAuthorization, TronGasfreeError> {
+    reject_expired_deadline(transfer.deadline)?;
+    verify_signing_key_matches_user(key_pair, &transfer.user)?;
+
+    let digest = hash_permit_transfer_typed_data(provider, transfer)?;
+    let signature = sign(key_pair.secret(), &digest).map_to_mm(|e| TronGasfreeError::Internal(e.to_string()))?;
+    let mut signature_bytes = signature.to_vec();
+    if signature_bytes.len() != 65 {
+        return MmError::err(TronGasfreeError::Internal(format!(
+            "Invalid GasFree signature length: {}",
+            signature_bytes.len()
+        )));
+    }
+    signature_bytes[64] = normalize_eip712_v(signature_bytes[64])?;
+    let sig = TronSignature::from_hex_str(&hex::encode(signature_bytes)).map_to_mm(TronGasfreeError::Internal)?;
+
+    Ok(GasfreeSignedAuthorization {
+        token: transfer.token,
+        service_provider: *provider.service_provider(),
+        user: transfer.user,
+        receiver: transfer.receiver,
+        value: transfer.value,
+        max_fee: transfer.max_fee,
+        deadline: transfer.deadline,
+        version: U256::from(GASFREE_PERMIT_VERSION),
+        nonce: transfer.nonce,
+        sig,
+    })
+}
+
+fn reject_expired_deadline(deadline: U256) -> MmResult<(), TronGasfreeError> {
+    if deadline <= U256::from(now_sec()) {
+        return MmError::err(TronGasfreeError::InvalidRequest(
+            "GasFree PermitTransfer deadline is expired".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn verify_signing_key_matches_user(key_pair: &KeyPair, user: &TronAddress) -> MmResult<(), TronGasfreeError> {
+    let signer = TronAddress::from(public_to_address(key_pair.public()));
+    if &signer != user {
+        return MmError::err(TronGasfreeError::InvalidRequest(
+            "GasFree PermitTransfer signing key does not match user address".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn normalize_eip712_v(v: u8) -> MmResult<u8, TronGasfreeError> {
+    match v {
+        0 | 1 => Ok(v + 27),
+        27 | 28 => Ok(v),
+        invalid => MmError::err(TronGasfreeError::Internal(format!(
+            "Invalid GasFree signature recovery id: {invalid}"
+        ))),
+    }
+}

--- a/mm2src/coins/eth/tron/gasfree/client.rs
+++ b/mm2src/coins/eth/tron/gasfree/client.rs
@@ -1,0 +1,470 @@
+use super::api_types::{
+    GasfreeAccountInfo, GasfreeSubmitRequest, GasfreeSubmitResponse, GasfreeSupportedToken, GasfreeTraceResponse,
+};
+use super::config::ResolvedTronGaslessProvider;
+use super::error::TronGasfreeError;
+use crate::eth::tron::TronAddress;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use common::custom_futures::timeout::FutureTimerExt;
+use common::now_sec;
+use hmac::{Hmac, Mac};
+use http::StatusCode;
+use mm2_err_handle::prelude::*;
+use mm2_net::transport::{slurp_post_json_with_headers, slurp_url_with_headers};
+use parking_lot::Mutex;
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::Value as Json;
+use sha2::Sha256;
+use std::fmt;
+use std::time::Duration;
+use url::Url;
+use uuid::Uuid;
+
+const API_PREFIX: &str = "api/v1";
+const HEADER_TIMESTAMP: &str = "Timestamp";
+const KOMODO_PROXY_COMMIT_MESSAGE: &str =
+    "KomodoProxy GasFree authentication is reserved for Commit 12 and is not implemented yet";
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Clone)]
+pub enum TronGasfreeTransport {
+    DirectHmac {
+        base_url: Url,
+        api_key: String,
+        api_secret: String,
+    },
+    KomodoProxy {
+        base_url: Url,
+    },
+}
+
+impl TronGasfreeTransport {
+    pub fn from_resolved_provider(provider: &ResolvedTronGaslessProvider) -> Self {
+        let config = provider.config();
+        TronGasfreeTransport::DirectHmac {
+            base_url: config.base_url.clone(),
+            api_key: config.api_key.clone(),
+            api_secret: config.api_secret.clone(),
+        }
+    }
+
+    fn base_url(&self) -> &Url {
+        match self {
+            TronGasfreeTransport::DirectHmac { base_url, .. } | TronGasfreeTransport::KomodoProxy { base_url } => {
+                base_url
+            },
+        }
+    }
+}
+
+impl fmt::Debug for TronGasfreeTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TronGasfreeTransport::DirectHmac { base_url, .. } => f
+                .debug_struct("TronGasfreeTransport::DirectHmac")
+                .field("base_url", base_url)
+                .field("api_key", &"<redacted>")
+                .field("api_secret", &"<redacted>")
+                .finish(),
+            TronGasfreeTransport::KomodoProxy { base_url } => f
+                .debug_struct("TronGasfreeTransport::KomodoProxy")
+                .field("base_url", base_url)
+                .finish(),
+        }
+    }
+}
+
+pub struct TronGasfreeClient {
+    transport: TronGasfreeTransport,
+    request_timeout: Duration,
+    // TODO(Commit 6): This cache is ineffective in production today because the client
+    // is rebuilt per call. Commit 6 should move the client/provider into a long-lived
+    // home on `EthCoinImpl` before supported-token caching can pay off.
+    supported_tokens_cache: Mutex<Option<Vec<GasfreeSupportedToken>>>,
+}
+
+impl TronGasfreeClient {
+    pub fn new(transport: TronGasfreeTransport, request_timeout_ms: u64) -> Self {
+        TronGasfreeClient {
+            transport,
+            request_timeout: Duration::from_millis(request_timeout_ms),
+            supported_tokens_cache: Mutex::new(None),
+        }
+    }
+
+    // TODO(Commit 6): The account service layer will call this to build the client
+    // from the platform-stored `ResolvedTronGaslessProvider`.
+    pub fn from_resolved_provider(provider: &ResolvedTronGaslessProvider) -> Self {
+        TronGasfreeClient::new(
+            TronGasfreeTransport::from_resolved_provider(provider),
+            provider.config().request_timeout_ms,
+        )
+    }
+
+    pub fn cached_supported_tokens(&self) -> Option<Vec<GasfreeSupportedToken>> {
+        self.supported_tokens_cache.lock().clone()
+    }
+
+    pub async fn get_account_info(&self, account: &TronAddress) -> MmResult<GasfreeAccountInfo, TronGasfreeError> {
+        let path = format!("{API_PREFIX}/address/{account}");
+        self.get_json(&path).await
+    }
+
+    pub async fn submit_transfer(
+        &self,
+        req: &GasfreeSubmitRequest,
+    ) -> MmResult<GasfreeSubmitResponse, TronGasfreeError> {
+        req.validate().map_to_mm(TronGasfreeError::InvalidRequest)?;
+        self.post_json(&format!("{API_PREFIX}/gasfree/submit"), req).await
+    }
+
+    pub async fn get_trace(&self, trace_id: &str) -> MmResult<GasfreeTraceResponse, TronGasfreeError> {
+        let trace_id = Uuid::parse_str(trace_id)
+            .map_err(|e| MmError::new(TronGasfreeError::InvalidRequest(format!("Invalid trace id: {e}"))))?;
+        self.get_json(&format!("{API_PREFIX}/gasfree/{trace_id}")).await
+    }
+
+    pub async fn get_supported_tokens(&self) -> MmResult<Vec<GasfreeSupportedToken>, TronGasfreeError> {
+        if let Some(cached) = self.cached_supported_tokens() {
+            return Ok(cached);
+        }
+
+        let tokens: Vec<GasfreeSupportedToken> = self.get_json(&format!("{API_PREFIX}/config/token/all")).await?;
+        *self.supported_tokens_cache.lock() = Some(tokens.clone());
+        Ok(tokens)
+    }
+
+    async fn get_json<T>(&self, path: &str) -> MmResult<T, TronGasfreeError>
+    where
+        T: DeserializeOwned,
+    {
+        self.execute_get(path).await
+    }
+
+    async fn post_json<T, R>(&self, path: &str, body: &T) -> MmResult<R, TronGasfreeError>
+    where
+        T: serde::Serialize,
+        R: DeserializeOwned,
+    {
+        let body = serde_json::to_string(body)
+            .map_to_mm(|e| TronGasfreeError::Internal(format!("Failed to serialize GasFree request: {e}")))?;
+        self.execute_post(path, body).await
+    }
+
+    async fn execute_get<T>(&self, endpoint_path: &str) -> MmResult<T, TronGasfreeError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_endpoint_url(self.transport.base_url(), endpoint_path)?;
+        let headers = build_auth_headers(&self.transport, "GET", url.path(), now_sec())?;
+        let borrowed_headers: Vec<(&str, &str)> = headers
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()))
+            .collect();
+        let response = Box::pin(slurp_url_with_headers(url.as_str(), borrowed_headers))
+            .timeout(self.request_timeout)
+            .await
+            .map_err(|_| MmError::new(TronGasfreeError::Timeout(format!("Request to {url} timed out"))))?;
+
+        let (status, _headers, body) = match response {
+            Ok(ok) => ok,
+            Err(err) => return MmError::err(TronGasfreeError::from(err.into_inner())),
+        };
+        decode_provider_response(status, &body)
+    }
+
+    async fn execute_post<T>(&self, endpoint_path: &str, body: String) -> MmResult<T, TronGasfreeError>
+    where
+        T: DeserializeOwned,
+    {
+        let url = join_endpoint_url(self.transport.base_url(), endpoint_path)?;
+        let headers = build_auth_headers(&self.transport, "POST", url.path(), now_sec())?;
+        let borrowed_headers: Vec<(&str, &str)> = headers
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.as_str()))
+            .collect();
+        let response = Box::pin(slurp_post_json_with_headers(url.as_str(), body, borrowed_headers))
+            .timeout(self.request_timeout)
+            .await
+            .map_err(|_| MmError::new(TronGasfreeError::Timeout(format!("Request to {url} timed out"))))?;
+
+        let (status, _headers, body) = match response {
+            Ok(ok) => ok,
+            Err(err) => return MmError::err(TronGasfreeError::from(err.into_inner())),
+        };
+        decode_provider_response(status, &body)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ProviderEnvelope<T> {
+    code: u16,
+    reason: Option<String>,
+    #[serde(default)]
+    message: String,
+    data: Option<T>,
+}
+
+fn join_endpoint_url(base_url: &Url, endpoint_path: &str) -> MmResult<Url, TronGasfreeError> {
+    let mut normalized = base_url.clone();
+    if !normalized.path().ends_with('/') {
+        let new_path = format!("{}/", normalized.path());
+        normalized.set_path(&new_path);
+    }
+
+    normalized
+        .join(endpoint_path.trim_start_matches('/'))
+        .map_to_mm(|e| TronGasfreeError::InvalidRequest(format!("Invalid GasFree base_url '{}': {e}", base_url)))
+}
+
+fn build_auth_headers(
+    transport: &TronGasfreeTransport,
+    method: &str,
+    request_path: &str,
+    timestamp: u64,
+) -> MmResult<Vec<(String, String)>, TronGasfreeError> {
+    match transport {
+        TronGasfreeTransport::DirectHmac {
+            api_key, api_secret, ..
+        } => {
+            let authorization = build_hmac_authorization(api_key, api_secret, method, request_path, timestamp);
+            Ok(vec![
+                (HEADER_TIMESTAMP.into(), timestamp.to_string()),
+                (http::header::AUTHORIZATION.as_str().into(), authorization),
+            ])
+        },
+        TronGasfreeTransport::KomodoProxy { .. } => {
+            MmError::err(TronGasfreeError::NotImplemented(KOMODO_PROXY_COMMIT_MESSAGE.into()))
+        },
+    }
+}
+
+fn build_hmac_authorization(
+    api_key: &str,
+    api_secret: &str,
+    method: &str,
+    request_path: &str,
+    timestamp: u64,
+) -> String {
+    let string_to_sign = format!("{method}{request_path}{timestamp}");
+    let mut mac = HmacSha256::new_from_slice(api_secret.as_bytes()).expect("HMAC-SHA256 accepts arbitrary-length keys");
+    mac.update(string_to_sign.as_bytes());
+    let signature = BASE64_STANDARD.encode(mac.finalize().into_bytes());
+    format!("ApiKey {api_key}:{signature}")
+}
+
+fn decode_provider_response<T>(status: StatusCode, body: &[u8]) -> MmResult<T, TronGasfreeError>
+where
+    T: DeserializeOwned,
+{
+    if !status.is_success() {
+        return MmError::err(provider_error_from_http_status(status, body));
+    }
+
+    let envelope: ProviderEnvelope<T> = serde_json::from_slice(body)
+        .map_to_mm(|e| TronGasfreeError::InvalidResponse(format!("GasFree API returned unexpected payload: {e}")))?;
+
+    if envelope.code != 200 {
+        let status_code = if (100..=599).contains(&envelope.code) {
+            envelope.code
+        } else {
+            StatusCode::BAD_GATEWAY.as_u16()
+        };
+        return MmError::err(provider_error_from_status(
+            status_code,
+            sanitize_provider_message(envelope.reason.as_deref(), Some(envelope.message.as_str()), None),
+        ));
+    }
+
+    envelope
+        .data
+        .or_mm_err(|| TronGasfreeError::InvalidResponse("GasFree API returned a success envelope without data".into()))
+}
+
+fn provider_error_from_http_status(status: StatusCode, body: &[u8]) -> TronGasfreeError {
+    if let Ok(envelope) = serde_json::from_slice::<ProviderEnvelope<Json>>(body) {
+        let status_code = if (100..=599).contains(&envelope.code) {
+            envelope.code
+        } else {
+            status.as_u16()
+        };
+        return provider_error_from_status(
+            status_code,
+            sanitize_provider_message(
+                envelope.reason.as_deref(),
+                Some(envelope.message.as_str()),
+                Some(&String::from_utf8_lossy(body)),
+            ),
+        );
+    }
+
+    provider_error_from_status(
+        status.as_u16(),
+        sanitize_provider_message(None, None, Some(&String::from_utf8_lossy(body))),
+    )
+}
+
+fn provider_error_from_status(status_code: u16, message: String) -> TronGasfreeError {
+    match status_code {
+        401 => TronGasfreeError::Unauthorized(message),
+        403 => TronGasfreeError::Forbidden(message),
+        429 => TronGasfreeError::RateLimited(message),
+        400..=499 => TronGasfreeError::ProviderBadRequest(message),
+        500..=599 => TronGasfreeError::Upstream(message),
+        _ => TronGasfreeError::Upstream(message),
+    }
+}
+
+fn sanitize_provider_message(reason: Option<&str>, message: Option<&str>, fallback_body: Option<&str>) -> String {
+    let reason = sanitize_text(reason.unwrap_or_default());
+    let message = sanitize_text(message.unwrap_or_default());
+
+    if !reason.is_empty() && !message.is_empty() {
+        return format!("{reason}: {message}");
+    }
+    if !message.is_empty() {
+        return message;
+    }
+    if !reason.is_empty() {
+        return reason;
+    }
+
+    let fallback = sanitize_text(fallback_body.unwrap_or_default());
+    if fallback.is_empty() {
+        "GasFree provider returned an error".into()
+    } else {
+        fallback
+    }
+}
+
+fn sanitize_text(text: &str) -> String {
+    const MAX_CHARS: usize = 256;
+
+    let sanitized = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if sanitized.chars().count() > MAX_CHARS {
+        let truncated: String = sanitized.chars().take(MAX_CHARS).collect();
+        format!("{truncated}…")
+    } else {
+        sanitized
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn hmac_authorization_matches_known_vector() {
+        let authorization = build_hmac_authorization(
+            "test-key",
+            "test-secret",
+            "GET",
+            "/nile/api/v1/config/token/all",
+            1_731_912_286,
+        );
+
+        assert_eq!(
+            authorization,
+            "ApiKey test-key:sYfwaLSnifcL/MTLFDmfORdCVceFLckEPL1mMKEjTHQ="
+        );
+    }
+
+    #[test]
+    fn transport_variants_preserve_routing_and_redaction() {
+        let err = build_auth_headers(
+            &TronGasfreeTransport::KomodoProxy {
+                base_url: Url::parse("https://proxy.komodo.test/").unwrap(),
+            },
+            "GET",
+            "/api/v1/config/token/all",
+            123,
+        )
+        .unwrap_err();
+        match err.into_inner() {
+            TronGasfreeError::NotImplemented(message) => assert!(message.contains("Commit 12")),
+            other => panic!("unexpected error: {:?}", other),
+        }
+
+        let transport = TronGasfreeTransport::DirectHmac {
+            base_url: Url::parse("https://open-test.gasfree.io/nile/").unwrap(),
+            api_key: "super-secret-key".into(),
+            api_secret: "super-secret-value".into(),
+        };
+        let debug = format!("{transport:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("super-secret-key"));
+        assert!(!debug.contains("super-secret-value"));
+    }
+
+    #[test]
+    fn http_200_with_provider_error_envelope_is_rejected() {
+        let err = decode_provider_response::<GasfreeSubmitResponse>(
+            StatusCode::OK,
+            br#"{"code":429,"reason":"TooManyRequests","message":" slow down ","data":null}"#,
+        )
+        .unwrap_err();
+
+        match err.into_inner() {
+            TronGasfreeError::RateLimited(message) => assert_eq!(message, "TooManyRequests: slow down"),
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn decode_submit_response_accepts_estimate_transfer_fee_alias_only() {
+        let body = serde_json::to_vec(&json!({
+            "code": 200,
+            "reason": null,
+            "message": "",
+            "data": {
+                "amount": 100000,
+                "providerAddress": "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E",
+                "accountAddress": "TUUSMd58eC3fKx3fn7whxJyr1FR56tgaP8",
+                "signature": "",
+                "targetAddress": "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT",
+                "maxFee": 2000000,
+                "version": 1,
+                "nonce": 8,
+                "tokenAddress": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+                "expiredAt": 1747909695000u64,
+                "estimateTransferFee": 2000,
+                "id": "6c3ff67e-0bf4-4c09-91ca-0c7c254b01a0",
+                "state": "WAITING",
+                "estimatedActivateFee": 0,
+                "gasFreeAddress": "TNER12mMVWruqopsW9FQtKxCGfZcEtb3ER"
+            }
+        }))
+        .unwrap();
+
+        let response: GasfreeSubmitResponse = decode_provider_response(StatusCode::OK, &body).unwrap();
+        assert_eq!(response.estimated_transfer_fee, 2000u64.into());
+    }
+
+    fn timed_out_slurp_error() -> mm2_net::transport::SlurpError {
+        mm2_net::transport::SlurpError::Timeout {
+            uri: "https://open-test.gasfree.io/nile/api/v1/config/token/all".into(),
+            error: "timed out".into(),
+        }
+    }
+
+    #[test]
+    fn timeout_slurp_error_maps_to_timeout_variant() {
+        let err = TronGasfreeError::from(timed_out_slurp_error());
+
+        match err {
+            TronGasfreeError::Timeout(message) => assert!(message.contains("timeout")),
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn sanitize_text_truncates_on_utf8_char_boundary() {
+        let input = format!("{}€€", "a".repeat(255));
+        let sanitized = sanitize_text(&input);
+        assert_eq!(sanitized, format!("{}€…", "a".repeat(255)));
+    }
+}

--- a/mm2src/coins/eth/tron/gasfree/client.rs
+++ b/mm2src/coins/eth/tron/gasfree/client.rs
@@ -1,7 +1,7 @@
 use super::api_types::{
     GasfreeAccountInfo, GasfreeSubmitRequest, GasfreeSubmitResponse, GasfreeSupportedToken, GasfreeTraceResponse,
 };
-use super::config::ResolvedTronGaslessProvider;
+use super::config::{ResolvedTronGaslessProvider, TronGaslessProviderConfig};
 use super::error::TronGasfreeError;
 use crate::eth::tron::TronAddress;
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
@@ -42,13 +42,16 @@ pub enum TronGasfreeTransport {
 }
 
 impl TronGasfreeTransport {
-    pub fn from_resolved_provider(provider: &ResolvedTronGaslessProvider) -> Self {
-        let config = provider.config();
+    pub fn from_config(config: &TronGaslessProviderConfig) -> Self {
         TronGasfreeTransport::DirectHmac {
             base_url: config.base_url.clone(),
             api_key: config.api_key.clone(),
             api_secret: config.api_secret.clone(),
         }
+    }
+
+    pub fn from_resolved_provider(provider: &ResolvedTronGaslessProvider) -> Self {
+        TronGasfreeTransport::from_config(provider.config())
     }
 
     fn base_url(&self) -> &Url {
@@ -80,9 +83,6 @@ impl fmt::Debug for TronGasfreeTransport {
 pub struct TronGasfreeClient {
     transport: TronGasfreeTransport,
     request_timeout: Duration,
-    // TODO(Commit 6): This cache is ineffective in production today because the client
-    // is rebuilt per call. Commit 6 should move the client/provider into a long-lived
-    // home on `EthCoinImpl` before supported-token caching can pay off.
     supported_tokens_cache: Mutex<Option<Vec<GasfreeSupportedToken>>>,
 }
 
@@ -95,13 +95,12 @@ impl TronGasfreeClient {
         }
     }
 
-    // TODO(Commit 6): The account service layer will call this to build the client
-    // from the platform-stored `ResolvedTronGaslessProvider`.
+    pub fn from_config(config: &TronGaslessProviderConfig) -> Self {
+        TronGasfreeClient::new(TronGasfreeTransport::from_config(config), config.request_timeout_ms)
+    }
+
     pub fn from_resolved_provider(provider: &ResolvedTronGaslessProvider) -> Self {
-        TronGasfreeClient::new(
-            TronGasfreeTransport::from_resolved_provider(provider),
-            provider.config().request_timeout_ms,
-        )
+        TronGasfreeClient::from_config(provider.config())
     }
 
     pub fn cached_supported_tokens(&self) -> Option<Vec<GasfreeSupportedToken>> {

--- a/mm2src/coins/eth/tron/gasfree/client.rs
+++ b/mm2src/coins/eth/tron/gasfree/client.rs
@@ -354,6 +354,7 @@ fn sanitize_text(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::eth::tron::gasfree::test_helpers::{base_submit_response_payload, provider_envelope};
     use serde_json::json;
 
     #[test]
@@ -415,29 +416,11 @@ mod tests {
 
     #[test]
     fn decode_submit_response_accepts_estimate_transfer_fee_alias_only() {
-        let body = serde_json::to_vec(&json!({
-            "code": 200,
-            "reason": null,
-            "message": "",
-            "data": {
-                "amount": 100000,
-                "providerAddress": "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E",
-                "accountAddress": "TUUSMd58eC3fKx3fn7whxJyr1FR56tgaP8",
-                "signature": "",
-                "targetAddress": "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT",
-                "maxFee": 2000000,
-                "version": 1,
-                "nonce": 8,
-                "tokenAddress": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
-                "expiredAt": 1747909695000u64,
-                "estimateTransferFee": 2000,
-                "id": "6c3ff67e-0bf4-4c09-91ca-0c7c254b01a0",
-                "state": "WAITING",
-                "estimatedActivateFee": 0,
-                "gasFreeAddress": "TNER12mMVWruqopsW9FQtKxCGfZcEtb3ER"
-            }
-        }))
-        .unwrap();
+        let mut data = base_submit_response_payload();
+        let object = data.as_object_mut().unwrap();
+        object.remove("estimatedTransferFee");
+        object.insert("estimateTransferFee".into(), json!(2000));
+        let body = serde_json::to_vec(&provider_envelope(data)).unwrap();
 
         let response: GasfreeSubmitResponse = decode_provider_response(StatusCode::OK, &body).unwrap();
         assert_eq!(response.estimated_transfer_fee, 2000u64.into());

--- a/mm2src/coins/eth/tron/gasfree/config.rs
+++ b/mm2src/coins/eth/tron/gasfree/config.rs
@@ -13,7 +13,9 @@ const DEFAULT_STATUS_POLL_INTERVAL_MS: u64 = 3_000;
 /// Contains API credentials that MUST NOT appear in Debug output or serialized responses.
 #[derive(Clone, Deserialize)]
 pub struct TronGaslessProviderConfig {
-    /// Base URL for the GasFree API.
+    /// Host-only GasFree API URL (e.g. `https://open.gasfree.io`).
+    /// The resolver appends `/tron/`, `/nile/`, or `/shasta/` based on the activated TRON network.
+    /// A user-supplied path segment is rejected as `InvalidBaseUrl` at activation.
     pub base_url: Url,
     /// API key for authentication.
     pub api_key: String,
@@ -83,10 +85,15 @@ impl ResolvedTronGaslessProvider {
         }
     }
 
+    /// TODO(Commit 7, Commit 8): Consumed by Commit 7 (`GasfreeSubmitRequest.service_provider`)
+    /// and Commit 8 (TIP-712 `serviceProvider` field). Pre-parsed at activation by design.
     pub fn service_provider(&self) -> &TronAddress {
         &self.service_provider
     }
 
+    /// TODO(Commit 8): Consumed by TIP-712 `PermitTransferMessage` signing
+    /// (`verifyingContract` domain field). Pre-parsed at activation by design;
+    /// see the Commit 3 plan section for rationale.
     pub fn verifying_contract(&self) -> &TronAddress {
         &self.verifying_contract
     }

--- a/mm2src/coins/eth/tron/gasfree/config.rs
+++ b/mm2src/coins/eth/tron/gasfree/config.rs
@@ -1,6 +1,7 @@
 use super::client::TronGasfreeClient;
 use super::error::TronGaslessConfigError;
 use crate::eth::tron::{Network, TronAddress};
+use ethereum_types::U256;
 use serde::Deserialize;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -59,8 +60,15 @@ impl TronGaslessProviderConfig {
     }
 }
 
+/// Token-level GasFree settings resolved at activation time for TRON TRC20 assets.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedTronGaslessTokenConfig {
+    /// Maximum provider fee allowed for transfers, converted at activation to token base units.
+    pub transfer_max_fee_token_base_units: Option<U256>,
+}
+
 /// Fully-validated GasFree provider state that can be stored on coin context.
-/// Redult of [`resolve_tron_gasless_provider`](super::resolve_tron_gasless_provider).
+/// Result of [`resolve_tron_gasless_provider`](super::resolve_tron_gasless_provider).
 #[derive(Clone)]
 pub struct ResolvedTronGaslessProvider {
     raw: TronGaslessProviderConfig,

--- a/mm2src/coins/eth/tron/gasfree/config.rs
+++ b/mm2src/coins/eth/tron/gasfree/config.rs
@@ -1,9 +1,10 @@
-use crate::eth::tron::TronAddress;
+use super::client::TronGasfreeClient;
+use super::error::TronGaslessConfigError;
+use crate::eth::tron::{Network, TronAddress};
 use serde::Deserialize;
 use std::str::FromStr;
+use std::sync::Arc;
 use url::Url;
-
-use super::error::TronGaslessConfigError;
 
 const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 15_000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS: u64 = 3_000;
@@ -58,31 +59,36 @@ impl TronGaslessProviderConfig {
     }
 }
 
-/// Fully-validated GasFree provider state stored on `EthCoinImpl` after activation.
-///
-/// `service_provider` is parsed from the user-supplied config.
-/// `verifying_contract` is derived from the hardcoded per-network controller.
-/// Construction is only possible via
-/// [`resolve_tron_gasless_provider`](super::resolve_tron_gasless_provider).
+/// Fully-validated GasFree provider state that can be stored on coin context.
+/// Redult of [`resolve_tron_gasless_provider`](super::resolve_tron_gasless_provider).
 #[derive(Clone)]
 pub struct ResolvedTronGaslessProvider {
     raw: TronGaslessProviderConfig,
+    network: Network,
     service_provider: TronAddress,
     verifying_contract: TronAddress,
+    client: Arc<TronGasfreeClient>,
 }
 
 impl ResolvedTronGaslessProvider {
     /// Construct a resolved provider. Only callable from the gasfree module.
     pub(super) fn new(
         raw: TronGaslessProviderConfig,
+        network: Network,
         service_provider: TronAddress,
         verifying_contract: TronAddress,
     ) -> Self {
         ResolvedTronGaslessProvider {
+            client: Arc::new(TronGasfreeClient::from_config(&raw)),
             raw,
+            network,
             service_provider,
             verifying_contract,
         }
+    }
+
+    pub fn network(&self) -> &Network {
+        &self.network
     }
 
     /// TODO(Commit 7, Commit 8): Consumed by Commit 7 (`GasfreeSubmitRequest.service_provider`)
@@ -98,6 +104,10 @@ impl ResolvedTronGaslessProvider {
         &self.verifying_contract
     }
 
+    pub fn client(&self) -> &Arc<TronGasfreeClient> {
+        &self.client
+    }
+
     pub fn config(&self) -> &TronGaslessProviderConfig {
         &self.raw
     }
@@ -108,7 +118,9 @@ impl std::fmt::Debug for ResolvedTronGaslessProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ResolvedTronGaslessProvider")
             .field("raw", &self.raw)
+            .field("network", &self.network)
             .field("service_provider", &self.service_provider)
+            .field("verifying_contract", &self.verifying_contract)
             .finish_non_exhaustive()
     }
 }

--- a/mm2src/coins/eth/tron/gasfree/config.rs
+++ b/mm2src/coins/eth/tron/gasfree/config.rs
@@ -1,0 +1,50 @@
+use serde::Deserialize;
+use url::Url;
+
+const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 15_000;
+const DEFAULT_STATUS_POLL_INTERVAL_MS: u64 = 3_000;
+
+/// Configuration for a TRON GasFree provider, supplied at platform activation time.
+///
+/// Contains API credentials that MUST NOT appear in Debug output or serialized responses.
+#[derive(Clone, Deserialize)]
+pub struct TronGaslessProviderConfig {
+    /// Base URL for the GasFree API.
+    pub base_url: Url,
+    /// API key for authentication.
+    pub api_key: String,
+    /// API secret for HMAC-SHA256 signing.
+    pub api_secret: String,
+    /// Service provider TRON address for TIP-712 PermitTransferMessage.
+    /// Per-network constant (same for all providers on a given network), but kept here
+    /// rather than hardcoded because GasFree protocol upgrades could deploy new addresses.
+    /// Can be obtained from the GasFree API (`/api/v1/config/provider/all`).
+    // TODO: Maybe obtain this on activation and cache it, rather than requiring users to manually input it.
+    pub service_provider: String,
+    /// Verifying contract TRON address for TIP-712 domain and CREATE2 address computation.
+    /// Per-network constant, but kept here rather than hardcoded because GasFree protocol
+    /// upgrades could deploy new addresses.
+    pub verifying_contract: String,
+    /// Request timeout in milliseconds for GasFree API calls.
+    #[serde(default = "default_request_timeout_ms")]
+    pub request_timeout_ms: u64,
+    /// Polling interval in milliseconds for transfer status checks.
+    #[serde(default = "default_status_poll_interval_ms")]
+    pub status_poll_interval_ms: u64,
+}
+
+fn default_request_timeout_ms() -> u64 {
+    DEFAULT_REQUEST_TIMEOUT_MS
+}
+fn default_status_poll_interval_ms() -> u64 {
+    DEFAULT_STATUS_POLL_INTERVAL_MS
+}
+
+/// Redacted Debug — secrets MUST NOT be logged.
+impl std::fmt::Debug for TronGaslessProviderConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TronGaslessProviderConfig")
+            .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
+}

--- a/mm2src/coins/eth/tron/gasfree/config.rs
+++ b/mm2src/coins/eth/tron/gasfree/config.rs
@@ -1,5 +1,9 @@
+use crate::eth::tron::TronAddress;
 use serde::Deserialize;
+use std::str::FromStr;
 use url::Url;
+
+use super::error::TronGaslessConfigError;
 
 const DEFAULT_REQUEST_TIMEOUT_MS: u64 = 15_000;
 const DEFAULT_STATUS_POLL_INTERVAL_MS: u64 = 3_000;
@@ -16,15 +20,10 @@ pub struct TronGaslessProviderConfig {
     /// API secret for HMAC-SHA256 signing.
     pub api_secret: String,
     /// Service provider TRON address for TIP-712 PermitTransferMessage.
-    /// Per-network constant (same for all providers on a given network), but kept here
-    /// rather than hardcoded because GasFree protocol upgrades could deploy new addresses.
-    /// Can be obtained from the GasFree API (`/api/v1/config/provider/all`).
-    // TODO: Maybe obtain this on activation and cache it, rather than requiring users to manually input it.
+    /// Validated as a parseable TRON address at activation time.
+    // TODO: Remove once the API-fetch path is implemented — fetch from
+    // `/api/v1/config/provider/all` at activation time instead of requiring user input.
     pub service_provider: String,
-    /// Verifying contract TRON address for TIP-712 domain and CREATE2 address computation.
-    /// Per-network constant, but kept here rather than hardcoded because GasFree protocol
-    /// upgrades could deploy new addresses.
-    pub verifying_contract: String,
     /// Request timeout in milliseconds for GasFree API calls.
     #[serde(default = "default_request_timeout_ms")]
     pub request_timeout_ms: u64,
@@ -45,6 +44,64 @@ impl std::fmt::Debug for TronGaslessProviderConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TronGaslessProviderConfig")
             .field("base_url", &self.base_url)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TronGaslessProviderConfig {
+    /// Parse `service_provider` as a TRON address.
+    pub fn service_provider_address(&self) -> Result<TronAddress, TronGaslessConfigError> {
+        TronAddress::from_str(&self.service_provider)
+            .map_err(|e| TronGaslessConfigError::InvalidServiceProvider { reason: e.to_string() })
+    }
+}
+
+/// Fully-validated GasFree provider state stored on `EthCoinImpl` after activation.
+///
+/// `service_provider` is parsed from the user-supplied config.
+/// `verifying_contract` is derived from the hardcoded per-network controller.
+/// Construction is only possible via
+/// [`resolve_tron_gasless_provider`](super::resolve_tron_gasless_provider).
+#[derive(Clone)]
+pub struct ResolvedTronGaslessProvider {
+    raw: TronGaslessProviderConfig,
+    service_provider: TronAddress,
+    verifying_contract: TronAddress,
+}
+
+impl ResolvedTronGaslessProvider {
+    /// Construct a resolved provider. Only callable from the gasfree module.
+    pub(super) fn new(
+        raw: TronGaslessProviderConfig,
+        service_provider: TronAddress,
+        verifying_contract: TronAddress,
+    ) -> Self {
+        ResolvedTronGaslessProvider {
+            raw,
+            service_provider,
+            verifying_contract,
+        }
+    }
+
+    pub fn service_provider(&self) -> &TronAddress {
+        &self.service_provider
+    }
+
+    pub fn verifying_contract(&self) -> &TronAddress {
+        &self.verifying_contract
+    }
+
+    pub fn config(&self) -> &TronGaslessProviderConfig {
+        &self.raw
+    }
+}
+
+/// Redacted Debug — delegates to the raw config's redacted Debug.
+impl std::fmt::Debug for ResolvedTronGaslessProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResolvedTronGaslessProvider")
+            .field("raw", &self.raw)
+            .field("service_provider", &self.service_provider)
             .finish_non_exhaustive()
     }
 }

--- a/mm2src/coins/eth/tron/gasfree/error.rs
+++ b/mm2src/coins/eth/tron/gasfree/error.rs
@@ -5,4 +5,6 @@ use derive_more::Display;
 pub enum TronGaslessConfigError {
     #[display(fmt = "GasFree is only supported on TRON chains, got {chain}")]
     UnsupportedChain { chain: String },
+    #[display(fmt = "Invalid GasFree service_provider address: {reason}")]
+    InvalidServiceProvider { reason: String },
 }

--- a/mm2src/coins/eth/tron/gasfree/error.rs
+++ b/mm2src/coins/eth/tron/gasfree/error.rs
@@ -1,10 +1,76 @@
+use common::HttpStatusCode;
 use derive_more::Display;
+use http::StatusCode;
+use mm2_net::transport::SlurpError;
+use ser_error_derive::SerializeErrorType;
+use serde::Serialize;
 
 /// Errors during GasFree activation-time configuration validation.
 #[derive(Debug, Display)]
 pub enum TronGaslessConfigError {
     #[display(fmt = "GasFree is only supported on TRON chains, got {chain}")]
     UnsupportedChain { chain: String },
+    #[display(fmt = "Invalid GasFree base_url: {reason}")]
+    InvalidBaseUrl { reason: String },
     #[display(fmt = "Invalid GasFree service_provider address: {reason}")]
     InvalidServiceProvider { reason: String },
+}
+
+/// Errors during GasFree runtime HTTP/API interactions.
+#[derive(Clone, Debug, Display, Serialize, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum TronGasfreeError {
+    #[display(fmt = "Invalid request: {_0}")]
+    InvalidRequest(String),
+    #[display(fmt = "Invalid response: {_0}")]
+    InvalidResponse(String),
+    #[display(fmt = "Transport: {_0}")]
+    Transport(String),
+    #[display(fmt = "Timeout: {_0}")]
+    Timeout(String),
+    #[display(fmt = "GasFree provider rejected the request: {_0}")]
+    ProviderBadRequest(String),
+    #[display(fmt = "GasFree authentication failed: {_0}")]
+    Unauthorized(String),
+    #[display(fmt = "GasFree access forbidden: {_0}")]
+    Forbidden(String),
+    #[display(fmt = "GasFree rate limit exceeded: {_0}")]
+    RateLimited(String),
+    #[display(fmt = "GasFree upstream error: {_0}")]
+    Upstream(String),
+    #[display(fmt = "Not implemented: {_0}")]
+    NotImplemented(String),
+    #[display(fmt = "Internal: {_0}")]
+    Internal(String),
+}
+
+impl HttpStatusCode for TronGasfreeError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            TronGasfreeError::InvalidRequest(_) => StatusCode::BAD_REQUEST,
+            TronGasfreeError::Timeout(_) => StatusCode::GATEWAY_TIMEOUT,
+            TronGasfreeError::Transport(_) | TronGasfreeError::InvalidResponse(_) | TronGasfreeError::Upstream(_) => {
+                StatusCode::BAD_GATEWAY
+            },
+            TronGasfreeError::ProviderBadRequest(_) => StatusCode::BAD_REQUEST,
+            TronGasfreeError::Unauthorized(_) => StatusCode::UNAUTHORIZED,
+            TronGasfreeError::Forbidden(_) => StatusCode::FORBIDDEN,
+            TronGasfreeError::RateLimited(_) => StatusCode::TOO_MANY_REQUESTS,
+            TronGasfreeError::NotImplemented(_) => StatusCode::NOT_IMPLEMENTED,
+            TronGasfreeError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}
+
+impl From<SlurpError> for TronGasfreeError {
+    fn from(err: SlurpError) -> Self {
+        let message = err.to_string();
+        match err {
+            SlurpError::InvalidRequest(_) => TronGasfreeError::InvalidRequest(message),
+            SlurpError::ErrorDeserializing { .. } => TronGasfreeError::InvalidResponse(message),
+            SlurpError::Timeout { .. } => TronGasfreeError::Timeout(message),
+            SlurpError::Transport { .. } => TronGasfreeError::Transport(message),
+            SlurpError::Internal(_) => TronGasfreeError::Internal(message),
+        }
+    }
 }

--- a/mm2src/coins/eth/tron/gasfree/error.rs
+++ b/mm2src/coins/eth/tron/gasfree/error.rs
@@ -1,3 +1,4 @@
+use crate::eth::{format_remote_error, Web3RpcError};
 use common::HttpStatusCode;
 use derive_more::Display;
 use http::StatusCode;
@@ -105,6 +106,22 @@ impl From<SlurpError> for TronGasfreeError {
             SlurpError::Timeout { .. } => TronGasfreeError::Timeout(message),
             SlurpError::Transport { .. } => TronGasfreeError::Transport(message),
             SlurpError::Internal(_) => TronGasfreeError::Internal(message),
+        }
+    }
+}
+
+impl From<Web3RpcError> for TronGasfreeError {
+    fn from(err: Web3RpcError) -> Self {
+        match err {
+            Web3RpcError::Transport(message) => TronGasfreeError::Transport(message),
+            Web3RpcError::Timeout(message) => TronGasfreeError::Timeout(message),
+            Web3RpcError::BadResponse(message) | Web3RpcError::InvalidResponse(message) => {
+                TronGasfreeError::InvalidResponse(message)
+            },
+            Web3RpcError::RemoteError { code, message } => {
+                TronGasfreeError::InvalidResponse(format_remote_error(code, message))
+            },
+            other => TronGasfreeError::InvalidResponse(other.to_string()),
         }
     }
 }

--- a/mm2src/coins/eth/tron/gasfree/error.rs
+++ b/mm2src/coins/eth/tron/gasfree/error.rs
@@ -16,6 +16,40 @@ pub enum TronGaslessConfigError {
     InvalidServiceProvider { reason: String },
 }
 
+/// Withdraw-level errors specific to TRON GasFree routing.
+#[derive(Clone, Debug, Display, PartialEq, Serialize, SerializeErrorType)]
+#[serde(tag = "error_type", content = "error_data")]
+pub enum GaslessWithdrawError {
+    #[display(fmt = "Gasless withdraw is unavailable for this coin or request")]
+    Unavailable,
+    #[display(fmt = "A gasless transfer is already pending; wait for settlement and retry")]
+    PendingTransfer,
+    #[display(fmt = "Gasless provider fee exceeds the requested maximum")]
+    MaxFeeExceeded,
+    #[display(fmt = "Gasless provider rejected the transfer")]
+    ProviderRejected,
+    #[display(fmt = "Gasless provider returned an invalid response")]
+    InvalidProviderResponse,
+    #[display(fmt = "Gasless transfer trace was not found")]
+    TraceNotFound,
+    #[display(fmt = "Gasless quote expired")]
+    QuoteExpired,
+}
+
+impl HttpStatusCode for GaslessWithdrawError {
+    fn status_code(&self) -> StatusCode {
+        match self {
+            GaslessWithdrawError::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+            GaslessWithdrawError::PendingTransfer => StatusCode::CONFLICT,
+            GaslessWithdrawError::MaxFeeExceeded | GaslessWithdrawError::QuoteExpired => StatusCode::BAD_REQUEST,
+            GaslessWithdrawError::ProviderRejected | GaslessWithdrawError::InvalidProviderResponse => {
+                StatusCode::BAD_GATEWAY
+            },
+            GaslessWithdrawError::TraceNotFound => StatusCode::NOT_FOUND,
+        }
+    }
+}
+
 /// Errors during GasFree runtime HTTP/API interactions.
 #[derive(Clone, Debug, Display, Serialize, SerializeErrorType)]
 #[serde(tag = "error_type", content = "error_data")]

--- a/mm2src/coins/eth/tron/gasfree/error.rs
+++ b/mm2src/coins/eth/tron/gasfree/error.rs
@@ -1,0 +1,8 @@
+use derive_more::Display;
+
+/// Errors during GasFree activation-time configuration validation.
+#[derive(Debug, Display)]
+pub enum TronGaslessConfigError {
+    #[display(fmt = "GasFree is only supported on TRON chains, got {chain}")]
+    UnsupportedChain { chain: String },
+}

--- a/mm2src/coins/eth/tron/gasfree/mod.rs
+++ b/mm2src/coins/eth/tron/gasfree/mod.rs
@@ -1,12 +1,19 @@
 pub mod address;
+pub mod api_types;
+pub mod client;
 pub mod config;
 pub mod error;
 
-pub use address::{compute_gasfree_address_for_network, controller_for_network};
-pub use config::{ResolvedTronGaslessProvider, TronGaslessProviderConfig};
-pub use error::TronGaslessConfigError;
-
 use crate::eth::ChainSpec;
+pub use address::{api_path_segment_for_network, compute_gasfree_address_for_network, controller_for_network};
+pub use api_types::{
+    GasfreeAccountAsset, GasfreeAccountInfo, GasfreeRequestId, GasfreeSubmitRequest, GasfreeSubmitResponse,
+    GasfreeSupportedToken, GasfreeTraceResponse, GasfreeTransactionState, GasfreeTransferState,
+};
+pub use client::{TronGasfreeClient, TronGasfreeTransport};
+pub use config::{ResolvedTronGaslessProvider, TronGaslessProviderConfig};
+pub use error::{TronGasfreeError, TronGaslessConfigError};
+use url::Url;
 
 /// Validate and resolve a TRON GasFree provider config at platform activation time.
 pub fn resolve_tron_gasless_provider(
@@ -30,10 +37,99 @@ pub fn resolve_tron_gasless_provider(
 
     let service_provider = config.service_provider_address()?;
     let verifying_contract = controller_for_network(network);
+    let mut resolved_config = config.clone();
+    resolved_config.base_url = resolve_gasfree_base_url(&config.base_url, network)?;
 
     Ok(Some(ResolvedTronGaslessProvider::new(
-        config.clone(),
+        resolved_config,
         service_provider,
         verifying_contract,
     )))
+}
+
+fn resolve_gasfree_base_url(
+    base_url: &Url,
+    network: &crate::eth::tron::Network,
+) -> Result<Url, TronGaslessConfigError> {
+    let path = base_url.path();
+    if path != "/" {
+        return Err(TronGaslessConfigError::InvalidBaseUrl {
+            reason: format!("expected a host-only URL, got path '{path}'"),
+        });
+    }
+
+    let mut resolved = base_url.clone();
+    resolved.set_path(&format!("/{}/", api_path_segment_for_network(network)));
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eth::tron::Network;
+
+    fn provider_config(base_url: &str) -> TronGaslessProviderConfig {
+        TronGaslessProviderConfig {
+            base_url: Url::parse(base_url).unwrap(),
+            api_key: "key".into(),
+            api_secret: "secret".into(),
+            service_provider: "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E".into(),
+            request_timeout_ms: 15_000,
+            status_poll_interval_ms: 3_000,
+        }
+    }
+
+    fn resolved_path(network: Network, base_url: &str) -> String {
+        let provider = resolve_tron_gasless_provider(&ChainSpec::Tron { network }, Some(&provider_config(base_url)))
+            .unwrap()
+            .unwrap();
+
+        provider
+            .config()
+            .base_url
+            .join("api/v1/config/token/all")
+            .unwrap()
+            .path()
+            .to_string()
+    }
+
+    #[test]
+    fn resolver_derives_network_base_path_for_each_network() {
+        assert_eq!(
+            resolved_path(Network::Mainnet, "https://open.gasfree.io"),
+            "/tron/api/v1/config/token/all"
+        );
+        assert_eq!(
+            resolved_path(Network::Nile, "https://open-test.gasfree.io"),
+            "/nile/api/v1/config/token/all"
+        );
+        assert_eq!(
+            resolved_path(Network::Shasta, "https://open-test.gasfree.io"),
+            "/shasta/api/v1/config/token/all"
+        );
+    }
+
+    #[test]
+    fn resolver_rejects_user_supplied_base_url_path() {
+        let err = resolve_tron_gasless_provider(
+            &ChainSpec::Tron {
+                network: Network::Mainnet,
+            },
+            Some(&provider_config("https://open.gasfree.io/tron/")),
+        )
+        .unwrap_err();
+
+        match err {
+            TronGaslessConfigError::InvalidBaseUrl { reason } => assert!(reason.contains("host-only")),
+            other => panic!("unexpected error: {:?}", other),
+        }
+    }
+
+    #[test]
+    fn resolver_tolerates_trailing_slash_on_host_only_base_url() {
+        assert_eq!(
+            resolved_path(Network::Mainnet, "https://open.gasfree.io"),
+            resolved_path(Network::Mainnet, "https://open.gasfree.io/")
+        );
+    }
 }

--- a/mm2src/coins/eth/tron/gasfree/mod.rs
+++ b/mm2src/coins/eth/tron/gasfree/mod.rs
@@ -3,6 +3,7 @@ pub mod api_types;
 pub mod client;
 pub mod config;
 pub mod error;
+pub mod service;
 
 use crate::eth::ChainSpec;
 pub use address::{api_path_segment_for_network, compute_gasfree_address_for_network, controller_for_network};
@@ -13,6 +14,10 @@ pub use api_types::{
 pub use client::{TronGasfreeClient, TronGasfreeTransport};
 pub use config::{ResolvedTronGaslessProvider, TronGaslessProviderConfig};
 pub use error::{TronGasfreeError, TronGaslessConfigError};
+pub use service::{
+    DisabledReason, GasfreeAccountService, GasfreeAvailability, GasfreeRecommendation, GasfreeTransferPreflight,
+    GasfreeTransferRequest, NativeRouteAvailability, OnChainBalanceFetcher,
+};
 use url::Url;
 
 /// Validate and resolve a TRON GasFree provider config at platform activation time.
@@ -42,6 +47,7 @@ pub fn resolve_tron_gasless_provider(
 
     Ok(Some(ResolvedTronGaslessProvider::new(
         resolved_config,
+        network.clone(),
         service_provider,
         verifying_contract,
     )))

--- a/mm2src/coins/eth/tron/gasfree/mod.rs
+++ b/mm2src/coins/eth/tron/gasfree/mod.rs
@@ -4,8 +4,10 @@ pub mod authorization;
 pub mod client;
 pub mod config;
 pub mod error;
+pub mod relay_payload;
 pub mod service;
 pub mod typed_data;
+pub(crate) mod withdraw;
 
 use crate::eth::ChainSpec;
 pub use address::{api_path_segment_for_network, compute_gasfree_address_for_network, controller_for_network};
@@ -15,11 +17,12 @@ pub use api_types::{
 };
 pub use authorization::{sign_permit_transfer, GasfreeSignedAuthorization};
 pub use client::{TronGasfreeClient, TronGasfreeTransport};
-pub use config::{ResolvedTronGaslessProvider, TronGaslessProviderConfig};
+pub use config::{ResolvedTronGaslessProvider, ResolvedTronGaslessTokenConfig, TronGaslessProviderConfig};
 pub use error::{GaslessWithdrawError, TronGasfreeError, TronGaslessConfigError};
+pub use relay_payload::{TronGasfreeRelayPayload, TRON_GASFREE_RELAY_TYPE};
 pub use service::{
-    DisabledReason, GasfreeAccountService, GasfreeAvailability, GasfreeRecommendation, GasfreeTransferPreflight,
-    GasfreeTransferRequest, NativeRouteAvailability, OnChainBalanceFetcher,
+    DisabledReason, GasfreeAccountService, GasfreeAvailability, GasfreeTransferPreflight, GasfreeTransferRequest,
+    OnChainBalanceFetcher, TronOnChainBalanceFetcher,
 };
 pub use typed_data::{
     build_permit_transfer_typed_data, hash_permit_transfer_typed_data, GasfreeDomain, PermitTransferData,

--- a/mm2src/coins/eth/tron/gasfree/mod.rs
+++ b/mm2src/coins/eth/tron/gasfree/mod.rs
@@ -13,7 +13,7 @@ pub use api_types::{
 };
 pub use client::{TronGasfreeClient, TronGasfreeTransport};
 pub use config::{ResolvedTronGaslessProvider, TronGaslessProviderConfig};
-pub use error::{TronGasfreeError, TronGaslessConfigError};
+pub use error::{GaslessWithdrawError, TronGasfreeError, TronGaslessConfigError};
 pub use service::{
     DisabledReason, GasfreeAccountService, GasfreeAvailability, GasfreeRecommendation, GasfreeTransferPreflight,
     GasfreeTransferRequest, NativeRouteAvailability, OnChainBalanceFetcher,

--- a/mm2src/coins/eth/tron/gasfree/mod.rs
+++ b/mm2src/coins/eth/tron/gasfree/mod.rs
@@ -1,7 +1,9 @@
+pub mod address;
 pub mod config;
 pub mod error;
 
-pub use config::TronGaslessProviderConfig;
+pub use address::{compute_gasfree_address_for_network, controller_for_network};
+pub use config::{ResolvedTronGaslessProvider, TronGaslessProviderConfig};
 pub use error::TronGaslessConfigError;
 
 use crate::eth::ChainSpec;
@@ -10,18 +12,28 @@ use crate::eth::ChainSpec;
 pub fn resolve_tron_gasless_provider(
     chain_spec: &ChainSpec,
     provider_config: Option<&TronGaslessProviderConfig>,
-) -> Result<Option<TronGaslessProviderConfig>, TronGaslessConfigError> {
+) -> Result<Option<ResolvedTronGaslessProvider>, TronGaslessConfigError> {
     let config = match provider_config {
         Some(cfg) => cfg,
         None => return Ok(None),
     };
 
     // GasFree is TRON-only
-    if !matches!(chain_spec, ChainSpec::Tron { .. }) {
-        return Err(TronGaslessConfigError::UnsupportedChain {
-            chain: chain_spec.kind().to_string(),
-        });
-    }
+    let network = match chain_spec {
+        ChainSpec::Tron { network } => network,
+        _ => {
+            return Err(TronGaslessConfigError::UnsupportedChain {
+                chain: chain_spec.kind().to_string(),
+            });
+        },
+    };
 
-    Ok(Some(config.clone()))
+    let service_provider = config.service_provider_address()?;
+    let verifying_contract = controller_for_network(network);
+
+    Ok(Some(ResolvedTronGaslessProvider::new(
+        config.clone(),
+        service_provider,
+        verifying_contract,
+    )))
 }

--- a/mm2src/coins/eth/tron/gasfree/mod.rs
+++ b/mm2src/coins/eth/tron/gasfree/mod.rs
@@ -1,9 +1,11 @@
 pub mod address;
 pub mod api_types;
+pub mod authorization;
 pub mod client;
 pub mod config;
 pub mod error;
 pub mod service;
+pub mod typed_data;
 
 use crate::eth::ChainSpec;
 pub use address::{api_path_segment_for_network, compute_gasfree_address_for_network, controller_for_network};
@@ -11,12 +13,17 @@ pub use api_types::{
     GasfreeAccountAsset, GasfreeAccountInfo, GasfreeRequestId, GasfreeSubmitRequest, GasfreeSubmitResponse,
     GasfreeSupportedToken, GasfreeTraceResponse, GasfreeTransactionState, GasfreeTransferState,
 };
+pub use authorization::{sign_permit_transfer, GasfreeSignedAuthorization};
 pub use client::{TronGasfreeClient, TronGasfreeTransport};
 pub use config::{ResolvedTronGaslessProvider, TronGaslessProviderConfig};
 pub use error::{GaslessWithdrawError, TronGasfreeError, TronGaslessConfigError};
 pub use service::{
     DisabledReason, GasfreeAccountService, GasfreeAvailability, GasfreeRecommendation, GasfreeTransferPreflight,
     GasfreeTransferRequest, NativeRouteAvailability, OnChainBalanceFetcher,
+};
+pub use typed_data::{
+    build_permit_transfer_typed_data, hash_permit_transfer_typed_data, GasfreeDomain, PermitTransferData,
+    PermitTransferMessage,
 };
 use url::Url;
 
@@ -70,25 +77,111 @@ fn resolve_gasfree_base_url(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::eth::tron::Network;
+mod test_helpers {
+    use super::config::{ResolvedTronGaslessProvider, TronGaslessProviderConfig};
+    use super::controller_for_network;
+    use crate::eth::tron::{Network, TronAddress};
+    use serde_json::{json, Value};
+    use std::str::FromStr;
+    use url::Url;
 
-    fn provider_config(base_url: &str) -> TronGaslessProviderConfig {
+    pub(super) const TEST_BASE_URL: &str = "https://open-test.gasfree.io";
+    pub(super) const DEFAULT_SERVICE_PROVIDER: &str = "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E";
+
+    pub(super) fn provider_config(base_url: &str, service_provider: &str) -> TronGaslessProviderConfig {
         TronGaslessProviderConfig {
             base_url: Url::parse(base_url).unwrap(),
             api_key: "key".into(),
             api_secret: "secret".into(),
-            service_provider: "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E".into(),
+            service_provider: service_provider.into(),
             request_timeout_ms: 15_000,
             status_poll_interval_ms: 3_000,
         }
     }
 
+    pub(super) fn test_provider(network: Network, service_provider: &str) -> ResolvedTronGaslessProvider {
+        let raw = provider_config(TEST_BASE_URL, service_provider);
+        let parsed = TronAddress::from_str(service_provider).unwrap();
+        let verifying_contract = controller_for_network(&network);
+        ResolvedTronGaslessProvider::new(raw, network, parsed, verifying_contract)
+    }
+
+    pub(super) fn base_submit_response_payload() -> Value {
+        json!({
+            "id": "6c3ff67e-0bf4-4c09-91ca-0c7c254b01a0",
+            "accountAddress": "TUUSMd58eC3fKx3fn7whxJyr1FR56tgaP8",
+            "gasFreeAddress": "TNER12mMVWruqopsW9FQtKxCGfZcEtb3ER",
+            "providerAddress": "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E",
+            "targetAddress": "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT",
+            "tokenAddress": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+            "amount": 100000,
+            "maxFee": 2000000,
+            "signature": "",
+            "version": 1,
+            "nonce": 8,
+            "expiredAt": 1747909695000u64,
+            "state": "WAITING",
+            "estimatedActivateFee": 0,
+            "estimatedTransferFee": 2000,
+            "createdAt": 1747909635678u64,
+            "updatedAt": 1747909635678u64
+        })
+    }
+
+    pub(super) fn base_trace_response_payload() -> Value {
+        json!({
+            "id": "6c3ff67e-0bf4-4c09-91ca-0c7c254b01a0",
+            "accountAddress": "TUUSMd58eC3fKx3fn7whxJyr1FR56tgaP8",
+            "gasFreeAddress": "TNER12mMVWruqopsW9FQtKxCGfZcEtb3ER",
+            "providerAddress": "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E",
+            "targetAddress": "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT",
+            "tokenAddress": "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+            "amount": 100000,
+            "state": "CONFIRMING",
+            "expiredAt": 1747909695000u64,
+            "estimatedActivateFee": 0,
+            "estimatedTransferFee": 2000,
+            "estimatedTotalFee": 2000,
+            "estimatedTotalCost": 102000,
+            "txnHash": "22".repeat(32),
+            "txnBlockNum": 57175988,
+            "txnBlockTimestamp": 1747909638000u64,
+            "txnState": "ON_CHAIN",
+            "txnActivateFee": 0,
+            "txnTransferFee": 2000,
+            "txnTotalFee": 2000,
+            "txnAmount": 100000,
+            "txnTotalCost": 102000,
+            "nonce": 8,
+            "version": 1,
+            "signature": "33".repeat(65)
+        })
+    }
+
+    /// Wrap a payload in the GasFree provider's success envelope (`{code, reason, message, data}`).
+    pub(super) fn provider_envelope(data: Value) -> Value {
+        json!({
+            "code": 200,
+            "reason": null,
+            "message": "",
+            "data": data,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_helpers::{provider_config, DEFAULT_SERVICE_PROVIDER};
+    use super::*;
+    use crate::eth::tron::Network;
+
     fn resolved_path(network: Network, base_url: &str) -> String {
-        let provider = resolve_tron_gasless_provider(&ChainSpec::Tron { network }, Some(&provider_config(base_url)))
-            .unwrap()
-            .unwrap();
+        let provider = resolve_tron_gasless_provider(
+            &ChainSpec::Tron { network },
+            Some(&provider_config(base_url, DEFAULT_SERVICE_PROVIDER)),
+        )
+        .unwrap()
+        .unwrap();
 
         provider
             .config()
@@ -121,7 +214,10 @@ mod tests {
             &ChainSpec::Tron {
                 network: Network::Mainnet,
             },
-            Some(&provider_config("https://open.gasfree.io/tron/")),
+            Some(&provider_config(
+                "https://open.gasfree.io/tron/",
+                DEFAULT_SERVICE_PROVIDER,
+            )),
         )
         .unwrap_err();
 

--- a/mm2src/coins/eth/tron/gasfree/mod.rs
+++ b/mm2src/coins/eth/tron/gasfree/mod.rs
@@ -1,0 +1,27 @@
+pub mod config;
+pub mod error;
+
+pub use config::TronGaslessProviderConfig;
+pub use error::TronGaslessConfigError;
+
+use crate::eth::ChainSpec;
+
+/// Validate and resolve a TRON GasFree provider config at platform activation time.
+pub fn resolve_tron_gasless_provider(
+    chain_spec: &ChainSpec,
+    provider_config: Option<&TronGaslessProviderConfig>,
+) -> Result<Option<TronGaslessProviderConfig>, TronGaslessConfigError> {
+    let config = match provider_config {
+        Some(cfg) => cfg,
+        None => return Ok(None),
+    };
+
+    // GasFree is TRON-only
+    if !matches!(chain_spec, ChainSpec::Tron { .. }) {
+        return Err(TronGaslessConfigError::UnsupportedChain {
+            chain: chain_spec.kind().to_string(),
+        });
+    }
+
+    Ok(Some(config.clone()))
+}

--- a/mm2src/coins/eth/tron/gasfree/relay_payload.rs
+++ b/mm2src/coins/eth/tron/gasfree/relay_payload.rs
@@ -1,0 +1,118 @@
+use super::authorization::GasfreeSignedAuthorization;
+use super::config::ResolvedTronGaslessProvider;
+use crate::eth::tron::TronAddress;
+use crate::hd_wallet::HDAddressSelector;
+use serde::{Deserialize, Serialize};
+
+pub const TRON_GASFREE_RELAY_TYPE: &str = "tron_gasfree";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct TronGasfreeRelayPayload {
+    pub relay_type: String,
+    pub chain_id: String,
+    pub coin: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub from: Option<HDAddressSelector>,
+    pub from_address: String,
+    pub gasfree_address: String,
+    pub verifying_contract: String,
+    pub signed_authorization: GasfreeSignedAuthorization,
+    pub created_at: String,
+}
+
+pub(crate) struct SignedWithdrawRelayPayload<'a> {
+    pub provider: &'a ResolvedTronGaslessProvider,
+    pub coin: String,
+    pub from: Option<HDAddressSelector>,
+    pub from_address: String,
+    pub gasfree_address: TronAddress,
+    pub signed_authorization: GasfreeSignedAuthorization,
+    pub created_at: String,
+}
+
+impl From<SignedWithdrawRelayPayload<'_>> for TronGasfreeRelayPayload {
+    fn from(input: SignedWithdrawRelayPayload<'_>) -> Self {
+        TronGasfreeRelayPayload {
+            relay_type: TRON_GASFREE_RELAY_TYPE.to_string(),
+            chain_id: input.provider.network().chain_id().to_string(),
+            coin: input.coin,
+            from: input.from,
+            from_address: input.from_address,
+            gasfree_address: input.gasfree_address.to_base58(),
+            verifying_contract: input.provider.verifying_contract().to_base58(),
+            signed_authorization: input.signed_authorization,
+            created_at: input.created_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eth::tron::gasfree::test_helpers::{test_provider, DEFAULT_SERVICE_PROVIDER};
+    use crate::eth::tron::{Network, TronAddress, TronSignature};
+    use ethereum_types::U256;
+    use serde_json::json;
+
+    fn sample_payload() -> TronGasfreeRelayPayload {
+        TronGasfreeRelayPayload {
+            relay_type: TRON_GASFREE_RELAY_TYPE.to_string(),
+            chain_id: "3448148188".to_string(),
+            coin: "USDT-TRC20-NILE".to_string(),
+            from: Some(HDAddressSelector::AddressId(
+                crate::hd_wallet::HDPathAccountToAddressId {
+                    account_id: 0,
+                    chain: crypto::Bip44Chain::External,
+                    address_id: 2,
+                },
+            )),
+            from_address: "TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC".to_string(),
+            gasfree_address: "TCtSt8fCkZcVdrGpaVHUr6P8EmdjysswMF".to_string(),
+            verifying_contract: "THQGuFzL87ZqhxkgqYEryRAd7gqFqL5rdc".to_string(),
+            signed_authorization: GasfreeSignedAuthorization {
+                token: "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf".parse::<TronAddress>().unwrap(),
+                service_provider: "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E".parse::<TronAddress>().unwrap(),
+                user: "TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC".parse::<TronAddress>().unwrap(),
+                receiver: "TJM1BE5wq1VdHh3gwjUeyaVkvZp9DVYCfC".parse::<TronAddress>().unwrap(),
+                value: U256::from(5_000_000u64),
+                max_fee: U256::from(2_000u64),
+                deadline: U256::from(1_742_000_000u64),
+                version: U256::from(1u64),
+                nonce: U256::from(9u64),
+                sig: TronSignature::from_hex_str(&"11".repeat(65)).unwrap(),
+            },
+            created_at: "2026-04-23T20:47:34Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn relay_payload_serializes_expected_shape() {
+        let payload = serde_json::to_value(sample_payload()).unwrap();
+        assert_eq!(payload["relay_type"], json!(TRON_GASFREE_RELAY_TYPE));
+        assert_eq!(payload["chain_id"], json!("3448148188"));
+        assert_eq!(payload["from"]["account_id"], json!(0));
+        assert_eq!(payload["from_address"], json!("TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC"));
+        assert_eq!(payload["signed_authorization"]["value"], json!("5000000"));
+        assert_eq!(payload["signed_authorization"]["max_fee"], json!("2000"));
+    }
+
+    #[test]
+    fn signed_withdraw_payload_conversion_uses_supplied_created_at() {
+        let provider = test_provider(Network::Nile, DEFAULT_SERVICE_PROVIDER);
+        let created_at = "2026-04-23T20:47:34Z".to_string();
+        let signed_authorization = sample_payload().signed_authorization;
+
+        let payload = TronGasfreeRelayPayload::from(SignedWithdrawRelayPayload {
+            provider: &provider,
+            coin: "USDT-TRC20-NILE".to_string(),
+            from: None,
+            from_address: "TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC".to_string(),
+            gasfree_address: "TCtSt8fCkZcVdrGpaVHUr6P8EmdjysswMF".parse().unwrap(),
+            signed_authorization,
+            created_at: created_at.clone(),
+        });
+
+        assert_eq!(payload.created_at, created_at);
+    }
+}

--- a/mm2src/coins/eth/tron/gasfree/service.rs
+++ b/mm2src/coins/eth/tron/gasfree/service.rs
@@ -1,0 +1,676 @@
+use crate::eth::tron::gasfree::address::compute_gasfree_address_for_network;
+use crate::eth::tron::gasfree::api_types::{GasfreeAccountAsset, GasfreeAccountInfo};
+use crate::eth::tron::gasfree::config::ResolvedTronGaslessProvider;
+use crate::eth::tron::gasfree::error::TronGasfreeError;
+use crate::eth::tron::TronAddress;
+use async_trait::async_trait;
+use ethereum_types::U256;
+use mm2_err_handle::prelude::*;
+
+/// Caller intent for a single GasFree transfer: which TRC-20 token and how much.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GasfreeTransferRequest {
+    pub token_address: TronAddress,
+    pub transfer_value: U256,
+}
+
+/// Snapshot of everything needed to decide and execute a GasFree transfer.
+///
+/// Carries raw source-of-truth fields only, derived quantities (spendable, total fee, required
+/// balances) should be recomputed by callers that need them.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GasfreeTransferPreflight {
+    /// Locally-derived CREATE2 custody address for this user + network.
+    pub gasfree_address: TronAddress,
+    /// Whether the GasFree account has been on-chain activated.
+    pub account_active: bool,
+    /// TRC-20 balance at `gasfree_address`.
+    pub on_chain_balance: U256,
+    /// Amount currently locked by in-flight transfers. This should be reported by the GasFree provider.
+    pub frozen_balance: U256,
+    /// Per-transfer fee in the token, should be reported by the provider for this account + token.
+    pub transfer_fee: U256,
+    /// Extra fee charged when the account is inactive and will auto-activate. Zero when active.
+    pub activation_fee: U256,
+    /// Primary preflight decision.
+    pub availability: GasfreeAvailability,
+    /// Hint for auto withdraw: which rail the service suggests given the native
+    /// route state the caller supplied.
+    // Todo: Maybe this is not the best place for this
+    pub recommendation: GasfreeRecommendation,
+}
+
+/// Result of the preflight decision. Distinguishes transient waits from permanent failures
+/// so callers can choose to retry, fall back to native, or surface an error.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GasfreeAvailability {
+    /// Gasless rail is ready; withdraw may sign and submit.
+    Available,
+    /// GasFree enforces "one pending transfer per account" — caller must wait for the
+    /// current transfer to settle and retry. Transient, not an error.
+    PendingTransfer,
+    /// Gasless is not usable for this request. `reason` distinguishes recoverable from
+    /// systemic failures.
+    Disabled { reason: DisabledReason },
+}
+
+/// Why a preflight returned `Disabled`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DisabledReason {
+    /// Provider-reported GasFree address disagrees with our local CREATE2 derivation.
+    /// Indicates systemic drift (wrong controller, wrong formula, or malicious provider)
+    /// and is treated as a safety stop: withdraw must not sign against an unverifiable custody.
+    AddressMismatch {
+        expected: TronAddress,
+        provider_reported: TronAddress,
+    },
+    /// Token is not enrolled in the caller's GasFree account. Gasless cannot be used here;
+    /// caller should fall back to native or error.
+    TokenUnsupported { token_address: TronAddress },
+    /// Spendable (on-chain minus frozen) balance is below the required spendable amount
+    /// (`value + transfer_fee + activation_fee`).
+    InsufficientSpendableBalance,
+    /// For an inactive account, the on-chain balance must cover the required total
+    /// (`value + transfer_fee + activation_fee + frozen`). This variant fires when it
+    /// doesn't — preflight must reject before signing to avoid a guaranteed on-chain failure.
+    InactiveAccountInsufficientBalance,
+}
+
+/// Service recommendation for which rail to use under auto withdraw.
+/// Todo: Maybe this is not the best place for this
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GasfreeRecommendation {
+    GasfreeOnly,
+    NativeOnly,
+    PreferGasfree,
+    PreferNative,
+    NoAvailableRoute,
+}
+
+/// What the caller knows about the native (TRX) withdraw route at preflight time.
+///
+/// Used only to shape `GasfreeRecommendation`. The service does not fetch native fee data
+/// itself — the caller is expected to have already quoted the native path.
+/// Todo: Maybe this is not the best place for this
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum NativeRouteAvailability {
+    /// Native is available and the caller has quoted the fee in the same token units as
+    /// `transfer_fee + activation_fee` so the two rails can be compared directly.
+    Available { comparable_cost_in_token: U256 },
+    /// Native is available but the caller has no comparable quote (e.g. price feed missing).
+    /// Service will prefer native absent a tiebreaker.
+    AvailableButUnpriced,
+    /// Native is not usable (e.g. insufficient TRX for fee).
+    Unavailable,
+}
+
+/// Abstraction over on-chain TRC-20 `balanceOf` reads.
+///
+/// Keeps the service decoupled from the coin and useful for unit tests to
+/// drive the preflight math without standing up a live chain RPC or Coin.
+/// TODO: EthCoin lives a layer below and will supply the production impl in Commit 9.
+#[async_trait]
+pub trait OnChainBalanceFetcher: Send + Sync {
+    async fn trc20_balance(
+        &self,
+        token_address: &TronAddress,
+        owner_address: &TronAddress,
+    ) -> MmResult<U256, TronGasfreeError>;
+}
+
+/// Stateless per-request preflight layer over a [`ResolvedTronGaslessProvider`] and an
+/// [`OnChainBalanceFetcher`].
+///
+/// Construction computes the user's CREATE2 GasFree address once; each call to
+/// [`Self::preflight_transfer`] fetches fresh provider + on-chain state.
+pub struct GasfreeAccountService<'a, B: OnChainBalanceFetcher> {
+    provider: &'a ResolvedTronGaslessProvider,
+    user_address: TronAddress,
+    local_gasfree_address: TronAddress,
+    balance_fetcher: B,
+}
+
+impl<'a, B> GasfreeAccountService<'a, B>
+where
+    B: OnChainBalanceFetcher,
+{
+    pub fn new(provider: &'a ResolvedTronGaslessProvider, user_address: TronAddress, balance_fetcher: B) -> Self {
+        let local_gasfree_address = compute_gasfree_address_for_network(provider.network(), &user_address);
+        GasfreeAccountService {
+            provider,
+            user_address,
+            local_gasfree_address,
+            balance_fetcher,
+        }
+    }
+
+    pub fn local_gasfree_address(&self) -> &TronAddress {
+        &self.local_gasfree_address
+    }
+
+    /// Fetch provider account state, verify the GasFree address against local CREATE2, and
+    /// compute preflight availability for a single transfer.
+    ///
+    /// Returns `Err` only on transport/provider errors; any preflight-level rejection (bad
+    /// config, unsupported token, pending transfer, insufficient balance) surfaces through
+    /// [`GasfreeTransferPreflight::availability`].
+    pub async fn preflight_transfer(
+        &self,
+        request: GasfreeTransferRequest,
+        native_route: NativeRouteAvailability,
+    ) -> MmResult<GasfreeTransferPreflight, TronGasfreeError> {
+        let account_info_fetcher = ProviderAccountInfoFetcher {
+            provider: self.provider,
+        };
+        self.preflight_with_account_fetcher(&request, native_route, &account_info_fetcher)
+            .await
+    }
+
+    async fn preflight_with_account_fetcher<F>(
+        &self,
+        request: &GasfreeTransferRequest,
+        native_route: NativeRouteAvailability,
+        account_info_fetcher: &F,
+    ) -> MmResult<GasfreeTransferPreflight, TronGasfreeError>
+    where
+        F: AccountInfoFetcher,
+    {
+        let account_info = account_info_fetcher.get_account_info(&self.user_address).await?;
+        let snapshot = AccountSnapshot::from_account_info(&account_info);
+
+        if account_info.gas_free_address != self.local_gasfree_address {
+            return self.unavailable_preflight(
+                GasfreeAvailability::Disabled {
+                    reason: DisabledReason::AddressMismatch {
+                        expected: self.local_gasfree_address,
+                        provider_reported: account_info.gas_free_address,
+                    },
+                },
+                native_route,
+                snapshot,
+            );
+        }
+
+        let Some(asset) = account_info
+            .assets
+            .iter()
+            .find(|asset| asset.token_address == request.token_address)
+            .cloned()
+        else {
+            return self.unavailable_preflight(
+                GasfreeAvailability::Disabled {
+                    reason: DisabledReason::TokenUnsupported {
+                        token_address: request.token_address,
+                    },
+                },
+                native_route,
+                snapshot,
+            );
+        };
+
+        if !account_info.allow_submit {
+            let transfer_fee = asset.transfer_fee;
+            let activation_fee = if account_info.active {
+                U256::zero()
+            } else {
+                asset.activate_fee
+            };
+            return self.unavailable_preflight(
+                GasfreeAvailability::PendingTransfer,
+                native_route,
+                snapshot.with_asset_details(asset.frozen, transfer_fee, activation_fee),
+            );
+        }
+
+        let on_chain_balance = self
+            .balance_fetcher
+            .trc20_balance(&request.token_address, &self.local_gasfree_address)
+            .await?;
+
+        self.evaluate_account_state(request, native_route, &account_info, &asset, on_chain_balance)
+    }
+
+    fn evaluate_account_state(
+        &self,
+        request: &GasfreeTransferRequest,
+        native_route: NativeRouteAvailability,
+        account_info: &GasfreeAccountInfo,
+        asset: &GasfreeAccountAsset,
+        on_chain_balance: U256,
+    ) -> MmResult<GasfreeTransferPreflight, TronGasfreeError> {
+        let frozen_balance = asset.frozen;
+        let spendable_balance = on_chain_balance.saturating_sub(frozen_balance);
+        let activation_fee = if account_info.active {
+            U256::zero()
+        } else {
+            asset.activate_fee
+        };
+        let total_token_fee = checked_add_u256(asset.transfer_fee, activation_fee, "total token fee")?;
+        let required_spendable_balance =
+            checked_add_u256(request.transfer_value, total_token_fee, "required spendable")?;
+        let required_total_balance = checked_add_u256(required_spendable_balance, frozen_balance, "required total")?;
+
+        let availability = if !account_info.active && on_chain_balance < required_total_balance {
+            GasfreeAvailability::Disabled {
+                reason: DisabledReason::InactiveAccountInsufficientBalance,
+            }
+        } else if spendable_balance < required_spendable_balance {
+            GasfreeAvailability::Disabled {
+                reason: DisabledReason::InsufficientSpendableBalance,
+            }
+        } else {
+            GasfreeAvailability::Available
+        };
+
+        let recommendation = recommend_route(&availability, total_token_fee, native_route);
+
+        Ok(GasfreeTransferPreflight {
+            gasfree_address: self.local_gasfree_address,
+            account_active: account_info.active,
+            on_chain_balance,
+            frozen_balance,
+            transfer_fee: asset.transfer_fee,
+            activation_fee,
+            availability,
+            recommendation,
+        })
+    }
+
+    fn unavailable_preflight(
+        &self,
+        availability: GasfreeAvailability,
+        native_route: NativeRouteAvailability,
+        snapshot: AccountSnapshot,
+    ) -> MmResult<GasfreeTransferPreflight, TronGasfreeError> {
+        let total_token_fee = checked_add_u256(
+            snapshot.transfer_fee,
+            snapshot.activation_fee,
+            "unavailable total token fee",
+        )?;
+        let recommendation = recommend_route(&availability, total_token_fee, native_route);
+
+        Ok(GasfreeTransferPreflight {
+            gasfree_address: self.local_gasfree_address,
+            account_active: snapshot.account_active,
+            on_chain_balance: U256::zero(),
+            frozen_balance: snapshot.frozen_balance,
+            transfer_fee: snapshot.transfer_fee,
+            activation_fee: snapshot.activation_fee,
+            availability,
+            recommendation,
+        })
+    }
+}
+
+#[async_trait]
+trait AccountInfoFetcher: Send + Sync {
+    async fn get_account_info(&self, account: &TronAddress) -> MmResult<GasfreeAccountInfo, TronGasfreeError>;
+}
+
+struct ProviderAccountInfoFetcher<'a> {
+    provider: &'a ResolvedTronGaslessProvider,
+}
+
+#[async_trait]
+impl<'a> AccountInfoFetcher for ProviderAccountInfoFetcher<'a> {
+    async fn get_account_info(&self, account: &TronAddress) -> MmResult<GasfreeAccountInfo, TronGasfreeError> {
+        self.provider.client().get_account_info(account).await
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct AccountSnapshot {
+    account_active: bool,
+    frozen_balance: U256,
+    transfer_fee: U256,
+    activation_fee: U256,
+}
+
+impl AccountSnapshot {
+    fn from_account_info(account_info: &GasfreeAccountInfo) -> Self {
+        AccountSnapshot {
+            account_active: account_info.active,
+            ..AccountSnapshot::default()
+        }
+    }
+
+    fn with_asset_details(mut self, frozen_balance: U256, transfer_fee: U256, activation_fee: U256) -> Self {
+        self.frozen_balance = frozen_balance;
+        self.transfer_fee = transfer_fee;
+        self.activation_fee = activation_fee;
+        self
+    }
+}
+
+fn checked_add_u256(lhs: U256, rhs: U256, field_name: &str) -> MmResult<U256, TronGasfreeError> {
+    lhs.checked_add(rhs)
+        .or_mm_err(|| TronGasfreeError::Internal(format!("Overflow while computing {field_name}")))
+}
+
+// TODO(Commit 9): Revisit whether native-vs-gasless route selection belongs in the service
+// layer or in the withdraw caller. Kept here to match the Commit 6 plan, but Commit 9 has
+// the real context (user's `WithdrawFeeMethod`, native TRX fee) and may prefer to inline
+// the comparison from raw preflight outputs. If inlined there, drop this function,
+// `GasfreeRecommendation`, `NativeRouteAvailability`, and the `recommendation` field on
+// `GasfreeTransferPreflight`.
+fn recommend_route(
+    availability: &GasfreeAvailability,
+    gasless_total_token_fee: U256,
+    native_route: NativeRouteAvailability,
+) -> GasfreeRecommendation {
+    let gasless_available = matches!(availability, GasfreeAvailability::Available);
+
+    match (gasless_available, native_route) {
+        (true, NativeRouteAvailability::Unavailable) => GasfreeRecommendation::GasfreeOnly,
+        (false, NativeRouteAvailability::Unavailable) => GasfreeRecommendation::NoAvailableRoute,
+        (false, NativeRouteAvailability::Available { .. }) | (false, NativeRouteAvailability::AvailableButUnpriced) => {
+            GasfreeRecommendation::NativeOnly
+        },
+        (
+            true,
+            NativeRouteAvailability::Available {
+                comparable_cost_in_token,
+            },
+        ) => {
+            if comparable_cost_in_token <= gasless_total_token_fee {
+                GasfreeRecommendation::PreferNative
+            } else {
+                GasfreeRecommendation::PreferGasfree
+            }
+        },
+        (true, NativeRouteAvailability::AvailableButUnpriced) => GasfreeRecommendation::PreferNative,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eth::tron::gasfree::config::TronGaslessProviderConfig;
+    use crate::eth::tron::gasfree::resolve_tron_gasless_provider;
+    use crate::eth::tron::Network;
+    use crate::eth::ChainSpec;
+    use parking_lot::Mutex;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use url::Url;
+
+    #[derive(Clone, Default)]
+    struct MockOnChainBalanceFetcher {
+        balances: HashMap<(TronAddress, TronAddress), U256>,
+        calls: Arc<Mutex<usize>>,
+    }
+
+    impl MockOnChainBalanceFetcher {
+        fn with_balance(mut self, token: TronAddress, owner: TronAddress, balance: U256) -> Self {
+            self.balances.insert((token, owner), balance);
+            self
+        }
+
+        fn call_count(&self) -> usize {
+            *self.calls.lock()
+        }
+    }
+
+    #[async_trait]
+    impl OnChainBalanceFetcher for MockOnChainBalanceFetcher {
+        async fn trc20_balance(
+            &self,
+            token_address: &TronAddress,
+            owner_address: &TronAddress,
+        ) -> MmResult<U256, TronGasfreeError> {
+            *self.calls.lock() += 1;
+            self.balances
+                .get(&(*token_address, *owner_address))
+                .copied()
+                .or_mm_err(|| {
+                    TronGasfreeError::InvalidRequest(format!(
+                        "missing mock balance for token {} owner {}",
+                        token_address, owner_address
+                    ))
+                })
+        }
+    }
+
+    #[derive(Clone, Default)]
+    struct MockAccountInfoFetcher {
+        account_info_by_account: HashMap<TronAddress, GasfreeAccountInfo>,
+        calls: Arc<Mutex<usize>>,
+    }
+
+    impl MockAccountInfoFetcher {
+        fn returning(account_info: GasfreeAccountInfo) -> Self {
+            Self::default().with_account_info(user_address(), account_info)
+        }
+
+        fn with_account_info(mut self, account: TronAddress, account_info: GasfreeAccountInfo) -> Self {
+            self.account_info_by_account.insert(account, account_info);
+            self
+        }
+
+        fn call_count(&self) -> usize {
+            *self.calls.lock()
+        }
+    }
+
+    #[async_trait]
+    impl AccountInfoFetcher for MockAccountInfoFetcher {
+        async fn get_account_info(&self, account: &TronAddress) -> MmResult<GasfreeAccountInfo, TronGasfreeError> {
+            *self.calls.lock() += 1;
+            self.account_info_by_account.get(account).cloned().or_mm_err(|| {
+                TronGasfreeError::InvalidRequest(format!("missing mock account info for account {}", account))
+            })
+        }
+    }
+
+    fn provider() -> ResolvedTronGaslessProvider {
+        let provider_config = TronGaslessProviderConfig {
+            base_url: Url::parse("https://open-test.gasfree.io").unwrap(),
+            api_key: "key".into(),
+            api_secret: "secret".into(),
+            service_provider: "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E".into(),
+            request_timeout_ms: 15_000,
+            status_poll_interval_ms: 3_000,
+        };
+
+        resolve_tron_gasless_provider(&ChainSpec::Tron { network: Network::Nile }, Some(&provider_config))
+            .unwrap()
+            .unwrap()
+    }
+
+    fn user_address() -> TronAddress {
+        "TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC".parse().unwrap()
+    }
+
+    fn token_address() -> TronAddress {
+        "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf".parse().unwrap()
+    }
+
+    fn request(value: u64) -> GasfreeTransferRequest {
+        GasfreeTransferRequest {
+            token_address: token_address(),
+            transfer_value: U256::from(value),
+        }
+    }
+
+    fn account_info(
+        provider_gasfree_address: TronAddress,
+        active: bool,
+        allow_submit: bool,
+        frozen: u64,
+        transfer_fee: u64,
+        activation_fee: u64,
+        nonce: u64,
+    ) -> GasfreeAccountInfo {
+        GasfreeAccountInfo {
+            account_address: user_address(),
+            gas_free_address: provider_gasfree_address,
+            active,
+            nonce: U256::from(nonce),
+            allow_submit,
+            assets: vec![GasfreeAccountAsset {
+                token_address: token_address(),
+                token_symbol: "USDT".into(),
+                activate_fee: U256::from(activation_fee),
+                transfer_fee: U256::from(transfer_fee),
+                decimal: 6,
+                frozen: U256::from(frozen),
+            }],
+        }
+    }
+
+    #[test]
+    fn inactive_account_without_required_total_balance_is_disabled_before_signing() {
+        let provider = provider();
+        let user = user_address();
+        let local_gasfree = compute_gasfree_address_for_network(provider.network(), &user);
+        let service = GasfreeAccountService::new(
+            &provider,
+            user,
+            MockOnChainBalanceFetcher::default().with_balance(token_address(), local_gasfree, U256::from(59u64)),
+        );
+        let fetcher = MockAccountInfoFetcher::returning(account_info(local_gasfree, false, true, 10, 5, 7, 9));
+
+        let preflight = common::block_on(service.preflight_with_account_fetcher(
+            &request(38),
+            NativeRouteAvailability::Unavailable,
+            &fetcher,
+        ))
+        .unwrap();
+
+        assert_eq!(
+            preflight.availability,
+            GasfreeAvailability::Disabled {
+                reason: DisabledReason::InactiveAccountInsufficientBalance,
+            }
+        );
+    }
+
+    #[test]
+    fn frozen_balance_is_subtracted_from_spendable_balance() {
+        let provider = provider();
+        let user = user_address();
+        let local_gasfree = compute_gasfree_address_for_network(provider.network(), &user);
+        let service = GasfreeAccountService::new(
+            &provider,
+            user,
+            MockOnChainBalanceFetcher::default().with_balance(token_address(), local_gasfree, U256::from(100u64)),
+        );
+        let fetcher = MockAccountInfoFetcher::returning(account_info(local_gasfree, true, true, 30, 10, 0, 3));
+
+        let preflight = common::block_on(service.preflight_with_account_fetcher(
+            &request(65),
+            NativeRouteAvailability::Unavailable,
+            &fetcher,
+        ))
+        .unwrap();
+
+        assert_eq!(preflight.on_chain_balance, U256::from(100u64));
+        assert_eq!(preflight.frozen_balance, U256::from(30u64));
+        assert_eq!(
+            preflight.availability,
+            GasfreeAvailability::Disabled {
+                reason: DisabledReason::InsufficientSpendableBalance,
+            }
+        );
+    }
+
+    #[test]
+    fn inactive_account_uses_required_total_balance_even_when_spendable_saturates() {
+        let provider = provider();
+        let user = user_address();
+        let local_gasfree = compute_gasfree_address_for_network(provider.network(), &user);
+        let service = GasfreeAccountService::new(
+            &provider,
+            user,
+            MockOnChainBalanceFetcher::default().with_balance(token_address(), local_gasfree, U256::from(5u64)),
+        );
+        let fetcher = MockAccountInfoFetcher::returning(account_info(local_gasfree, false, true, 10, 0, 0, 4));
+
+        let preflight = common::block_on(service.preflight_with_account_fetcher(
+            &request(0),
+            NativeRouteAvailability::Unavailable,
+            &fetcher,
+        ))
+        .unwrap();
+
+        assert_eq!(
+            preflight.availability,
+            GasfreeAvailability::Disabled {
+                reason: DisabledReason::InactiveAccountInsufficientBalance,
+            }
+        );
+    }
+
+    #[test]
+    fn pending_transfer_short_circuits_before_balance_fetch() {
+        let provider = provider();
+        let user = user_address();
+        let balance_fetcher = MockOnChainBalanceFetcher::default();
+        let service = GasfreeAccountService::new(&provider, user, balance_fetcher.clone());
+        let fetcher =
+            MockAccountInfoFetcher::returning(account_info(*service.local_gasfree_address(), true, false, 0, 9, 0, 7));
+
+        let preflight = common::block_on(service.preflight_with_account_fetcher(
+            &request(10),
+            NativeRouteAvailability::Unavailable,
+            &fetcher,
+        ))
+        .unwrap();
+
+        assert_eq!(preflight.availability, GasfreeAvailability::PendingTransfer);
+        assert_eq!(balance_fetcher.call_count(), 0);
+    }
+
+    #[test]
+    fn address_mismatch_is_detected_on_every_preflight() {
+        let provider = provider();
+        let user = user_address();
+        let second_user: TronAddress = "TEkj3ndMVEmFLYaFrATMwMjBRZ1EAZkucT".parse().unwrap();
+        let balance_fetcher = MockOnChainBalanceFetcher::default();
+        let service = GasfreeAccountService::new(&provider, user, balance_fetcher.clone());
+        let second_service = GasfreeAccountService::new(&provider, second_user, balance_fetcher.clone());
+        let first_wrong_gasfree_address: TronAddress = "TLvVuqx74fMy8QMjEsMT4dWwmVbuNwYt8X".parse().unwrap();
+        let second_wrong_gasfree_address: TronAddress = "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E".parse().unwrap();
+        let fetcher = MockAccountInfoFetcher::default()
+            .with_account_info(user, account_info(first_wrong_gasfree_address, true, true, 0, 5, 0, 1))
+            .with_account_info(
+                second_user,
+                account_info(second_wrong_gasfree_address, true, true, 0, 5, 0, 1),
+            );
+        let first = common::block_on(service.preflight_with_account_fetcher(
+            &request(1),
+            NativeRouteAvailability::Unavailable,
+            &fetcher,
+        ))
+        .unwrap();
+
+        assert_eq!(
+            first.availability,
+            GasfreeAvailability::Disabled {
+                reason: DisabledReason::AddressMismatch {
+                    expected: *service.local_gasfree_address(),
+                    provider_reported: first_wrong_gasfree_address,
+                },
+            }
+        );
+
+        let second = common::block_on(second_service.preflight_with_account_fetcher(
+            &request(1),
+            NativeRouteAvailability::Unavailable,
+            &fetcher,
+        ))
+        .unwrap();
+
+        assert_eq!(
+            second.availability,
+            GasfreeAvailability::Disabled {
+                reason: DisabledReason::AddressMismatch {
+                    expected: *second_service.local_gasfree_address(),
+                    provider_reported: second_wrong_gasfree_address,
+                },
+            }
+        );
+        assert_eq!(fetcher.call_count(), 2);
+        assert_eq!(balance_fetcher.call_count(), 0);
+    }
+}

--- a/mm2src/coins/eth/tron/gasfree/service.rs
+++ b/mm2src/coins/eth/tron/gasfree/service.rs
@@ -385,14 +385,13 @@ fn recommend_route(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::eth::tron::gasfree::config::TronGaslessProviderConfig;
     use crate::eth::tron::gasfree::resolve_tron_gasless_provider;
+    use crate::eth::tron::gasfree::test_helpers::{provider_config, DEFAULT_SERVICE_PROVIDER, TEST_BASE_URL};
     use crate::eth::tron::Network;
     use crate::eth::ChainSpec;
     use parking_lot::Mutex;
     use std::collections::HashMap;
     use std::sync::Arc;
-    use url::Url;
 
     #[derive(Clone, Default)]
     struct MockOnChainBalanceFetcher {
@@ -463,16 +462,8 @@ mod tests {
     }
 
     fn provider() -> ResolvedTronGaslessProvider {
-        let provider_config = TronGaslessProviderConfig {
-            base_url: Url::parse("https://open-test.gasfree.io").unwrap(),
-            api_key: "key".into(),
-            api_secret: "secret".into(),
-            service_provider: "TKtWbdzEq5ss9vTS9kwRhBp5mXmBfBns3E".into(),
-            request_timeout_ms: 15_000,
-            status_poll_interval_ms: 3_000,
-        };
-
-        resolve_tron_gasless_provider(&ChainSpec::Tron { network: Network::Nile }, Some(&provider_config))
+        let raw = provider_config(TEST_BASE_URL, DEFAULT_SERVICE_PROVIDER);
+        resolve_tron_gasless_provider(&ChainSpec::Tron { network: Network::Nile }, Some(&raw))
             .unwrap()
             .unwrap()
     }

--- a/mm2src/coins/eth/tron/gasfree/service.rs
+++ b/mm2src/coins/eth/tron/gasfree/service.rs
@@ -2,7 +2,7 @@ use crate::eth::tron::gasfree::address::compute_gasfree_address_for_network;
 use crate::eth::tron::gasfree::api_types::{GasfreeAccountAsset, GasfreeAccountInfo};
 use crate::eth::tron::gasfree::config::ResolvedTronGaslessProvider;
 use crate::eth::tron::gasfree::error::TronGasfreeError;
-use crate::eth::tron::TronAddress;
+use crate::eth::tron::{TronAddress, TronApiClient};
 use async_trait::async_trait;
 use ethereum_types::U256;
 use mm2_err_handle::prelude::*;
@@ -12,6 +12,7 @@ use mm2_err_handle::prelude::*;
 pub struct GasfreeTransferRequest {
     pub token_address: TronAddress,
     pub transfer_value: U256,
+    pub expected_token_decimals: u8,
 }
 
 /// Snapshot of everything needed to decide and execute a GasFree transfer.
@@ -22,6 +23,8 @@ pub struct GasfreeTransferRequest {
 pub struct GasfreeTransferPreflight {
     /// Locally-derived CREATE2 custody address for this user + network.
     pub gasfree_address: TronAddress,
+    /// Provider-reported nonce bound into the signed authorization.
+    pub nonce: U256,
     /// Whether the GasFree account has been on-chain activated.
     pub account_active: bool,
     /// TRC-20 balance at `gasfree_address`.
@@ -34,10 +37,6 @@ pub struct GasfreeTransferPreflight {
     pub activation_fee: U256,
     /// Primary preflight decision.
     pub availability: GasfreeAvailability,
-    /// Hint for auto withdraw: which rail the service suggests given the native
-    /// route state the caller supplied.
-    // Todo: Maybe this is not the best place for this
-    pub recommendation: GasfreeRecommendation,
 }
 
 /// Result of the preflight decision. Distinguishes transient waits from permanent failures
@@ -67,6 +66,13 @@ pub enum DisabledReason {
     /// Token is not enrolled in the caller's GasFree account. Gasless cannot be used here;
     /// caller should fall back to native or error.
     TokenUnsupported { token_address: TronAddress },
+    /// Provider-reported token decimals disagree with the activated token decimals.
+    /// Indicates provider/config drift, so callers must not sign or silently fall back.
+    TokenDecimalMismatch {
+        token_address: TronAddress,
+        expected: u8,
+        provider_reported: u8,
+    },
     /// Spendable (on-chain minus frozen) balance is below the required spendable amount
     /// (`value + transfer_fee + activation_fee`).
     InsufficientSpendableBalance,
@@ -76,39 +82,11 @@ pub enum DisabledReason {
     InactiveAccountInsufficientBalance,
 }
 
-/// Service recommendation for which rail to use under auto withdraw.
-/// Todo: Maybe this is not the best place for this
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum GasfreeRecommendation {
-    GasfreeOnly,
-    NativeOnly,
-    PreferGasfree,
-    PreferNative,
-    NoAvailableRoute,
-}
-
-/// What the caller knows about the native (TRX) withdraw route at preflight time.
-///
-/// Used only to shape `GasfreeRecommendation`. The service does not fetch native fee data
-/// itself — the caller is expected to have already quoted the native path.
-/// Todo: Maybe this is not the best place for this
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum NativeRouteAvailability {
-    /// Native is available and the caller has quoted the fee in the same token units as
-    /// `transfer_fee + activation_fee` so the two rails can be compared directly.
-    Available { comparable_cost_in_token: U256 },
-    /// Native is available but the caller has no comparable quote (e.g. price feed missing).
-    /// Service will prefer native absent a tiebreaker.
-    AvailableButUnpriced,
-    /// Native is not usable (e.g. insufficient TRX for fee).
-    Unavailable,
-}
-
 /// Abstraction over on-chain TRC-20 `balanceOf` reads.
 ///
 /// Keeps the service decoupled from the coin and useful for unit tests to
 /// drive the preflight math without standing up a live chain RPC or Coin.
-/// TODO: EthCoin lives a layer below and will supply the production impl in Commit 9.
+/// Production withdraw code uses [`TronOnChainBalanceFetcher`] backed by [`TronApiClient`].
 #[async_trait]
 pub trait OnChainBalanceFetcher: Send + Sync {
     async fn trc20_balance(
@@ -116,6 +94,36 @@ pub trait OnChainBalanceFetcher: Send + Sync {
         token_address: &TronAddress,
         owner_address: &TronAddress,
     ) -> MmResult<U256, TronGasfreeError>;
+}
+
+pub struct TronOnChainBalanceFetcher<'a> {
+    tron: &'a TronApiClient,
+}
+
+impl<'a> TronOnChainBalanceFetcher<'a> {
+    pub fn new(tron: &'a TronApiClient) -> Self {
+        TronOnChainBalanceFetcher { tron }
+    }
+}
+
+impl<'a> From<&'a TronApiClient> for TronOnChainBalanceFetcher<'a> {
+    fn from(tron: &'a TronApiClient) -> Self {
+        TronOnChainBalanceFetcher::new(tron)
+    }
+}
+
+#[async_trait]
+impl OnChainBalanceFetcher for TronOnChainBalanceFetcher<'_> {
+    async fn trc20_balance(
+        &self,
+        token_address: &TronAddress,
+        owner_address: &TronAddress,
+    ) -> MmResult<U256, TronGasfreeError> {
+        self.tron
+            .trc20_balance_of(token_address, owner_address)
+            .await
+            .mm_err(TronGasfreeError::from)
+    }
 }
 
 /// Stateless per-request preflight layer over a [`ResolvedTronGaslessProvider`] and an
@@ -157,26 +165,24 @@ where
     pub async fn preflight_transfer(
         &self,
         request: GasfreeTransferRequest,
-        native_route: NativeRouteAvailability,
     ) -> MmResult<GasfreeTransferPreflight, TronGasfreeError> {
         let account_info_fetcher = ProviderAccountInfoFetcher {
             provider: self.provider,
         };
-        self.preflight_with_account_fetcher(&request, native_route, &account_info_fetcher)
+        self.preflight_with_account_fetcher(&request, &account_info_fetcher)
             .await
     }
 
     async fn preflight_with_account_fetcher<F>(
         &self,
         request: &GasfreeTransferRequest,
-        native_route: NativeRouteAvailability,
         account_info_fetcher: &F,
     ) -> MmResult<GasfreeTransferPreflight, TronGasfreeError>
     where
         F: AccountInfoFetcher,
     {
         let account_info = account_info_fetcher.get_account_info(&self.user_address).await?;
-        let snapshot = AccountSnapshot::from_account_info(&account_info);
+        let snapshot = AccountSnapshot::from(&account_info);
 
         if account_info.gas_free_address != self.local_gasfree_address {
             return self.unavailable_preflight(
@@ -186,7 +192,6 @@ where
                         provider_reported: account_info.gas_free_address,
                     },
                 },
-                native_route,
                 snapshot,
             );
         }
@@ -203,10 +208,30 @@ where
                         token_address: request.token_address,
                     },
                 },
-                native_route,
                 snapshot,
             );
         };
+
+        if asset.decimal != request.expected_token_decimals {
+            return self.unavailable_preflight(
+                GasfreeAvailability::Disabled {
+                    reason: DisabledReason::TokenDecimalMismatch {
+                        token_address: request.token_address,
+                        expected: request.expected_token_decimals,
+                        provider_reported: asset.decimal,
+                    },
+                },
+                snapshot.with_asset_details(
+                    asset.frozen,
+                    asset.transfer_fee,
+                    if account_info.active {
+                        U256::zero()
+                    } else {
+                        asset.activate_fee
+                    },
+                ),
+            );
+        }
 
         if !account_info.allow_submit {
             let transfer_fee = asset.transfer_fee;
@@ -217,7 +242,6 @@ where
             };
             return self.unavailable_preflight(
                 GasfreeAvailability::PendingTransfer,
-                native_route,
                 snapshot.with_asset_details(asset.frozen, transfer_fee, activation_fee),
             );
         }
@@ -227,13 +251,12 @@ where
             .trc20_balance(&request.token_address, &self.local_gasfree_address)
             .await?;
 
-        self.evaluate_account_state(request, native_route, &account_info, &asset, on_chain_balance)
+        self.evaluate_account_state(request, &account_info, &asset, on_chain_balance)
     }
 
     fn evaluate_account_state(
         &self,
         request: &GasfreeTransferRequest,
-        native_route: NativeRouteAvailability,
         account_info: &GasfreeAccountInfo,
         asset: &GasfreeAccountAsset,
         on_chain_balance: U256,
@@ -262,42 +285,32 @@ where
             GasfreeAvailability::Available
         };
 
-        let recommendation = recommend_route(&availability, total_token_fee, native_route);
-
         Ok(GasfreeTransferPreflight {
             gasfree_address: self.local_gasfree_address,
+            nonce: account_info.nonce,
             account_active: account_info.active,
             on_chain_balance,
             frozen_balance,
             transfer_fee: asset.transfer_fee,
             activation_fee,
             availability,
-            recommendation,
         })
     }
 
     fn unavailable_preflight(
         &self,
         availability: GasfreeAvailability,
-        native_route: NativeRouteAvailability,
         snapshot: AccountSnapshot,
     ) -> MmResult<GasfreeTransferPreflight, TronGasfreeError> {
-        let total_token_fee = checked_add_u256(
-            snapshot.transfer_fee,
-            snapshot.activation_fee,
-            "unavailable total token fee",
-        )?;
-        let recommendation = recommend_route(&availability, total_token_fee, native_route);
-
         Ok(GasfreeTransferPreflight {
             gasfree_address: self.local_gasfree_address,
+            nonce: snapshot.nonce,
             account_active: snapshot.account_active,
             on_chain_balance: U256::zero(),
             frozen_balance: snapshot.frozen_balance,
             transfer_fee: snapshot.transfer_fee,
             activation_fee: snapshot.activation_fee,
             availability,
-            recommendation,
         })
     }
 }
@@ -320,20 +333,24 @@ impl<'a> AccountInfoFetcher for ProviderAccountInfoFetcher<'a> {
 
 #[derive(Clone, Copy, Debug, Default)]
 struct AccountSnapshot {
+    nonce: U256,
     account_active: bool,
     frozen_balance: U256,
     transfer_fee: U256,
     activation_fee: U256,
 }
 
-impl AccountSnapshot {
-    fn from_account_info(account_info: &GasfreeAccountInfo) -> Self {
+impl From<&GasfreeAccountInfo> for AccountSnapshot {
+    fn from(account_info: &GasfreeAccountInfo) -> Self {
         AccountSnapshot {
+            nonce: account_info.nonce,
             account_active: account_info.active,
             ..AccountSnapshot::default()
         }
     }
+}
 
+impl AccountSnapshot {
     fn with_asset_details(mut self, frozen_balance: U256, transfer_fee: U256, activation_fee: U256) -> Self {
         self.frozen_balance = frozen_balance;
         self.transfer_fee = transfer_fee;
@@ -345,41 +362,6 @@ impl AccountSnapshot {
 fn checked_add_u256(lhs: U256, rhs: U256, field_name: &str) -> MmResult<U256, TronGasfreeError> {
     lhs.checked_add(rhs)
         .or_mm_err(|| TronGasfreeError::Internal(format!("Overflow while computing {field_name}")))
-}
-
-// TODO(Commit 9): Revisit whether native-vs-gasless route selection belongs in the service
-// layer or in the withdraw caller. Kept here to match the Commit 6 plan, but Commit 9 has
-// the real context (user's `WithdrawFeeMethod`, native TRX fee) and may prefer to inline
-// the comparison from raw preflight outputs. If inlined there, drop this function,
-// `GasfreeRecommendation`, `NativeRouteAvailability`, and the `recommendation` field on
-// `GasfreeTransferPreflight`.
-fn recommend_route(
-    availability: &GasfreeAvailability,
-    gasless_total_token_fee: U256,
-    native_route: NativeRouteAvailability,
-) -> GasfreeRecommendation {
-    let gasless_available = matches!(availability, GasfreeAvailability::Available);
-
-    match (gasless_available, native_route) {
-        (true, NativeRouteAvailability::Unavailable) => GasfreeRecommendation::GasfreeOnly,
-        (false, NativeRouteAvailability::Unavailable) => GasfreeRecommendation::NoAvailableRoute,
-        (false, NativeRouteAvailability::Available { .. }) | (false, NativeRouteAvailability::AvailableButUnpriced) => {
-            GasfreeRecommendation::NativeOnly
-        },
-        (
-            true,
-            NativeRouteAvailability::Available {
-                comparable_cost_in_token,
-            },
-        ) => {
-            if comparable_cost_in_token <= gasless_total_token_fee {
-                GasfreeRecommendation::PreferNative
-            } else {
-                GasfreeRecommendation::PreferGasfree
-            }
-        },
-        (true, NativeRouteAvailability::AvailableButUnpriced) => GasfreeRecommendation::PreferNative,
-    }
 }
 
 #[cfg(test)]
@@ -480,6 +462,7 @@ mod tests {
         GasfreeTransferRequest {
             token_address: token_address(),
             transfer_value: U256::from(value),
+            expected_token_decimals: 6,
         }
     }
 
@@ -492,6 +475,29 @@ mod tests {
         activation_fee: u64,
         nonce: u64,
     ) -> GasfreeAccountInfo {
+        account_info_with_decimals(
+            provider_gasfree_address,
+            active,
+            allow_submit,
+            frozen,
+            transfer_fee,
+            activation_fee,
+            nonce,
+            6,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn account_info_with_decimals(
+        provider_gasfree_address: TronAddress,
+        active: bool,
+        allow_submit: bool,
+        frozen: u64,
+        transfer_fee: u64,
+        activation_fee: u64,
+        nonce: u64,
+        decimals: u8,
+    ) -> GasfreeAccountInfo {
         GasfreeAccountInfo {
             account_address: user_address(),
             gas_free_address: provider_gasfree_address,
@@ -503,7 +509,7 @@ mod tests {
                 token_symbol: "USDT".into(),
                 activate_fee: U256::from(activation_fee),
                 transfer_fee: U256::from(transfer_fee),
-                decimal: 6,
+                decimal: decimals,
                 frozen: U256::from(frozen),
             }],
         }
@@ -521,12 +527,7 @@ mod tests {
         );
         let fetcher = MockAccountInfoFetcher::returning(account_info(local_gasfree, false, true, 10, 5, 7, 9));
 
-        let preflight = common::block_on(service.preflight_with_account_fetcher(
-            &request(38),
-            NativeRouteAvailability::Unavailable,
-            &fetcher,
-        ))
-        .unwrap();
+        let preflight = common::block_on(service.preflight_with_account_fetcher(&request(38), &fetcher)).unwrap();
 
         assert_eq!(
             preflight.availability,
@@ -548,12 +549,7 @@ mod tests {
         );
         let fetcher = MockAccountInfoFetcher::returning(account_info(local_gasfree, true, true, 30, 10, 0, 3));
 
-        let preflight = common::block_on(service.preflight_with_account_fetcher(
-            &request(65),
-            NativeRouteAvailability::Unavailable,
-            &fetcher,
-        ))
-        .unwrap();
+        let preflight = common::block_on(service.preflight_with_account_fetcher(&request(65), &fetcher)).unwrap();
 
         assert_eq!(preflight.on_chain_balance, U256::from(100u64));
         assert_eq!(preflight.frozen_balance, U256::from(30u64));
@@ -577,12 +573,7 @@ mod tests {
         );
         let fetcher = MockAccountInfoFetcher::returning(account_info(local_gasfree, false, true, 10, 0, 0, 4));
 
-        let preflight = common::block_on(service.preflight_with_account_fetcher(
-            &request(0),
-            NativeRouteAvailability::Unavailable,
-            &fetcher,
-        ))
-        .unwrap();
+        let preflight = common::block_on(service.preflight_with_account_fetcher(&request(0), &fetcher)).unwrap();
 
         assert_eq!(
             preflight.availability,
@@ -601,12 +592,7 @@ mod tests {
         let fetcher =
             MockAccountInfoFetcher::returning(account_info(*service.local_gasfree_address(), true, false, 0, 9, 0, 7));
 
-        let preflight = common::block_on(service.preflight_with_account_fetcher(
-            &request(10),
-            NativeRouteAvailability::Unavailable,
-            &fetcher,
-        ))
-        .unwrap();
+        let preflight = common::block_on(service.preflight_with_account_fetcher(&request(10), &fetcher)).unwrap();
 
         assert_eq!(preflight.availability, GasfreeAvailability::PendingTransfer);
         assert_eq!(balance_fetcher.call_count(), 0);
@@ -628,12 +614,7 @@ mod tests {
                 second_user,
                 account_info(second_wrong_gasfree_address, true, true, 0, 5, 0, 1),
             );
-        let first = common::block_on(service.preflight_with_account_fetcher(
-            &request(1),
-            NativeRouteAvailability::Unavailable,
-            &fetcher,
-        ))
-        .unwrap();
+        let first = common::block_on(service.preflight_with_account_fetcher(&request(1), &fetcher)).unwrap();
 
         assert_eq!(
             first.availability,
@@ -645,12 +626,7 @@ mod tests {
             }
         );
 
-        let second = common::block_on(second_service.preflight_with_account_fetcher(
-            &request(1),
-            NativeRouteAvailability::Unavailable,
-            &fetcher,
-        ))
-        .unwrap();
+        let second = common::block_on(second_service.preflight_with_account_fetcher(&request(1), &fetcher)).unwrap();
 
         assert_eq!(
             second.availability,

--- a/mm2src/coins/eth/tron/gasfree/typed_data.rs
+++ b/mm2src/coins/eth/tron/gasfree/typed_data.rs
@@ -1,0 +1,282 @@
+use super::config::ResolvedTronGaslessProvider;
+use super::error::TronGasfreeError;
+use crate::eth::tron::TronAddress;
+use common::u256_to_hex;
+use ethereum_types::{H256, U256};
+use mm2_err_handle::prelude::*;
+use mm2_eth::eip712::{CustomTypes, Eip712, ObjectType, PropertyType, EIP712_DOMAIN};
+use mm2_eth::eip712_encode::hash_typed_data;
+use serde::Serialize;
+use std::collections::HashMap;
+
+pub const GASFREE_DOMAIN_NAME: &str = "GasFreeController";
+pub const GASFREE_DOMAIN_VERSION: &str = "V1.0.0";
+pub const PERMIT_TRANSFER_PRIMARY_TYPE: &str = "PermitTransfer";
+pub const GASFREE_PERMIT_VERSION: u64 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PermitTransferData {
+    pub token: TronAddress,
+    pub user: TronAddress,
+    pub receiver: TronAddress,
+    pub value: U256,
+    pub max_fee: U256,
+    pub deadline: U256,
+    pub nonce: U256,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GasfreeDomain {
+    pub name: String,
+    pub version: String,
+    pub chain_id: String,
+    pub verifying_contract: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PermitTransferMessage {
+    pub token: String,
+    pub service_provider: String,
+    pub user: String,
+    pub receiver: String,
+    pub value: String,
+    pub max_fee: String,
+    pub deadline: String,
+    pub version: String,
+    pub nonce: String,
+}
+
+pub fn build_permit_transfer_typed_data(
+    provider: &ResolvedTronGaslessProvider,
+    transfer: &PermitTransferData,
+) -> MmResult<Eip712<GasfreeDomain, PermitTransferMessage>, TronGasfreeError> {
+    let domain = GasfreeDomain {
+        name: GASFREE_DOMAIN_NAME.to_string(),
+        version: GASFREE_DOMAIN_VERSION.to_string(),
+        chain_id: u256_to_hex(U256::from(provider.network().chain_id())),
+        verifying_contract: format!("{:#x}", provider.verifying_contract().to_evm_address()),
+    };
+
+    let message = PermitTransferMessage {
+        token: format!("{:#x}", transfer.token.to_evm_address()),
+        service_provider: format!("{:#x}", provider.service_provider().to_evm_address()),
+        user: format!("{:#x}", transfer.user.to_evm_address()),
+        receiver: format!("{:#x}", transfer.receiver.to_evm_address()),
+        value: u256_to_hex(transfer.value),
+        max_fee: u256_to_hex(transfer.max_fee),
+        deadline: u256_to_hex(transfer.deadline),
+        version: u256_to_hex(U256::from(GASFREE_PERMIT_VERSION)),
+        nonce: u256_to_hex(transfer.nonce),
+    };
+
+    Ok(Eip712 {
+        types: permit_transfer_types(),
+        domain,
+        primary_type: PERMIT_TRANSFER_PRIMARY_TYPE.to_string(),
+        message,
+    })
+}
+
+pub fn hash_permit_transfer_typed_data(
+    provider: &ResolvedTronGaslessProvider,
+    transfer: &PermitTransferData,
+) -> MmResult<H256, TronGasfreeError> {
+    let typed_data = build_permit_transfer_typed_data(provider, transfer)?;
+    hash_typed_data(typed_data).map_to_mm(|e: web3::Error| TronGasfreeError::Internal(e.to_string()))
+}
+
+fn permit_transfer_types() -> CustomTypes {
+    let mut domain = ObjectType::domain();
+    domain
+        .property("name", PropertyType::String)
+        .property("version", PropertyType::String)
+        .property("chainId", PropertyType::Uint256)
+        .property("verifyingContract", PropertyType::Address);
+
+    let mut permit_transfer = ObjectType::new(PERMIT_TRANSFER_PRIMARY_TYPE);
+    permit_transfer
+        .property("token", PropertyType::Address)
+        .property("serviceProvider", PropertyType::Address)
+        .property("user", PropertyType::Address)
+        .property("receiver", PropertyType::Address)
+        .property("value", PropertyType::Uint256)
+        .property("maxFee", PropertyType::Uint256)
+        .property("deadline", PropertyType::Uint256)
+        .property("version", PropertyType::Uint256)
+        .property("nonce", PropertyType::Uint256);
+
+    let mut types = HashMap::new();
+    types.insert(EIP712_DOMAIN.to_string(), domain.properties);
+    types.insert(PERMIT_TRANSFER_PRIMARY_TYPE.to_string(), permit_transfer.properties);
+    types
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::eth::tron::gasfree::test_helpers::test_provider;
+    use crate::eth::tron::Network;
+    use bitcrypto::keccak256;
+    use ethabi::Token;
+    use ethereum_types::H160;
+    use std::str::FromStr;
+
+    fn transfer(
+        token: &str,
+        user: &str,
+        receiver: &str,
+        value: u64,
+        max_fee: u64,
+        deadline: u64,
+        nonce: u64,
+    ) -> PermitTransferData {
+        PermitTransferData {
+            token: TronAddress::from_str(token).unwrap(),
+            user: TronAddress::from_str(user).unwrap(),
+            receiver: TronAddress::from_str(receiver).unwrap(),
+            value: U256::from(value),
+            max_fee: U256::from(max_fee),
+            deadline: U256::from(deadline),
+            nonce: U256::from(nonce),
+        }
+    }
+
+    fn typed_data_hash_hex(provider: &ResolvedTronGaslessProvider, transfer: &PermitTransferData) -> String {
+        format!("0x{:02x}", hash_permit_transfer_typed_data(provider, transfer).unwrap())
+    }
+
+    fn domain_separator_hex(provider: &ResolvedTronGaslessProvider) -> String {
+        let typed_data = build_permit_transfer_typed_data(
+            provider,
+            &transfer(
+                "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+                "TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC",
+                "TJM1BE5wq1VdHh3gwjUeyaVkvZp9DVYCfC",
+                1,
+                1,
+                1,
+                0,
+            ),
+        )
+        .unwrap();
+        let type_hash =
+            keccak256(b"EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+        let name_hash = keccak256(typed_data.domain.name.as_bytes());
+        let version_hash = keccak256(typed_data.domain.version.as_bytes());
+        let chain_id = U256::from_str(typed_data.domain.chain_id.trim_start_matches("0x")).unwrap();
+        let verifying_contract =
+            H160::from_slice(&hex::decode(typed_data.domain.verifying_contract.trim_start_matches("0x")).unwrap());
+        let encoded = ethabi::encode(&[
+            Token::FixedBytes(type_hash.to_vec()),
+            Token::FixedBytes(name_hash.to_vec()),
+            Token::FixedBytes(version_hash.to_vec()),
+            Token::Uint(chain_id),
+            Token::Address(verifying_contract),
+        ]);
+        format!("0x{}", hex::encode(keccak256(&encoded)))
+    }
+
+    #[test]
+    fn official_domain_separator_vectors_match() {
+        assert_eq!(
+            domain_separator_hex(&test_provider(Network::Nile, "TDbJyQ6g1Lx9BAfEEeN5S5TMjjDRAVFCaA")),
+            "0x31a0a46f427dd040c91835228e4555951bde0a894cae6239869bb680ebc6ebea"
+        );
+        assert_eq!(
+            domain_separator_hex(&test_provider(Network::Mainnet, "TLntW9Z59LYY5KEi9cmwk3PKjQga828ird")),
+            "0x82f2b33881ada15cfdfa98b393db0e6f80fc9a27a4883ad62943ec5da825c9e8"
+        );
+    }
+
+    #[test]
+    fn official_permit_transfer_hash_vectors_match() {
+        let nile = test_provider(Network::Nile, "TDbJyQ6g1Lx9BAfEEeN5S5TMjjDRAVFCaA");
+        let mainnet = test_provider(Network::Mainnet, "TLntW9Z59LYY5KEi9cmwk3PKjQga828ird");
+        let vectors = [
+            (
+                &mainnet,
+                transfer(
+                    "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t",
+                    "TFDP1vFeSYPT6FUznL7zUjhg5X7p2AA8vw",
+                    "TSPrmJetAMo6S6RxMd4tswzeRCFVegBNig",
+                    20_000_000,
+                    20_000_000,
+                    1_740_641_152,
+                    1,
+                ),
+                "0x4e0e1444d20768c286b9de66064e4e7311b5160871c8c0292ffeac9a16265622",
+            ),
+            (
+                &nile,
+                transfer(
+                    "TXYZopYRdj2D9XRtbG411XZZ3kM5VkAeBf",
+                    "TMVQGm1qAQYVdetCeGRRkTWYYrLXuHK2HC",
+                    "TJM1BE5wq1VdHh3gwjUeyaVkvZp9DVYCfC",
+                    10_000,
+                    2_000,
+                    1_726_207_632,
+                    2,
+                ),
+                "0xb1226f3a0b690b04e2c39fac3b58352ed68943a12a54b58035045215aaf0b9b1",
+            ),
+            (
+                &nile,
+                transfer(
+                    "TLBaRhANQoJFTqre9Nf1mjuwNWjCJeYqUL",
+                    "TDvSsdrNM5eeXNL3czpa6AxLDHZA9nwe9K",
+                    "TLFXfejEMgivFDR2x8qBpukMXd56spmFhz",
+                    20_000,
+                    2_000,
+                    1_726_507_632,
+                    3,
+                ),
+                "0x25c20423c18719438f4d40e6b8fec40ede6b73fb3fa702453ea9bd17dd154fb5",
+            ),
+            (
+                &nile,
+                transfer(
+                    "TVSvjZdyDSNocHm7dP3jvCmMNsCnMTPa5W",
+                    "TKTX96CBxr5kvhjsDHcqoiPWZageGxoTW3",
+                    "TX7WF4tRGQehC9W88XEEKBhQRkLmAtZqKo",
+                    100_000,
+                    2_000,
+                    1_729_507_632,
+                    5,
+                ),
+                "0x3d103a6a3407dfe7540696131d7cafc3d41d7d8649b93a95daeee041e66238ce",
+            ),
+            (
+                &nile,
+                transfer(
+                    "TWrZRHY9aKQZcyjpovdH6qeCEyYZrRQDZt",
+                    "TCo75zcxTuWn5nnFqZUeK5socdVnG11f2T",
+                    "TCN4biEVzzfyUgN1NM8iysp4bYx6mx2gPv",
+                    100_000,
+                    2_000,
+                    1_729_517_632,
+                    15,
+                ),
+                "0xa1a612e946ad2fecc8bcd2f93f987c38a06ca4807db7af30442e9308a20234ea",
+            ),
+            (
+                &nile,
+                transfer(
+                    "TDnDyfMigx5nch7cCrtzGSwTXkUBnQJ9Pg",
+                    "TWYSVbUy6eTu6ZrFWRUimgDy9SinkggVKL",
+                    "TVkoisqxn1SbET8ztcnjqRGAY4npxqDcmv",
+                    100_000,
+                    2_000,
+                    1_729_907_632,
+                    50,
+                ),
+                "0xc78d11f0afc5397f9329861888a6724b66fe370f0189e67c39bfad4eeb7ec2a9",
+            ),
+        ];
+
+        for (provider, transfer, expected_hash) in vectors {
+            assert_eq!(typed_data_hash_hex(provider, &transfer), expected_hash);
+        }
+    }
+}

--- a/mm2src/coins/eth/tron/gasfree/withdraw.rs
+++ b/mm2src/coins/eth/tron/gasfree/withdraw.rs
@@ -1,0 +1,514 @@
+use crate::eth::eth_withdraw::EthWithdraw;
+use crate::eth::tron::fee::{TronGaslessFeeDetails, TronGaslessFeeMethod, TRON_GASFREE_PROVIDER_NAME};
+use crate::eth::tron::gasfree::relay_payload::SignedWithdrawRelayPayload;
+use crate::eth::tron::gasfree::{
+    sign_permit_transfer, DisabledReason, GasfreeAccountService, GasfreeAvailability, GasfreeTransferPreflight,
+    GasfreeTransferRequest, GaslessWithdrawError, PermitTransferData, ResolvedTronGaslessProvider, TronGasfreeError,
+    TronGasfreeRelayPayload, TronOnChainBalanceFetcher,
+};
+use crate::eth::tron::{TronAddress, TronApiClient};
+use crate::eth::{u256_from_big_decimal, u256_to_big_decimal, ChainTaggedAddress, EthCoinType, EthPrivKeyPolicy};
+use crate::hd_wallet::DisplayAddress;
+use crate::{
+    BigDecimal, EthCoin, TransactionData, TransactionDetails, WithdrawError, WithdrawFeeMethod, WithdrawRequest,
+    WithdrawResult,
+};
+use common::{now_sec, utc_now_rfc3339_secs};
+use ethereum_types::U256;
+use mm2_err_handle::map_mm_error::{MapMmError, MmResultExt};
+use mm2_err_handle::prelude::{MapToMmResult, MmError, OrMmError};
+use std::convert::TryFrom;
+
+const DEFAULT_GASLESS_DEADLINE_SECONDS: u64 = 300;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TronGaslessMode {
+    Native,
+    Gasless,
+    Auto,
+}
+
+struct QuotedGaslessWithdraw {
+    preflight: GasfreeTransferPreflight,
+    gasfree_provider: ResolvedTronGaslessProvider,
+    permit: PermitTransferData,
+    total_token_fee_token_base_units: U256,
+    signed_max_fee_token_base_units: U256,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ResolvedTronGaslessWithdrawPolicy {
+    fallback_to_standard_fee_route: bool,
+    request_max_fee_token_base_units: Option<U256>,
+    config_max_fee_token_base_units: Option<U256>,
+    deadline_seconds: u64,
+}
+
+impl ResolvedTronGaslessWithdrawPolicy {
+    fn effective_authorization_max_fee_token_base_units(self, quoted_total_fee_token_base_units: U256) -> U256 {
+        match (
+            self.request_max_fee_token_base_units,
+            self.config_max_fee_token_base_units,
+        ) {
+            (Some(request_cap), Some(token_cap)) => request_cap.min(token_cap),
+            (Some(request_cap), None) => request_cap,
+            (None, Some(token_cap)) => token_cap,
+            (None, None) => quoted_total_fee_token_base_units,
+        }
+    }
+}
+
+pub(crate) async fn maybe_build_tron_gasless_withdraw<W: EthWithdraw>(
+    withdraw: &W,
+    tron: &TronApiClient,
+    from_tagged: &ChainTaggedAddress,
+    to_tagged: &ChainTaggedAddress,
+    contract_tron: TronAddress,
+    mode: TronGaslessMode,
+) -> Result<Option<TransactionDetails>, MmError<WithdrawError>> {
+    match mode {
+        TronGaslessMode::Native => return Ok(None),
+        TronGaslessMode::Auto if withdraw.request().max => return Ok(None),
+        TronGaslessMode::Gasless | TronGaslessMode::Auto => {},
+    }
+
+    let coin = withdraw.coin();
+    let Some(policy) = resolve_gasless_withdraw_policy(coin, withdraw.request(), mode)? else {
+        return Ok(None);
+    };
+
+    let gasfree_provider = resolve_gasfree_provider_for_withdraw_coin(coin).await?;
+    let Some(gasfree_provider) = gasfree_provider else {
+        return match mode {
+            TronGaslessMode::Gasless if policy.fallback_to_standard_fee_route => Ok(None),
+            TronGaslessMode::Gasless => MmError::err(WithdrawError::Gasless(GaslessWithdrawError::Unavailable)),
+            TronGaslessMode::Auto | TronGaslessMode::Native => Ok(None),
+        };
+    };
+
+    let gasless_result = {
+        let address_lock = coin.get_address_lock(from_tagged.inner()).await;
+        let _nonce_lock = address_lock.lock().await;
+        match quote_tron_gasless_withdraw(
+            withdraw,
+            gasfree_provider,
+            policy,
+            tron,
+            from_tagged,
+            to_tagged,
+            contract_tron,
+        )
+        .await
+        {
+            Ok(quoted) => match mode {
+                TronGaslessMode::Gasless | TronGaslessMode::Auto => {
+                    finalize_tron_gasless_withdraw(withdraw, from_tagged, to_tagged, quoted)
+                        .await
+                        .map(Some)
+                },
+                TronGaslessMode::Native => Ok(None),
+            },
+            Err(err) => Err(err),
+        }
+    };
+
+    match gasless_result {
+        Ok(outcome) => Ok(outcome),
+        Err(err)
+            if mode == TronGaslessMode::Gasless
+                && policy.fallback_to_standard_fee_route
+                && is_deterministic_gasless_unavailable(&err) =>
+        {
+            Ok(None)
+        },
+        Err(err) => Err(err),
+    }
+}
+
+impl TryFrom<&WithdrawRequest> for TronGaslessMode {
+    type Error = MmError<WithdrawError>;
+
+    fn try_from(req: &WithdrawRequest) -> Result<Self, Self::Error> {
+        match req.fee_method {
+            None | Some(WithdrawFeeMethod::Native) => {
+                if req.gasless.is_some() {
+                    return MmError::err(WithdrawError::InvalidFee {
+                        reason: "Gasless options can only be used with fee_method 'gasless' or 'auto'".to_string(),
+                        details: None,
+                    });
+                }
+                Ok(TronGaslessMode::Native)
+            },
+            Some(WithdrawFeeMethod::Gasless) => Ok(TronGaslessMode::Gasless),
+            Some(WithdrawFeeMethod::Auto) => Ok(TronGaslessMode::Auto),
+        }
+    }
+}
+
+async fn quote_tron_gasless_withdraw<W: EthWithdraw>(
+    withdraw: &W,
+    gasfree_provider: ResolvedTronGaslessProvider,
+    policy: ResolvedTronGaslessWithdrawPolicy,
+    tron: &TronApiClient,
+    from_tagged: &ChainTaggedAddress,
+    to_tagged: &ChainTaggedAddress,
+    contract_tron: TronAddress,
+) -> Result<QuotedGaslessWithdraw, MmError<WithdrawError>> {
+    let coin = withdraw.coin();
+    let req = withdraw.request();
+
+    if req.max {
+        return MmError::err(WithdrawError::UnsupportedError(
+            "Gasless TRC20 max withdraw is not supported".to_string(),
+        ));
+    }
+
+    let amount = u256_from_big_decimal(&req.amount, coin.decimals).map_mm_err()?;
+    ensure_nonzero_tron_gasless_amount(amount)?;
+    let from_tron = TronAddress::from(from_tagged.inner());
+    let to_tron = TronAddress::from(to_tagged.inner());
+
+    withdraw.on_fetching_gasless_quote()?;
+    let service = GasfreeAccountService::new(&gasfree_provider, from_tron, TronOnChainBalanceFetcher::from(tron));
+    let preflight = service
+        .preflight_transfer(GasfreeTransferRequest {
+            token_address: contract_tron,
+            transfer_value: amount,
+            expected_token_decimals: coin.decimals,
+        })
+        .await
+        .mm_err(WithdrawError::from)?;
+
+    ensure_gasfree_preflight_available(coin, amount, &preflight)?;
+    let total_token_fee_token_base_units =
+        checked_add_u256(preflight.transfer_fee, preflight.activation_fee, "gasless total fee")?;
+    let effective_cap = policy.effective_authorization_max_fee_token_base_units(total_token_fee_token_base_units);
+    if total_token_fee_token_base_units > effective_cap {
+        return MmError::err(WithdrawError::Gasless(GaslessWithdrawError::MaxFeeExceeded));
+    }
+
+    let deadline = now_sec()
+        .checked_add(policy.deadline_seconds)
+        .or_mm_err(|| WithdrawError::InvalidFee {
+            reason: "Gasless deadline overflow".to_string(),
+            details: None,
+        })?;
+
+    let nonce = preflight.nonce;
+
+    Ok(QuotedGaslessWithdraw {
+        gasfree_provider,
+        permit: PermitTransferData {
+            token: contract_tron,
+            user: from_tron,
+            receiver: to_tron,
+            value: amount,
+            max_fee: effective_cap,
+            deadline: U256::from(deadline),
+            nonce,
+        },
+        preflight,
+        total_token_fee_token_base_units,
+        signed_max_fee_token_base_units: effective_cap,
+    })
+}
+
+async fn finalize_tron_gasless_withdraw<W: EthWithdraw>(
+    withdraw: &W,
+    from_tagged: &ChainTaggedAddress,
+    to_tagged: &ChainTaggedAddress,
+    quoted: QuotedGaslessWithdraw,
+) -> WithdrawResult {
+    let coin = withdraw.coin();
+    let req = withdraw.request();
+    let derivation_path = match coin.priv_key_policy {
+        EthPrivKeyPolicy::HDWallet { .. } => Some(withdraw.get_withdraw_derivation_path(req).await?),
+        EthPrivKeyPolicy::Iguana(_) => None,
+        EthPrivKeyPolicy::Trezor | EthPrivKeyPolicy::WalletConnect { .. } => None,
+        #[cfg(target_arch = "wasm32")]
+        EthPrivKeyPolicy::Metamask(_) => None,
+    };
+
+    withdraw.on_signing_gasless_authorization()?;
+    let signed_authorization = sign_permit_transfer(
+        &quoted.gasfree_provider,
+        &quoted.permit,
+        &coin.priv_key_policy,
+        derivation_path.as_ref(),
+    )
+    .mm_err(WithdrawError::from)?;
+
+    let payload = TronGasfreeRelayPayload::from(SignedWithdrawRelayPayload {
+        provider: &quoted.gasfree_provider,
+        coin: coin.ticker.clone(),
+        from: req.from.clone(),
+        from_address: from_tagged.display_address(),
+        gasfree_address: quoted.preflight.gasfree_address,
+        signed_authorization,
+        created_at: utc_now_rfc3339_secs(),
+    });
+    let tx = TransactionData::new_unsigned(
+        serde_json::to_value(payload).map_to_mm(|e| WithdrawError::InternalError(e.to_string()))?,
+    );
+    let fee_details = build_tron_gasless_fee_details(coin, &quoted)?;
+
+    withdraw.on_finishing()?;
+    build_gasless_transaction_details(
+        coin,
+        from_tagged,
+        to_tagged,
+        tx,
+        quoted.permit.value,
+        quoted.total_token_fee_token_base_units,
+        fee_details,
+    )
+}
+
+fn is_deterministic_gasless_unavailable(err: &MmError<WithdrawError>) -> bool {
+    matches!(
+        err.get_inner(),
+        WithdrawError::Gasless(GaslessWithdrawError::Unavailable) | WithdrawError::NotSufficientBalance { .. }
+    )
+}
+
+pub(crate) fn is_standard_tron_withdraw_unavailable(err: &MmError<WithdrawError>) -> bool {
+    matches!(
+        err.get_inner(),
+        WithdrawError::NotSufficientBalance { .. }
+            | WithdrawError::NotSufficientPlatformBalanceForFee { .. }
+            | WithdrawError::ZeroBalanceToWithdrawMax
+            | WithdrawError::AmountTooLow { .. }
+    )
+}
+
+#[allow(clippy::result_large_err)]
+pub(crate) fn validate_non_tron_gasless_request(req: &WithdrawRequest) -> Result<(), MmError<WithdrawError>> {
+    match req.fee_method {
+        Some(WithdrawFeeMethod::Gasless) | Some(WithdrawFeeMethod::Auto) => {
+            MmError::err(WithdrawError::Gasless(GaslessWithdrawError::Unavailable))
+        },
+        Some(WithdrawFeeMethod::Native) | None if req.gasless.is_some() => MmError::err(WithdrawError::InvalidFee {
+            reason: "Gasless options can only be used with fee_method 'gasless' or 'auto'".to_string(),
+            details: None,
+        }),
+        Some(WithdrawFeeMethod::Native) | None => Ok(()),
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn resolve_gasless_withdraw_policy(
+    coin: &EthCoin,
+    req: &WithdrawRequest,
+    mode: TronGaslessMode,
+) -> Result<Option<ResolvedTronGaslessWithdrawPolicy>, MmError<WithdrawError>> {
+    let fallback_to_standard_fee_route = req
+        .gasless
+        .as_ref()
+        .map(|options| options.fallback_to_native)
+        .unwrap_or(false);
+
+    let Some(token_config) = coin.0.tron_gasless_token_config.as_ref() else {
+        return match mode {
+            TronGaslessMode::Gasless if fallback_to_standard_fee_route => Ok(None),
+            TronGaslessMode::Gasless => MmError::err(WithdrawError::Gasless(GaslessWithdrawError::Unavailable)),
+            TronGaslessMode::Auto | TronGaslessMode::Native => Ok(None),
+        };
+    };
+
+    let deadline_seconds = req
+        .gasless
+        .as_ref()
+        .and_then(|options| options.deadline_seconds)
+        .unwrap_or(DEFAULT_GASLESS_DEADLINE_SECONDS);
+    if deadline_seconds == 0 {
+        return MmError::err(WithdrawError::InvalidFee {
+            reason: "Gasless deadline_seconds must be greater than zero".to_string(),
+            details: None,
+        });
+    }
+
+    let request_max_fee_token_base_units = req
+        .gasless
+        .as_ref()
+        .and_then(|options| options.max_fee.as_ref())
+        .map(|cap| request_gasless_max_fee_to_token_base_units(cap, coin.decimals))
+        .transpose()?;
+
+    Ok(Some(ResolvedTronGaslessWithdrawPolicy {
+        fallback_to_standard_fee_route,
+        request_max_fee_token_base_units,
+        config_max_fee_token_base_units: token_config.transfer_max_fee_token_base_units,
+        deadline_seconds,
+    }))
+}
+
+async fn resolve_gasfree_provider_for_withdraw_coin(
+    coin: &EthCoin,
+) -> Result<Option<ResolvedTronGaslessProvider>, MmError<WithdrawError>> {
+    if let Some(provider) = coin.0.tron_gasless_provider.clone() {
+        return Ok(Some(provider));
+    }
+
+    match coin.coin_type {
+        EthCoinType::Erc20 { .. } => Ok(coin.platform_coin().await.map_mm_err()?.0.tron_gasless_provider.clone()),
+        EthCoinType::Eth | EthCoinType::Nft { .. } => Ok(None),
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn build_gasless_transaction_details(
+    coin: &EthCoin,
+    from_tagged: &ChainTaggedAddress,
+    to_tagged: &ChainTaggedAddress,
+    tx: TransactionData,
+    amount: U256,
+    token_fee: U256,
+    fee_details: TronGaslessFeeDetails,
+) -> WithdrawResult {
+    let amount_decimal = u256_to_big_decimal(amount, coin.decimals).map_mm_err()?;
+    let token_fee_decimal = u256_to_big_decimal(token_fee, coin.decimals).map_mm_err()?;
+    let spent_by_me = &amount_decimal + &token_fee_decimal;
+    let received_by_me = if to_tagged.inner() == from_tagged.inner() {
+        amount_decimal.clone()
+    } else {
+        0.into()
+    };
+
+    Ok(TransactionDetails {
+        to: vec![to_tagged.display_address()],
+        from: vec![from_tagged.display_address()],
+        total_amount: amount_decimal,
+        my_balance_change: &received_by_me - &spent_by_me,
+        spent_by_me,
+        received_by_me,
+        tx,
+        block_height: 0,
+        fee_details: Some(fee_details.into()),
+        coin: coin.ticker.clone(),
+        internal_id: vec![].into(),
+        timestamp: now_sec(),
+        kmd_rewards: None,
+        transaction_type: Default::default(),
+        memo: None,
+    })
+}
+
+#[allow(clippy::result_large_err)]
+fn ensure_nonzero_tron_gasless_amount(amount: U256) -> Result<(), MmError<WithdrawError>> {
+    if amount.is_zero() {
+        return MmError::err(WithdrawError::InvalidFee {
+            reason: "Gasless withdraw amount must be greater than zero".to_string(),
+            details: None,
+        });
+    }
+    Ok(())
+}
+
+#[allow(clippy::result_large_err)]
+fn checked_add_u256(lhs: U256, rhs: U256, field_name: &str) -> Result<U256, MmError<WithdrawError>> {
+    lhs.checked_add(rhs)
+        .or_mm_err(|| WithdrawError::InternalError(format!("Overflow while computing {field_name}")))
+}
+
+#[allow(clippy::result_large_err)]
+fn request_gasless_max_fee_to_token_base_units(
+    cap: &BigDecimal,
+    token_decimals: u8,
+) -> Result<U256, MmError<WithdrawError>> {
+    u256_from_big_decimal(cap, token_decimals).mm_err(|_| WithdrawError::InvalidFee {
+        reason: format!("Invalid gasless max_fee value '{cap}'"),
+        details: None,
+    })
+}
+
+#[allow(clippy::result_large_err)]
+fn ensure_gasfree_preflight_available(
+    coin: &EthCoin,
+    amount: U256,
+    preflight: &GasfreeTransferPreflight,
+) -> Result<(), MmError<WithdrawError>> {
+    match &preflight.availability {
+        GasfreeAvailability::Available => Ok(()),
+        GasfreeAvailability::PendingTransfer => {
+            MmError::err(WithdrawError::Gasless(GaslessWithdrawError::PendingTransfer))
+        },
+        GasfreeAvailability::Disabled { reason } => match reason {
+            DisabledReason::TokenUnsupported { .. } => {
+                MmError::err(WithdrawError::Gasless(GaslessWithdrawError::Unavailable))
+            },
+            DisabledReason::AddressMismatch { .. } | DisabledReason::TokenDecimalMismatch { .. } => {
+                MmError::err(WithdrawError::Gasless(GaslessWithdrawError::InvalidProviderResponse))
+            },
+            DisabledReason::InsufficientSpendableBalance => {
+                let total_fee =
+                    checked_add_u256(preflight.transfer_fee, preflight.activation_fee, "gasless total fee")?;
+                let required = checked_add_u256(amount, total_fee, "gasless spendable required")?;
+                let available = preflight.on_chain_balance.saturating_sub(preflight.frozen_balance);
+                MmError::err(WithdrawError::NotSufficientBalance {
+                    coin: coin.ticker.clone(),
+                    available: u256_to_big_decimal(available, coin.decimals).map_mm_err()?,
+                    required: u256_to_big_decimal(required, coin.decimals).map_mm_err()?,
+                })
+            },
+            DisabledReason::InactiveAccountInsufficientBalance => {
+                let total_fee =
+                    checked_add_u256(preflight.transfer_fee, preflight.activation_fee, "gasless total fee")?;
+                let required_spendable = checked_add_u256(amount, total_fee, "gasless inactive spendable required")?;
+                let required_total = checked_add_u256(
+                    required_spendable,
+                    preflight.frozen_balance,
+                    "gasless inactive total required",
+                )?;
+                MmError::err(WithdrawError::NotSufficientBalance {
+                    coin: coin.ticker.clone(),
+                    available: u256_to_big_decimal(preflight.on_chain_balance, coin.decimals).map_mm_err()?,
+                    required: u256_to_big_decimal(required_total, coin.decimals).map_mm_err()?,
+                })
+            },
+        },
+    }
+}
+
+impl From<TronGasfreeError> for WithdrawError {
+    fn from(err: TronGasfreeError) -> Self {
+        match err {
+            TronGasfreeError::InvalidResponse(_) => {
+                WithdrawError::Gasless(GaslessWithdrawError::InvalidProviderResponse)
+            },
+            TronGasfreeError::ProviderBadRequest(_) => WithdrawError::Gasless(GaslessWithdrawError::ProviderRejected),
+            TronGasfreeError::Unauthorized(message)
+            | TronGasfreeError::Forbidden(message)
+            | TronGasfreeError::RateLimited(message)
+            | TronGasfreeError::Upstream(message)
+            | TronGasfreeError::Transport(message)
+            | TronGasfreeError::Timeout(message) => WithdrawError::Transport(format!("GasFree {message}")),
+            TronGasfreeError::InvalidRequest(message)
+            | TronGasfreeError::Internal(message)
+            | TronGasfreeError::NotImplemented(message) => WithdrawError::InternalError(format!("GasFree {message}")),
+        }
+    }
+}
+
+#[allow(clippy::result_large_err)]
+fn build_tron_gasless_fee_details(
+    coin: &EthCoin,
+    quoted: &QuotedGaslessWithdraw,
+) -> Result<TronGaslessFeeDetails, MmError<WithdrawError>> {
+    let transfer_fee = u256_to_big_decimal(quoted.preflight.transfer_fee, coin.decimals).map_mm_err()?;
+    let activation_fee = u256_to_big_decimal(quoted.preflight.activation_fee, coin.decimals).map_mm_err()?;
+    let total_token_fee = u256_to_big_decimal(quoted.total_token_fee_token_base_units, coin.decimals).map_mm_err()?;
+
+    let signed_max_fee = u256_to_big_decimal(quoted.signed_max_fee_token_base_units, coin.decimals).map_mm_err()?;
+
+    Ok(TronGaslessFeeDetails {
+        coin: coin.ticker.clone(),
+        fee_method: TronGaslessFeeMethod::Gasless,
+        provider_name: TRON_GASFREE_PROVIDER_NAME.to_string(),
+        gasfree_address: quoted.preflight.gasfree_address.to_base58(),
+        transfer_fee,
+        activation_fee,
+        total_token_fee,
+        signed_max_fee: Some(signed_max_fee),
+        trace_id: None,
+    })
+}

--- a/mm2src/coins/eth/tron/primitives.rs
+++ b/mm2src/coins/eth/tron/primitives.rs
@@ -1,0 +1,84 @@
+use ethereum_types::{H256, H520};
+use serde::de::Error as DeError;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::str::FromStr;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TronSignature(H520);
+
+impl TronSignature {
+    pub fn from_hex_str(value: &str) -> Result<Self, String> {
+        // H520::from_str silently strips a lowercase `0x` prefix. We reject it upfront to
+        // enforce the GasFree spec's "hex, no 0x prefix" wire-format requirement.
+        if value.starts_with("0x") || value.starts_with("0X") {
+            return Err("signature must not include a 0x prefix".to_string());
+        }
+
+        H520::from_str(value)
+            .map(TronSignature)
+            .map_err(|e| format!("Invalid signature: {e}"))
+    }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0.as_bytes())
+    }
+}
+
+impl Serialize for TronSignature {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for TronSignature {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        TronSignature::from_hex_str(&value).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TronTxHash(H256);
+
+impl TronTxHash {
+    pub fn from_hex_str(value: &str) -> Result<Self, String> {
+        // H256::from_str silently strips a lowercase `0x` prefix. We reject it upfront to
+        // enforce the GasFree spec's "hex, no 0x prefix" wire-format requirement.
+        if value.starts_with("0x") || value.starts_with("0X") {
+            return Err("txnHash must not include a 0x prefix".to_string());
+        }
+
+        H256::from_str(value)
+            .map(TronTxHash)
+            .map_err(|e| format!("Invalid txnHash: {e}"))
+    }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0.as_bytes())
+    }
+}
+
+impl Serialize for TronTxHash {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for TronTxHash {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        TronTxHash::from_hex_str(&value).map_err(D::Error::custom)
+    }
+}

--- a/mm2src/coins/eth/tron/withdraw.rs
+++ b/mm2src/coins/eth/tron/withdraw.rs
@@ -12,7 +12,7 @@ use crate::eth::tron::fee::{
 use crate::eth::tron::proto::TransactionRaw;
 use crate::eth::tron::tx_builder::{build_trc20_transfer, build_trx_transfer};
 use crate::eth::tron::{TaposBlockData, TronAddress, TronApiClient, TRX_DECIMALS};
-use crate::eth::{u256_from_big_decimal, u256_to_big_decimal};
+use crate::eth::{u256_from_big_decimal, u256_to_big_decimal, EthCoinType};
 use crate::{WithdrawError, WithdrawFee};
 use ethereum_types::U256;
 use mm2_err_handle::map_mm_error::MmResultExt;
@@ -59,6 +59,89 @@ pub fn u256_to_u64_checked(value: U256) -> Result<u64, MmError<WithdrawError>> {
         return MmError::err(WithdrawError::InternalError(format!("value {value} exceeds u64::MAX")));
     }
     Ok(value.as_u64())
+}
+
+#[allow(clippy::result_large_err)]
+fn ensure_tron_withdraw_asset_balance(
+    ticker: &str,
+    amount: U256,
+    balance: U256,
+    balance_dec: &BigDecimal,
+    decimals: u8,
+) -> Result<(), MmError<WithdrawError>> {
+    if amount <= balance {
+        return Ok(());
+    }
+
+    MmError::err(WithdrawError::NotSufficientBalance {
+        coin: ticker.to_owned(),
+        available: balance_dec.clone(),
+        required: u256_to_big_decimal(amount, decimals).map_mm_err()?,
+    })
+}
+
+#[derive(Clone, Copy)]
+pub struct StandardTronWithdrawParams<'a, 'ctx> {
+    pub coin_type: &'a EthCoinType,
+    pub ticker: &'a str,
+    pub decimals: u8,
+    pub balance: U256,
+    pub balance_dec: &'a BigDecimal,
+    pub amount_base_units: U256,
+    pub is_max: bool,
+    pub ctx: &'a TronWithdrawContext<'ctx>,
+    pub tron: &'a TronApiClient,
+}
+
+impl StandardTronWithdrawParams<'_, '_> {
+    #[allow(clippy::result_large_err)]
+    fn ensure_asset_balance(&self) -> Result<(), MmError<WithdrawError>> {
+        ensure_tron_withdraw_asset_balance(
+            self.ticker,
+            self.amount_base_units,
+            self.balance,
+            self.balance_dec,
+            self.decimals,
+        )
+    }
+}
+
+/// Build a standard TRON withdrawal, validating the asset balance before preparing the transaction.
+#[allow(clippy::result_large_err)]
+pub async fn build_standard_tron_withdraw(
+    params: StandardTronWithdrawParams<'_, '_>,
+) -> Result<(TransactionRaw, TronTxFeeDetails, U256), MmError<WithdrawError>> {
+    match params.coin_type {
+        EthCoinType::Eth => {
+            params.ensure_asset_balance()?;
+            build_tron_trx_withdraw(
+                params.ctx,
+                params.amount_base_units,
+                params.balance,
+                params.balance_dec,
+                params.is_max,
+            )
+        },
+        EthCoinType::Erc20 {
+            platform, token_addr, ..
+        } => {
+            params.ensure_asset_balance()?;
+            let contract_tron = TronAddress::from(*token_addr);
+            let trc20_ctx = TronWithdrawContext {
+                from: params.ctx.from,
+                to: params.ctx.to,
+                block_data: params.ctx.block_data,
+                resources: params.ctx.resources,
+                prices: params.ctx.prices,
+                fee_coin: platform.as_str(),
+                expiration_seconds: params.ctx.expiration_seconds,
+            };
+            build_tron_trc20_withdraw(&trc20_ctx, params.tron, &contract_tron, params.amount_base_units).await
+        },
+        EthCoinType::Nft { .. } => MmError::err(WithdrawError::ProtocolNotSupported(
+            "NFT withdraw is not supported for TRON".to_owned(),
+        )),
+    }
 }
 
 /// Build TRX (native) withdraw: estimate fees, handle max-deduction, return final tx raw.

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::eth::erc20::get_enabled_erc20_by_platform_and_contract;
 use crate::eth::eth_utils::nonce_sequencer::PerNetNonceLocks;
+use crate::eth::tron::gasfree::{resolve_tron_gasless_provider, TronGaslessProviderConfig};
 use crate::eth::wallet_connect::eth_request_wc_personal_sign;
 use crate::eth::web3_transport::http_transport::HttpTransport;
 use crate::hd_wallet::{
@@ -248,6 +249,10 @@ pub struct EthActivationV2Request {
     pub path_to_address: HDPathAccountToAddressId,
     pub gap_limit: Option<u32>,
     pub swap_gas_fee_policy: Option<SwapGasFeePolicy>,
+    /// Platform-level TRON GasFree provider configuration.
+    /// Only valid for TRON chains; rejected for EVM chains if present.
+    #[serde(default)]
+    pub tron_gasless_provider: Option<TronGaslessProviderConfig>,
 }
 
 #[derive(Clone, Deserialize)]
@@ -578,6 +583,7 @@ impl EthCoin {
             gas_limit_v2,
             estimate_gas_mult,
             abortable_system,
+            tron_gasless_provider: None,
         };
 
         Ok(EthCoin(Arc::new(token)))
@@ -676,6 +682,7 @@ impl EthCoin {
             gas_limit_v2,
             estimate_gas_mult,
             abortable_system,
+            tron_gasless_provider: None,
         };
         Ok(EthCoin(Arc::new(global_nft)))
     }
@@ -769,6 +776,9 @@ pub async fn eth_coin_from_conf_and_request_v2(
         req.swap_v2_contracts,
         req.fallback_swap_contract,
     )?;
+
+    let tron_gasless_provider = resolve_tron_gasless_provider(&chain_spec, req.tron_gasless_provider.as_ref())
+        .map_err(|e| EthActivationV2Error::InvalidPayload(e.to_string()))?;
 
     let (priv_key_policy, derivation_method) = build_address_and_priv_key_policy(
         ctx,
@@ -898,6 +908,7 @@ pub async fn eth_coin_from_conf_and_request_v2(
         gas_limit_v2,
         estimate_gas_mult,
         abortable_system,
+        tron_gasless_provider,
     };
 
     Ok(EthCoin(Arc::new(coin)))

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -583,7 +583,7 @@ impl EthCoin {
             gas_limit_v2,
             estimate_gas_mult,
             abortable_system,
-            tron_gasless_provider: None,
+            tron_gasless_provider: self.tron_gasless_provider.clone(),
         };
 
         Ok(EthCoin(Arc::new(token)))

--- a/mm2src/coins/eth/v2_activation.rs
+++ b/mm2src/coins/eth/v2_activation.rs
@@ -1,7 +1,9 @@
 use super::*;
 use crate::eth::erc20::get_enabled_erc20_by_platform_and_contract;
 use crate::eth::eth_utils::nonce_sequencer::PerNetNonceLocks;
-use crate::eth::tron::gasfree::{resolve_tron_gasless_provider, TronGaslessProviderConfig};
+use crate::eth::tron::gasfree::{
+    resolve_tron_gasless_provider, ResolvedTronGaslessTokenConfig, TronGaslessProviderConfig,
+};
 use crate::eth::wallet_connect::eth_request_wc_personal_sign;
 use crate::eth::web3_transport::http_transport::HttpTransport;
 use crate::hd_wallet::{
@@ -28,6 +30,7 @@ use mm2_metamask::{from_metamask_error, MetamaskError, MetamaskRpcError, WithMet
 use mm2_p2p::p2p_ctx::P2PContext;
 use proxy_signature::RawMessage;
 use rpc_task::RpcTaskError;
+use std::convert::TryFrom;
 use std::sync::atomic::Ordering;
 use url::Url;
 use web3_transport::websocket_transport::WebsocketTransport;
@@ -262,7 +265,7 @@ pub struct EthNode {
     pub komodo_proxy: bool,
 }
 
-#[derive(Display, Serialize, SerializeErrorType)]
+#[derive(Debug, Display, Serialize, SerializeErrorType)]
 #[serde(tag = "error_type", content = "error_data")]
 pub enum EthTokenActivationError {
     InternalError(String),
@@ -279,6 +282,59 @@ pub enum EthTokenActivationError {
 impl From<AbortedError> for EthTokenActivationError {
     fn from(e: AbortedError) -> Self {
         EthTokenActivationError::InternalError(e.to_string())
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+struct TronGaslessTokenActivationConfig {
+    #[serde(default)]
+    enabled: bool,
+    transfer_max_fee: Option<BigDecimal>,
+}
+
+fn resolve_tron_gasless_token_config(
+    raw: Option<&TronGaslessTokenActivationConfig>,
+    decimals: u8,
+) -> MmResult<Option<ResolvedTronGaslessTokenConfig>, EthTokenActivationError> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+
+    if !raw.enabled {
+        return Ok(None);
+    }
+
+    Ok(Some(ResolvedTronGaslessTokenConfig::try_from((
+        EnabledTronGaslessTokenActivationConfig(raw),
+        decimals,
+    ))?))
+}
+
+struct EnabledTronGaslessTokenActivationConfig<'a>(&'a TronGaslessTokenActivationConfig);
+
+impl TryFrom<(EnabledTronGaslessTokenActivationConfig<'_>, u8)> for ResolvedTronGaslessTokenConfig {
+    type Error = MmError<EthTokenActivationError>;
+
+    fn try_from((config, decimals): (EnabledTronGaslessTokenActivationConfig<'_>, u8)) -> Result<Self, Self::Error> {
+        let config = config.0;
+        let transfer_max_fee_token_base_units = if let Some(ref transfer_max_fee) = config.transfer_max_fee {
+            if transfer_max_fee < &BigDecimal::from(0) {
+                return MmError::err(EthTokenActivationError::InvalidPayload(
+                    "TRON token gasless.transfer_max_fee must be non-negative".to_string(),
+                ));
+            }
+            Some(u256_from_big_decimal(transfer_max_fee, decimals).mm_err(|e| {
+                EthTokenActivationError::InvalidPayload(format!(
+                    "Invalid TRON token gasless.transfer_max_fee representation: {e}"
+                ))
+            })?)
+        } else {
+            None
+        };
+
+        Ok(ResolvedTronGaslessTokenConfig {
+            transfer_max_fee_token_base_units,
+        })
     }
 }
 
@@ -410,6 +466,8 @@ pub enum EthTokenActivationParams {
 #[derive(Clone, Deserialize)]
 pub struct Erc20TokenActivationRequest {
     pub required_confirmations: Option<u64>,
+    #[serde(default)]
+    gasless: Option<TronGaslessTokenActivationConfig>,
 }
 
 /// Holds ERC-20 token-specific activation parameters when using the task manager for activation.
@@ -417,6 +475,8 @@ pub struct Erc20TokenActivationRequest {
 pub struct InitErc20TokenActivationRequest {
     /// The number of confirmations required for swap transactions.
     pub required_confirmations: Option<u64>,
+    #[serde(default)]
+    gasless: Option<TronGaslessTokenActivationConfig>,
     /// Parameters for HD wallet account and addresses initialization.
     #[serde(flatten)]
     pub enable_params: EnabledCoinBalanceParams,
@@ -430,6 +490,7 @@ impl From<InitErc20TokenActivationRequest> for Erc20TokenActivationRequest {
     fn from(req: InitErc20TokenActivationRequest) -> Self {
         Erc20TokenActivationRequest {
             required_confirmations: req.required_confirmations,
+            gasless: req.gasless,
         }
     }
 }
@@ -550,6 +611,25 @@ impl EthCoin {
                 .map_mm_err()?
                 .unwrap_or_default();
         let swap_gas_fee_policy = SwapGasFeePolicy::default();
+        let tron_gasless_token_config = match &self.chain_spec {
+            ChainSpec::Tron { .. } => {
+                let config = resolve_tron_gasless_token_config(activation_params.gasless.as_ref(), decimals)?;
+                if config.is_some() && self.tron_gasless_provider.is_none() {
+                    return MmError::err(EthTokenActivationError::InvalidPayload(
+                        "TRON token gasless config requires a platform tron_gasless_provider".to_string(),
+                    ));
+                }
+                config
+            },
+            ChainSpec::Evm { .. } => {
+                if activation_params.gasless.is_some() {
+                    return MmError::err(EthTokenActivationError::InvalidPayload(
+                        "Token gasless config is only supported on TRON chains".to_string(),
+                    ));
+                }
+                None
+            },
+        };
 
         let token = EthCoinImpl {
             priv_key_policy: self.priv_key_policy.clone(),
@@ -584,6 +664,7 @@ impl EthCoin {
             estimate_gas_mult,
             abortable_system,
             tron_gasless_provider: self.tron_gasless_provider.clone(),
+            tron_gasless_token_config,
         };
 
         Ok(EthCoin(Arc::new(token)))
@@ -683,6 +764,7 @@ impl EthCoin {
             estimate_gas_mult,
             abortable_system,
             tron_gasless_provider: None,
+            tron_gasless_token_config: None,
         };
         Ok(EthCoin(Arc::new(global_nft)))
     }
@@ -909,6 +991,7 @@ pub async fn eth_coin_from_conf_and_request_v2(
         estimate_gas_mult,
         abortable_system,
         tron_gasless_provider,
+        tron_gasless_token_config: None,
     };
 
     Ok(EthCoin(Arc::new(coin)))
@@ -1295,4 +1378,42 @@ fn compress_public_key(uncompressed: H520) -> MmResult<H264, EthActivationV2Erro
     let compressed = public_key.serialize();
 
     Ok(H264::from(compressed))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethereum_types::U256;
+
+    #[test]
+    fn resolve_tron_gasless_token_config_accepts_valid_positive_cap() {
+        let config = resolve_tron_gasless_token_config(
+            Some(&TronGaslessTokenActivationConfig {
+                enabled: true,
+                transfer_max_fee: Some("2.5".parse().unwrap()),
+            }),
+            6,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            config.transfer_max_fee_token_base_units.unwrap(),
+            U256::from(2_500_000u64)
+        );
+    }
+
+    #[test]
+    fn resolve_tron_gasless_token_config_rejects_negative_cap() {
+        let err = resolve_tron_gasless_token_config(
+            Some(&TronGaslessTokenActivationConfig {
+                enabled: true,
+                transfer_max_fee: Some("-1".parse().unwrap()),
+            }),
+            6,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err.into_inner(), EthTokenActivationError::InvalidPayload(_)));
+    }
 }

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -6326,6 +6326,7 @@ where
                         derivation_path: RpcDerivationPath(empty_address.derivation_path().clone()),
                         chain,
                         balance: HDWalletBalanceObject::<T>::new(),
+                        gasfree_address: None,
                     });
                 balances.extend(empty_addresses);
 
@@ -6335,6 +6336,7 @@ where
                     derivation_path: RpcDerivationPath(checking_address_der_path.clone()),
                     chain,
                     balance: non_empty_balance,
+                    gasfree_address: None,
                 });
                 // Reset the counter of unused addresses to zero since we found a non-empty address.
                 unused_addresses_counter = 0;

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -2347,23 +2347,14 @@ pub struct WithdrawRequest {
     /// but can be expanded to any protocol that supports transaction expiry.
     pub expiration_seconds: Option<u64>,
     /// Preferred withdrawal fee rail. `None` preserves each coin's existing native behavior.
-    ///
-    /// TODO(Commit 9): consume in `build_tron_withdraw` to branch native/gasless; non-TRON
-    /// coins should reject `Some(Gasless | Auto)` with `WithdrawError::Gasless(Unavailable)`.
-    /// check when working on commit 9 for ways to have this in a generic way while backward compatible.
     #[serde(default)]
     pub fee_method: Option<WithdrawFeeMethod>,
     /// Gasless rail constraints supplied by the caller.
-    ///
-    /// TODO(Commit 9): consume `max_fee` / `deadline_seconds` / `fallback_to_native` and
-    /// decide the policy for conflicting combos (`fee_method=Native` with populated options,
-    /// `fee_method=Gasless` with a manual `fee`).
-    /// check when working on commit 9 for ways to have this in a generic way while backward compatible.
     #[serde(default)]
     pub gasless: Option<GaslessWithdrawOptions>,
 }
 
-/// TODO(Commit 9): Is this needed here, or should it be in tron code. Is it needed at all?
+/// Preferred fee rail for withdrawals that support alternative fee payment.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum WithdrawFeeMethod {
@@ -2372,7 +2363,7 @@ pub enum WithdrawFeeMethod {
     Auto,
 }
 
-/// TODO(Commit 9): Is this needed here, or should it be in tron code. Is it needed at all?
+/// Caller-supplied constraints for gasless withdrawals.
 #[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct GaslessWithdrawOptions {
     pub max_fee: Option<BigDecimal>,

--- a/mm2src/coins/lp_coins.rs
+++ b/mm2src/coins/lp_coins.rs
@@ -233,6 +233,7 @@ use crypto::secret_hash_algo::SecretHashAlgo;
 pub mod eth;
 use eth::erc20::get_erc20_ticker_by_contract_address;
 use eth::eth_swap_v2::{PrepareTxDataError, ValidatePaymentV2Err};
+use eth::tron::gasfree::GaslessWithdrawError;
 use eth::{
     eth_coin_from_conf_and_request, get_eth_address, EthCoin, EthGasDetailsErr, GetEthAddressError,
     GetValidEthWithdrawAddError, SignedEthTx,
@@ -2345,6 +2346,39 @@ pub struct WithdrawRequest {
     /// Transaction expiration window in seconds. Currently only used by TRON (default 60s),
     /// but can be expanded to any protocol that supports transaction expiry.
     pub expiration_seconds: Option<u64>,
+    /// Preferred withdrawal fee rail. `None` preserves each coin's existing native behavior.
+    ///
+    /// TODO(Commit 9): consume in `build_tron_withdraw` to branch native/gasless; non-TRON
+    /// coins should reject `Some(Gasless | Auto)` with `WithdrawError::Gasless(Unavailable)`.
+    /// check when working on commit 9 for ways to have this in a generic way while backward compatible.
+    #[serde(default)]
+    pub fee_method: Option<WithdrawFeeMethod>,
+    /// Gasless rail constraints supplied by the caller.
+    ///
+    /// TODO(Commit 9): consume `max_fee` / `deadline_seconds` / `fallback_to_native` and
+    /// decide the policy for conflicting combos (`fee_method=Native` with populated options,
+    /// `fee_method=Gasless` with a manual `fee`).
+    /// check when working on commit 9 for ways to have this in a generic way while backward compatible.
+    #[serde(default)]
+    pub gasless: Option<GaslessWithdrawOptions>,
+}
+
+/// TODO(Commit 9): Is this needed here, or should it be in tron code. Is it needed at all?
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum WithdrawFeeMethod {
+    Native,
+    Gasless,
+    Auto,
+}
+
+/// TODO(Commit 9): Is this needed here, or should it be in tron code. Is it needed at all?
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GaslessWithdrawOptions {
+    pub max_fee: Option<BigDecimal>,
+    pub deadline_seconds: Option<u64>,
+    #[serde(default)]
+    pub fallback_to_native: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -3232,6 +3266,8 @@ pub enum WithdrawError {
     },
     #[display(fmt = "Invalid memo field: {_0}")]
     InvalidMemo(String),
+    #[display(fmt = "{_0}")]
+    Gasless(GaslessWithdrawError),
     #[display(fmt = "No such coin {coin}")]
     NoSuchCoin {
         coin: String,
@@ -3312,6 +3348,7 @@ impl HttpStatusCode for WithdrawError {
         match self {
             WithdrawError::NoSuchCoin { .. } => StatusCode::NOT_FOUND,
             WithdrawError::Timeout(_) => StatusCode::REQUEST_TIMEOUT,
+            WithdrawError::Gasless(inner) => inner.status_code(),
             WithdrawError::CoinDoesntSupportInitWithdraw { .. }
             | WithdrawError::NotSufficientBalance { .. }
             | WithdrawError::NotSufficientPlatformBalanceForFee { .. }

--- a/mm2src/coins/rpc_command/get_new_address.rs
+++ b/mm2src/coins/rpc_command/get_new_address.rs
@@ -236,7 +236,7 @@ pub struct GetNewAddressParams {
 /// Generic response for the `get_new_address` RPC command.
 #[derive(Clone, Debug, Serialize)]
 pub struct GetNewAddressResponse<BalanceObject> {
-    new_address: HDAddressBalance<BalanceObject>,
+    pub(crate) new_address: HDAddressBalance<BalanceObject>,
 }
 
 /// Enum for the response of the `get_new_address` RPC command.
@@ -523,6 +523,7 @@ pub(crate) mod common_impl {
                 derivation_path: RpcDerivationPath(hd_address.derivation_path().clone()),
                 chain,
                 balance,
+                gasfree_address: None,
             },
         })
     }
@@ -569,6 +570,7 @@ pub(crate) mod common_impl {
                 derivation_path: RpcDerivationPath(hd_address.derivation_path().clone()),
                 chain,
                 balance,
+                gasfree_address: None,
             },
         })
     }

--- a/mm2src/coins/rpc_command/init_withdraw.rs
+++ b/mm2src/coins/rpc_command/init_withdraw.rs
@@ -73,6 +73,19 @@ pub enum WithdrawInProgressStatus {
     Preparing,
     GeneratingTransaction,
     SigningTransaction,
+    // TODO(Commit 9 / Commit 10): emit the variants below from the TRON gasless withdraw path.
+    // Defined now for wire compatibility; no execution path produces them yet. Check if one wrapped variant will be better and how to add those in a generic way if possible.
+    FetchingGaslessQuote,
+    SigningGaslessAuthorization,
+    SubmittingGaslessAuthorization,
+    WaitingForGaslessProvider {
+        trace_id: String,
+        provider_state: String,
+    },
+    WaitingForGaslessSettlement {
+        trace_id: String,
+        tx_hash: Option<String>,
+    },
     Finishing,
     /// The following statuses don't require the user to send `UserAction`,
     /// but they tell the user that he should confirm/decline the operation on his device.

--- a/mm2src/coins/rpc_command/init_withdraw.rs
+++ b/mm2src/coins/rpc_command/init_withdraw.rs
@@ -73,8 +73,6 @@ pub enum WithdrawInProgressStatus {
     Preparing,
     GeneratingTransaction,
     SigningTransaction,
-    // TODO(Commit 9 / Commit 10): emit the variants below from the TRON gasless withdraw path.
-    // Defined now for wire compatibility; no execution path produces them yet. Check if one wrapped variant will be better and how to add those in a generic way if possible.
     FetchingGaslessQuote,
     SigningGaslessAuthorization,
     SubmittingGaslessAuthorization,

--- a/mm2src/coins/tx_fee_details.rs
+++ b/mm2src/coins/tx_fee_details.rs
@@ -3,7 +3,7 @@
 //! `TxFeeDetails` serializes with a `"type"` tag for outbound JSON, but deserializes
 //! as untagged to accept responses without the discriminator field.
 
-use crate::eth::tron::fee::TronTxFeeDetails;
+use crate::eth::tron::fee::{TronGaslessFeeDetails, TronTxFeeDetails};
 use crate::eth::EthTxFeeDetails;
 use crate::qrc20::Qrc20FeeDetails;
 use crate::siacoin::SiaFeeDetails;
@@ -18,6 +18,7 @@ pub enum TxFeeDetails {
     Utxo(UtxoFeeDetails),
     Eth(EthTxFeeDetails),
     Tron(TronTxFeeDetails),
+    TronGasless(TronGaslessFeeDetails),
     Qrc20(Qrc20FeeDetails),
     Slp(crate::utxo::slp::SlpFeeDetails),
     Tendermint(TendermintFeeDetails),
@@ -37,6 +38,7 @@ impl<'de> Deserialize<'de> for TxFeeDetails {
             Utxo(UtxoFeeDetails),
             Eth(EthTxFeeDetails),
             Tron(TronTxFeeDetails),
+            TronGasless(TronGaslessFeeDetails),
             Qrc20(Qrc20FeeDetails),
             Slp(crate::utxo::slp::SlpFeeDetails),
             Tendermint(TendermintFeeDetails),
@@ -48,6 +50,7 @@ impl<'de> Deserialize<'de> for TxFeeDetails {
             TxFeeDetailsUnTagged::Utxo(f) => Ok(TxFeeDetails::Utxo(f)),
             TxFeeDetailsUnTagged::Eth(f) => Ok(TxFeeDetails::Eth(f)),
             TxFeeDetailsUnTagged::Tron(f) => Ok(TxFeeDetails::Tron(f)),
+            TxFeeDetailsUnTagged::TronGasless(f) => Ok(TxFeeDetails::TronGasless(f)),
             TxFeeDetailsUnTagged::Qrc20(f) => Ok(TxFeeDetails::Qrc20(f)),
             TxFeeDetailsUnTagged::Slp(f) => Ok(TxFeeDetails::Slp(f)),
             TxFeeDetailsUnTagged::Tendermint(f) => Ok(TxFeeDetails::Tendermint(f)),
@@ -66,6 +69,12 @@ impl From<EthTxFeeDetails> for TxFeeDetails {
 impl From<TronTxFeeDetails> for TxFeeDetails {
     fn from(tron_details: TronTxFeeDetails) -> Self {
         TxFeeDetails::Tron(tron_details)
+    }
+}
+
+impl From<TronGaslessFeeDetails> for TxFeeDetails {
+    fn from(tron_gasless_details: TronGaslessFeeDetails) -> Self {
+        TxFeeDetails::TronGasless(tron_gasless_details)
     }
 }
 

--- a/mm2src/coins/utxo/utxo_tests.rs
+++ b/mm2src/coins/utxo/utxo_tests.rs
@@ -4382,6 +4382,7 @@ fn test_account_balance_rpc() {
                         TEST_COIN_NAME.to_string(),
                         CoinBalance::new(BigDecimal::from($balance)),
                     )]),
+                    gasfree_address: None,
                 },
             )
         };
@@ -4746,6 +4747,7 @@ fn test_scan_for_new_addresses() {
                     balance: $balance.map_or_else(HashMap::default, |balance| {
                         HashMap::from([(TEST_COIN_NAME.to_string(), CoinBalance::new(BigDecimal::from(balance)))])
                     }),
+                    gasfree_address: None,
                 },
             );
         }};

--- a/mm2src/coins_activation/src/bch_with_tokens_activation.rs
+++ b/mm2src/coins_activation/src/bch_with_tokens_activation.rs
@@ -340,6 +340,7 @@ impl PlatformCoinWithTokensActivationOps for BchCoin {
             pubkey: pubkey.clone(),
             balances: None,
             tickers: None,
+            gasfree_address: None,
         };
 
         let mut slp_address_info = CoinAddressInfo {
@@ -347,6 +348,7 @@ impl PlatformCoinWithTokensActivationOps for BchCoin {
             pubkey: pubkey.clone(),
             balances: None,
             tickers: None,
+            gasfree_address: None,
         };
 
         if !activation_request.get_balances {

--- a/mm2src/coins_activation/src/erc20_token_activation.rs
+++ b/mm2src/coins_activation/src/erc20_token_activation.rs
@@ -34,6 +34,10 @@ pub struct Erc20InitResult {
     platform_coin: String,
     token_contract_address: String,
     required_confirmations: u64,
+    /// TRON GasFree receive address derived locally via CREATE2.
+    /// Only populated for TRC20 tokens with a configured GasFree provider.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    gasfree_address: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -197,6 +201,7 @@ impl TokenActivationOps for EthCoin {
                         .await
                         .map_err(|e| EthTokenActivationError::CouldNotFetchBalance(e.to_string()))?;
 
+                    let gasfree_address = token.compute_gasfree_for_display(&address);
                     let balances = HashMap::from([(address, balance)]);
 
                     let init_result = EthTokenInitResult::Erc20(Erc20InitResult {
@@ -204,6 +209,7 @@ impl TokenActivationOps for EthCoin {
                         platform_coin: token.platform_ticker().to_owned(),
                         required_confirmations: token.required_confirmations(),
                         token_contract_address,
+                        gasfree_address,
                     });
 
                     Ok((token, init_result))

--- a/mm2src/coins_activation/src/eth_with_token_activation.rs
+++ b/mm2src/coins_activation/src/eth_with_token_activation.rs
@@ -396,17 +396,20 @@ impl PlatformCoinWithTokensActivationOps for EthCoin {
             DerivationMethod::SingleAddress(my_address) => {
                 let my_address_formatted = my_address.display_address();
                 let pubkey = self.get_public_key().await.map_mm_err()?;
+                let gasfree_address = self.compute_gasfree_for_display(&my_address_formatted);
                 let mut eth_address_info = CoinAddressInfo {
                     derivation_method: self.derivation_method().to_response().await.map_mm_err()?,
                     pubkey: pubkey.clone(),
                     balances: None,
                     tickers: None,
+                    gasfree_address: gasfree_address.clone(),
                 };
                 let mut erc20_address_info = CoinAddressInfo {
                     derivation_method: self.derivation_method().to_response().await.map_mm_err()?,
                     pubkey,
                     balances: None,
                     tickers: None,
+                    gasfree_address,
                 };
                 // Todo: make get_balances work with HDWallet if it's needed
                 if !activation_request.get_balances {
@@ -477,7 +480,7 @@ impl PlatformCoinWithTokensActivationOps for EthCoin {
                     None
                 };
 
-                let wallet_balance = self
+                let mut wallet_balance = self
                     .enable_coin_balance(
                         xpub_extractor,
                         activation_request.platform_request.enable_params.clone(),
@@ -485,6 +488,9 @@ impl PlatformCoinWithTokensActivationOps for EthCoin {
                     )
                     .await
                     .map_mm_err()?;
+
+                // Enrich HD addresses with GasFree address if TRON + provider configured
+                self.enrich_balance_report_with_gasfree(&mut wallet_balance);
 
                 Ok(EthWithTokensActivationResult::HD(HDEthWithTokensActivationResult {
                     current_block,

--- a/mm2src/coins_activation/src/init_erc20_token_activation.rs
+++ b/mm2src/coins_activation/src/init_erc20_token_activation.rs
@@ -189,7 +189,7 @@ impl InitTokenActivationOps for EthCoin {
         task_handle
             .update_in_progress_status(InitTokenInProgressStatus::RequestingWalletBalance)
             .map_mm_err()?;
-        let wallet_balance = self
+        let mut wallet_balance = self
             .enable_coin_balance(
                 xpub_extractor,
                 activation_request.enable_params.clone(),
@@ -197,6 +197,8 @@ impl InitTokenActivationOps for EthCoin {
             )
             .await
             .map_mm_err()?;
+        // Enrich HD addresses with GasFree address if TRON + provider configured
+        self.enrich_balance_report_with_gasfree(&mut wallet_balance);
         task_handle
             .update_in_progress_status(InitTokenInProgressStatus::ActivatingCoin)
             .map_mm_err()?;

--- a/mm2src/coins_activation/src/prelude.rs
+++ b/mm2src/coins_activation/src/prelude.rs
@@ -54,6 +54,8 @@ pub struct CoinAddressInfo<Balance> {
     pub(crate) balances: Option<Balance>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) tickers: Option<HashSet<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) gasfree_address: Option<String>,
 }
 
 pub type TokenBalances = HashMap<String, CoinBalance>;

--- a/mm2src/coins_activation/src/sia_coin_activation.rs
+++ b/mm2src/coins_activation/src/sia_coin_activation.rs
@@ -245,7 +245,11 @@ impl InitStandaloneCoinActivationOps for SiaCoin {
         Ok(SiaCoinActivationResult {
             ticker: self.ticker().into(),
             current_block,
-            wallet_balance: CoinBalanceReport::Iguana(IguanaWalletBalance { address, balance }),
+            wallet_balance: CoinBalanceReport::Iguana(IguanaWalletBalance {
+                address,
+                balance,
+                gasfree_address: None,
+            }),
         })
     }
 

--- a/mm2src/coins_activation/src/z_coin_activation.rs
+++ b/mm2src/coins_activation/src/z_coin_activation.rs
@@ -311,6 +311,7 @@ impl InitStandaloneCoinActivationOps for ZCoin {
             wallet_balance: CoinBalanceReport::Iguana(IguanaWalletBalance {
                 address: self.my_z_address_encoded(),
                 balance,
+                gasfree_address: None,
             }),
             first_sync_block,
         })

--- a/mm2src/common/Cargo.toml
+++ b/mm2src/common/Cargo.toml
@@ -63,7 +63,7 @@ web-sys = { workspace = true, features = ["console", "CloseEvent", "DomException
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow.workspace = true
-chrono.workspace = true 
+chrono = { workspace = true, features = ["alloc", "clock"] }
 hyper = { workspace = true, features = ["client", "http2", "server", "tcp"] }
 # using webpki-tokio to avoid rejecting valid certificates
 # got "invalid certificate: UnknownIssuer" for https://ropsten.infura.io on iOS using default-features

--- a/mm2src/common/common.rs
+++ b/mm2src/common/common.rs
@@ -157,7 +157,7 @@ pub use wasm::*;
 
 use backtrace::SymbolName;
 use chrono::format::ParseError;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, SecondsFormat, TimeZone, Utc};
 use derive_more::Display;
 pub use futures::compat::Future01CompatExt;
 use futures01::{future, Future};
@@ -1204,6 +1204,14 @@ pub fn get_utc_timestamp() -> i64 {
 
     #[cfg(not(feature = "for-tests"))]
     return Utc::now().timestamp();
+}
+
+#[inline(always)]
+pub fn utc_now_rfc3339_secs() -> String {
+    Utc.timestamp_opt(get_utc_timestamp(), 0)
+        .single()
+        .unwrap_or_else(Utc::now)
+        .to_rfc3339_opts(SecondsFormat::Secs, true)
 }
 
 #[inline(always)]

--- a/mm2src/mm2_eth/src/eip712.rs
+++ b/mm2src/mm2_eth/src/eip712.rs
@@ -5,9 +5,9 @@ use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
-pub(crate) const EIP712_DOMAIN: &str = "EIP712Domain";
+pub const EIP712_DOMAIN: &str = "EIP712Domain";
 
-pub(crate) type CustomTypes = HashMap<String, Vec<ObjectProperty>>;
+pub type CustomTypes = HashMap<String, Vec<ObjectProperty>>;
 
 /// `ObjectType` is used to describes an object type accordingly to:
 /// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-typed-structured-data-%F0%9D%95%8A
@@ -85,6 +85,7 @@ pub enum PropertyType {
     String,
     Uint256,
     Address,
+    Bytes,
     Bytes32,
     Custom(String),
 }
@@ -96,6 +97,7 @@ impl fmt::Display for PropertyType {
             PropertyType::String => write!(f, "string"),
             PropertyType::Uint256 => write!(f, "uint256"),
             PropertyType::Address => write!(f, "address"),
+            PropertyType::Bytes => write!(f, "bytes"),
             PropertyType::Bytes32 => write!(f, "bytes32"),
             PropertyType::Custom(custom) => write!(f, "{custom}"),
         }
@@ -111,6 +113,7 @@ impl FromStr for PropertyType {
             "string" => PropertyType::String,
             "uint256" => PropertyType::Uint256,
             "address" => PropertyType::Address,
+            "bytes" => PropertyType::Bytes,
             "bytes32" => PropertyType::Bytes32,
             custom => PropertyType::Custom(custom.to_string()),
         };

--- a/mm2src/mm2_eth/src/eip712_encode.rs
+++ b/mm2src/mm2_eth/src/eip712_encode.rs
@@ -82,6 +82,7 @@ fn encode_data(
         PropertyType::String => encode_string(data, field_name),
         PropertyType::Uint256 => encode_u256(data, field_name),
         PropertyType::Address => encode_address(data, field_name),
+        PropertyType::Bytes => encode_bytes(data, field_name),
         PropertyType::Bytes32 => encode_bytes32(data, field_name),
         PropertyType::Custom(custom) => encode_custom(custom_types, &custom, data, field_name),
     }
@@ -110,16 +111,18 @@ fn encode_custom(
     Ok(keccak256(&encoded_tokens).as_ref().to_vec())
 }
 
-fn encode_bytes32(value: &Json, field_name: Option<&str>) -> Result<Vec<u8>> {
-    let string = value
-        .as_str()
-        .ok_or_else(|| expected_type_error("bytes32", value, field_name))?;
-    check_hex(string, field_name)?;
-
-    let bytes = hex::decode(string).map_err(|e| decode_error(e, field_name))?;
+/// Encode dynamic `bytes` — keccak256 hash of the raw bytes (same treatment as `string`).
+fn encode_bytes(value: &Json, field_name: Option<&str>) -> Result<Vec<u8>> {
+    let bytes = decode_hex_bytes(value, field_name)?;
     let hash = keccak256(&bytes).to_vec();
-
     Ok(encode(&[Token::FixedBytes(hash)]))
+}
+
+/// Encode fixed-size `bytes32` — the raw 32-byte value is encoded directly, NOT hashed.
+/// Per EIP-712: fixed-size bytesN values are zero-padded to 32 bytes and encoded as-is.
+fn encode_bytes32(value: &Json, field_name: Option<&str>) -> Result<Vec<u8>> {
+    let bytes = decode_hex_bytes_exact::<32>(value, "bytes32", field_name)?;
+    Ok(encode(&[Token::FixedBytes(bytes.to_vec())]))
 }
 
 fn encode_string(value: &Json, field_name: Option<&str>) -> Result<Vec<u8>> {
@@ -139,24 +142,22 @@ fn encode_bool(value: &Json, field_name: Option<&str>) -> Result<Vec<u8>> {
 }
 
 fn encode_address(value: &Json, field_name: Option<&str>) -> Result<Vec<u8>> {
-    let string = value
-        .as_str()
-        .ok_or_else(|| expected_type_error("address", value, field_name))?;
-    // "0x" - 2 chars, 40 chars are 20 hexed bytes.
-    if string.len() != 42 {
-        return Err(decode_error("Expected 0x-prefixed address (20 bytes)", field_name));
-    }
-    let address = Address::from_str(&string[2..]).map_err(|e| decode_error(e, field_name))?;
-    Ok(encode(&[Token::Address(address)]))
+    let bytes = decode_hex_bytes_exact::<20>(value, "address", field_name)?;
+    Ok(encode(&[Token::Address(Address::from(bytes))]))
 }
 
 fn encode_u256(value: &Json, field_name: Option<&str>) -> Result<Vec<u8>> {
     let string = value
         .as_str()
-        .ok_or_else(|| expected_type_error("str(u256)", value, field_name))?;
-    check_hex(string, field_name)?;
-
-    let uint = U256::from_str(&string[2..]).map_err(|e| decode_error(e, field_name))?;
+        .ok_or_else(|| expected_type_error("uint256", value, field_name))?;
+    let hex_str = string
+        .strip_prefix("0x")
+        .or_else(|| string.strip_prefix("0X"))
+        .ok_or_else(|| decode_error("Expected 0x-prefixed hex string", field_name))?;
+    if hex_str.len() > 64 {
+        return Err(decode_error("uint256 value exceeds 32 bytes", field_name));
+    }
+    let uint = U256::from_str(hex_str).map_err(|e| decode_error(e, field_name))?;
     Ok(encode(&[Token::Uint(uint)]))
 }
 
@@ -224,24 +225,43 @@ fn build_dependencies<'a>(data_type: &'a str, custom_types: &'a CustomTypes) -> 
     Some(deps)
 }
 
-fn check_hex(string: &str, field_name: Option<&str>) -> Result<()> {
-    if string.len() >= 2 && &string[..2] == "0x" {
-        return Ok(());
+/// Decode a `0x`-prefixed hex string from a JSON value into raw bytes.
+/// Accepts any even-length hex payload (including empty `"0x"`).
+fn decode_hex_bytes(value: &Json, field_name: Option<&str>) -> Result<Vec<u8>> {
+    let string = value
+        .as_str()
+        .ok_or_else(|| expected_type_error("hex bytes", value, field_name))?;
+    let hex_payload = string
+        .strip_prefix("0x")
+        .or_else(|| string.strip_prefix("0X"))
+        .ok_or_else(|| decode_error("Expected 0x-prefixed hex string", field_name))?;
+    if hex_payload.len() % 2 != 0 {
+        return Err(decode_error(
+            format!(
+                "Hex payload must have even length, found {} characters",
+                hex_payload.len()
+            ),
+            field_name,
+        ));
     }
+    hex::decode(hex_payload).map_err(|e| decode_error(e, field_name))
+}
 
-    Err(decode_error(
-        format!(
-            "Expected a 0x-prefixed string of even length, found {} length string",
-            string.len()
-        ),
-        field_name,
-    ))
+/// Decode a `0x`-prefixed hex string and enforce exactly `N` decoded bytes.
+fn decode_hex_bytes_exact<const N: usize>(value: &Json, type_name: &str, field_name: Option<&str>) -> Result<[u8; N]> {
+    let bytes = decode_hex_bytes(value, field_name)?;
+    bytes
+        .try_into()
+        .map_err(|_| decode_error(format!("{} must be exactly {} bytes", type_name, N), field_name))
 }
 
 fn expected_type_error(expected: &str, found: &Json, field_name: Option<&str>) -> Error {
     decode_error(format!("Expected '{expected}' type, found '{found}'"), field_name)
 }
 
+// TODO: Input validation errors currently reuse `web3::Error::Decoder`, which is
+// intended for RPC response parsing failures. Introduce a dedicated `Eip712EncodeError`
+// so callers can distinguish typed-data input errors from transport/deserialization errors.
 fn decode_error<E: fmt::Display>(error: E, field_name: Option<&str>) -> Error {
     let error = match field_name {
         Some(field_name) => format!("EIP712 '{field_name}' deserialization error: {error}"),
@@ -389,6 +409,141 @@ mod tests {
         assert_eq!(
             format!("{hash:02x}"),
             "be609aee343fb3c4b28e1df9e632fca64fcfaede20f02e86244efddf30957bd2",
+        );
+    }
+
+    #[test]
+    fn test_encode_bytes32_direct_no_hash() {
+        // Per EIP-712: bytes32 is encoded directly as its raw 32-byte value, NOT keccak256-hashed.
+        let value = Json::String("0x0000000000000000000000000000000000000000000000000000000000000001".to_string());
+        let encoded = encode_bytes32(&value, Some("testField")).unwrap();
+        // The ABI encoding of a 32-byte value that is 0x...01 should be the value itself,
+        // left-padded to 32 bytes (which it already is).
+        let expected = encode(&[Token::FixedBytes(
+            hex::decode("0000000000000000000000000000000000000000000000000000000000000001").unwrap(),
+        )]);
+        assert_eq!(encoded, expected);
+
+        // Verify this is NOT the old buggy behavior (keccak256 of the bytes).
+        let old_buggy = encode(&[Token::FixedBytes(
+            keccak256(&hex::decode("0000000000000000000000000000000000000000000000000000000000000001").unwrap())
+                .to_vec(),
+        )]);
+        assert_ne!(encoded, old_buggy, "bytes32 must NOT be keccak256-hashed");
+    }
+
+    #[test]
+    fn test_encode_bytes32_rejects_wrong_length() {
+        // Too short (16 bytes).
+        let short = Json::String("0x00000000000000000000000000000001".to_string());
+        assert!(encode_bytes32(&short, Some("salt")).is_err());
+
+        // Too long (33 bytes).
+        let long = Json::String(format!("0x{}", "ab".repeat(33)));
+        assert!(encode_bytes32(&long, Some("salt")).is_err());
+    }
+
+    #[test]
+    fn test_encode_bytes_dynamic_hashed() {
+        // Per EIP-712: dynamic `bytes` is encoded as keccak256 of its contents.
+        let value = Json::String("0x1234".to_string());
+        let encoded = encode_bytes(&value, Some("data")).unwrap();
+        let expected = encode(&[Token::FixedBytes(keccak256(&[0x12, 0x34]).to_vec())]);
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn test_encode_bytes_empty() {
+        // Empty bytes "0x" is valid — keccak256 of empty input.
+        let value = Json::String("0x".to_string());
+        let encoded = encode_bytes(&value, Some("data")).unwrap();
+        let expected = encode(&[Token::FixedBytes(keccak256(&[]).to_vec())]);
+        assert_eq!(encoded, expected);
+    }
+
+    #[test]
+    fn test_decode_hex_bytes_validation() {
+        // Missing 0x prefix.
+        let no_prefix = Json::String("1234".to_string());
+        assert!(decode_hex_bytes(&no_prefix, Some("f")).is_err());
+
+        // Odd-length hex.
+        let odd = Json::String("0x123".to_string());
+        assert!(decode_hex_bytes(&odd, Some("f")).is_err());
+
+        // Invalid hex characters.
+        let bad_chars = Json::String("0xZZZZ".to_string());
+        assert!(decode_hex_bytes(&bad_chars, Some("f")).is_err());
+
+        // Valid input.
+        let valid = Json::String("0xabcd".to_string());
+        assert_eq!(decode_hex_bytes(&valid, Some("f")).unwrap(), vec![0xab, 0xcd]);
+    }
+
+    #[test]
+    fn test_encode_u256_hex_parsing() {
+        // uint256 accepts odd-length hex like "0x1" (used by Ether Mail chainId).
+        let one = Json::String("0x1".to_string());
+        assert_eq!(encode_u256(&one, None).unwrap(), encode(&[Token::Uint(U256::from(1))]));
+
+        // Verify hex parsing — "0x10" must parse as 16, not 10.
+        let sixteen = Json::String("0x10".to_string());
+        assert_eq!(
+            encode_u256(&sixteen, None).unwrap(),
+            encode(&[Token::Uint(U256::from(16))])
+        );
+
+        // Alpha hex digits work.
+        let aa = Json::String("0xaa".to_string());
+        assert_eq!(
+            encode_u256(&aa, None).unwrap(),
+            encode(&[Token::Uint(U256::from(0xaa))])
+        );
+    }
+
+    #[test]
+    fn test_property_type_bytes_roundtrip() {
+        use crate::eip712::PropertyType;
+        assert_eq!(PropertyType::Bytes.to_string(), "bytes");
+        assert!(matches!(PropertyType::from_str("bytes").unwrap(), PropertyType::Bytes));
+    }
+
+    /// End-to-end hash_typed_data_raw test with bytes and bytes32 fields.
+    /// Validates the full dispatch + struct-hash composition path.
+    #[test]
+    fn test_hash_typed_data_with_bytes_and_bytes32() {
+        const JSON: &str = r#"{
+            "primaryType": "Transfer",
+            "domain": {
+                "name": "TestDomain",
+                "version": "1",
+                "chainId": "0x1",
+                "verifyingContract": "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC"
+            },
+            "message": {
+                "salt": "0x0000000000000000000000000000000000000000000000000000000000000001",
+                "data": "0xdeadbeef"
+            },
+            "types": {
+                "EIP712Domain": [
+                    { "name": "name", "type": "string" },
+                    { "name": "version", "type": "string" },
+                    { "name": "chainId", "type": "uint256" },
+                    { "name": "verifyingContract", "type": "address" }
+                ],
+                "Transfer": [
+                    { "name": "salt", "type": "bytes32" },
+                    { "name": "data", "type": "bytes" }
+                ]
+            }
+        }"#;
+
+        let typed_data = serde_json::from_str::<Eip712Raw>(JSON).unwrap();
+        let hash = hash_typed_data_raw(typed_data).unwrap();
+        // Expected value independently computed via Python + pycryptodome keccak256.
+        assert_eq!(
+            format!("{hash:02x}"),
+            "0f421a4ad456c22cd0dd059375a17daa4d2f6e12ae0fae0b441313cf58207ae9",
         );
     }
 }

--- a/mm2src/mm2_main/src/rpc/lp_commands/legacy.rs
+++ b/mm2src/mm2_main/src/rpc/lp_commands/legacy.rs
@@ -222,12 +222,20 @@ pub async fn my_balance(ctx: MmArc, req: Json) -> Result<Response<Vec<u8>>, Stri
         Err(err) => return ERR!("!lp_coinfind({}): {}", ticker, err),
     };
     let my_balance = try_s!(coin.my_balance().compat().await);
+    let address = try_s!(coin.my_address());
+
+    // Only ETH/TRON coins can have a GasFree address; returns None for everything else.
+    let gasfree_address = match &coin {
+        MmCoinEnum::EthCoinVariant(eth) => eth.compute_gasfree_for_display(&address),
+        _ => None,
+    };
 
     let res = try_s!(json::to_vec(&BalanceResponse {
         coin: ticker,
         balance: my_balance.spendable,
         unspendable_balance: my_balance.unspendable,
-        address: try_s!(coin.my_address())
+        address,
+        gasfree_address,
     }));
     Ok(try_s!(Response::builder().body(res)))
 }

--- a/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
+++ b/mm2src/mm2_main/tests/docker_tests/eth_docker_tests.rs
@@ -271,6 +271,7 @@ fn global_nft_with_random_privkey(
         path_to_address: Default::default(),
         gap_limit: None,
         swap_gas_fee_policy: None,
+        tron_gasless_provider: None,
     };
     let coin = block_on(eth_coin_from_conf_and_request_v2(
         &MM_CTX1,
@@ -1263,6 +1264,7 @@ fn eth_coin_v2_activation_with_random_privkey(
         path_to_address: Default::default(),
         gap_limit: None,
         swap_gas_fee_policy: None,
+        tron_gasless_provider: None,
     };
     let coin = block_on(eth_coin_from_conf_and_request_v2(
         ctx,

--- a/mm2src/mm2_metamask/src/lib.rs
+++ b/mm2src/mm2_metamask/src/lib.rs
@@ -12,6 +12,6 @@ pub use metamask::{detect_metamask_provider, MetamaskSession};
 #[cfg(target_arch = "wasm32")]
 pub use metamask_error::{from_metamask_error, MetamaskError, MetamaskResult, MetamaskRpcError, WithMetamaskRpcError};
 #[cfg(target_arch = "wasm32")]
-pub use mm2_eth::eip712::{Eip712, ObjectType, PropertyType};
+pub use mm2_eth::eip712::{CustomTypes, Eip712, ObjectType, PropertyType, EIP712_DOMAIN};
 #[cfg(target_arch = "wasm32")]
 pub use mm2_eth::eip712_encode::hash_typed_data;

--- a/mm2src/mm2_net/src/native_http.rs
+++ b/mm2src/mm2_net/src/native_http.rs
@@ -130,17 +130,15 @@ pub trait SlurpHttpClient {
 
     /// Executes a GET request with additional headers.
     /// Returning the response status, headers and body.
-    async fn slurp_url_with_headers(&self, url: &str, headers: Vec<(&'static str, &'static str)>) -> SlurpResult {
-        let mut req = Request::builder();
-        let h = req
-            .headers_mut()
-            .or_mm_err(|| SlurpError::Internal("An error occurred when accessing the request headers".to_string()))?;
+    async fn slurp_url_with_headers(&self, url: &str, headers: Vec<(&str, &str)>) -> SlurpResult {
+        let req = build_request_with_headers("GET", url, headers, None)?;
+        self.slurp_req(req).await
+    }
 
-        for (key, value) in headers {
-            h.insert(key, HeaderValue::from_static(value));
-        }
-
-        let req = req.uri(url).body(Vec::new())?;
+    /// Executes a POST request with a JSON body and additional headers.
+    /// `Content-Type: application/json` is enforced after custom headers so callers cannot override it.
+    async fn slurp_post_json_with_headers(&self, url: &str, body: String, headers: Vec<(&str, &str)>) -> SlurpResult {
+        let req = build_post_json_request_with_headers(url, body, headers)?;
         self.slurp_req(req).await
     }
 
@@ -207,13 +205,58 @@ pub async fn slurp_url(url: &str) -> SlurpResult {
 
 /// Executes a GET request with additional headers.
 /// Returning the response status, headers and body.
-pub async fn slurp_url_with_headers(url: &str, headers: Vec<(&'static str, &'static str)>) -> SlurpResult {
+pub async fn slurp_url_with_headers(url: &str, headers: Vec<(&str, &str)>) -> SlurpResult {
     HYPER.slurp_url_with_headers(url, headers).await
 }
 
 /// Executes a POST request, returning the response status, headers and body.
 pub async fn slurp_post_json(url: &str, body: String) -> SlurpResult {
     HYPER.slurp_post_json(url, body).await
+}
+
+/// Executes a POST request with a JSON body and additional headers.
+/// `Content-Type: application/json` is enforced after custom headers.
+pub async fn slurp_post_json_with_headers(url: &str, body: String, headers: Vec<(&str, &str)>) -> SlurpResult {
+    HYPER.slurp_post_json_with_headers(url, body, headers).await
+}
+
+/// Builds an HTTP request with the given method, URL, custom headers, and optional body.
+fn build_request_with_headers(
+    method: &str,
+    url: &str,
+    headers: Vec<(&str, &str)>,
+    body: Option<String>,
+) -> Result<Request<Vec<u8>>, MmError<SlurpError>> {
+    let mut builder = Request::builder().method(method);
+    let header_map = builder
+        .headers_mut()
+        .or_mm_err(|| SlurpError::Internal("Failed to access request headers".to_string()))?;
+
+    for (key, value) in headers {
+        let name = header::HeaderName::from_bytes(key.as_bytes())
+            .map_err(|e| SlurpError::InvalidRequest(format!("Invalid header name '{key}': {e}")))?;
+        let val = HeaderValue::from_str(value)
+            .map_err(|e| SlurpError::InvalidRequest(format!("Invalid header value for '{key}': {e}")))?;
+        header_map.insert(name, val);
+    }
+
+    let request_body = body.map(String::into_bytes).unwrap_or_default();
+    // URI is set last so invalid-URL errors surface as http::Error -> SlurpError::InvalidRequest,
+    // not as the misleading "Failed to access request headers" from a poisoned builder.
+    Ok(builder.uri(url).body(request_body)?)
+}
+
+/// Builds a POST JSON request with custom headers.
+/// `Content-Type: application/json` is enforced after custom headers so callers cannot override it.
+fn build_post_json_request_with_headers(
+    url: &str,
+    body: String,
+    headers: Vec<(&str, &str)>,
+) -> Result<Request<Vec<u8>>, MmError<SlurpError>> {
+    let mut req = build_request_with_headers("POST", url, headers, Some(body))?;
+    req.headers_mut()
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static(APPLICATION_JSON));
+    Ok(req)
 }
 
 impl From<Canceled> for SlurpError {
@@ -270,6 +313,7 @@ pub async fn send_request_to_uri(uri: &str, auth_header: Option<&str>) -> MmResu
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::native_http::slurp_url;
     use common::block_on;
 
@@ -277,5 +321,54 @@ mod tests {
     fn test_slurp_req() {
         let (status, headers, body) = block_on(slurp_url("https://postman-echo.com/get")).unwrap();
         assert!(status.is_success(), "{status:?} {headers:?} {body:?}");
+    }
+
+    #[test]
+    fn test_build_request_with_custom_headers_and_body() {
+        let headers = vec![("X-Api-Key", "test-key"), ("X-Signature", "abc123")];
+        let body = r#"{"amount":"100"}"#.to_string();
+        let req = build_request_with_headers("POST", "https://example.com/api", headers, Some(body.clone())).unwrap();
+
+        assert_eq!(req.method(), "POST");
+        assert_eq!(req.uri(), "https://example.com/api");
+        assert_eq!(req.headers().get("x-api-key").unwrap(), "test-key");
+        assert_eq!(req.headers().get("x-signature").unwrap(), "abc123");
+        // Generic builder does NOT set Content-Type — that's the caller's responsibility.
+        assert!(req.headers().get("content-type").is_none());
+        assert_eq!(req.body(), &body.into_bytes());
+    }
+
+    #[test]
+    fn test_build_request_get_with_headers() {
+        let headers = vec![("Authorization", "Bearer token123")];
+        let req = build_request_with_headers("GET", "https://example.com/data", headers, None).unwrap();
+
+        assert_eq!(req.method(), "GET");
+        assert_eq!(req.headers().get("authorization").unwrap(), "Bearer token123");
+        assert!(req.headers().get("content-type").is_none());
+        assert!(req.body().is_empty());
+    }
+
+    #[test]
+    fn test_build_post_json_enforces_content_type() {
+        let headers = vec![("Content-Type", "text/plain"), ("X-Api-Key", "key")];
+        let req = build_post_json_request_with_headers("https://example.com", "{}".to_string(), headers).unwrap();
+
+        assert_eq!(req.method(), "POST");
+        assert_eq!(req.headers().get("content-type").unwrap(), APPLICATION_JSON);
+        assert_eq!(req.headers().get("x-api-key").unwrap(), "key");
+        assert_eq!(req.body(), &b"{}"[..]);
+    }
+
+    #[test]
+    fn test_build_request_invalid_url() {
+        let result = build_request_with_headers("GET", "not a valid url\n", vec![], None);
+        match result {
+            Err(e) => assert!(
+                e.to_string().contains("Invalid"),
+                "Expected SlurpError::InvalidRequest, got: {e}"
+            ),
+            Ok(_) => panic!("Expected error for invalid URL"),
+        }
     }
 }

--- a/mm2src/mm2_net/src/transport.rs
+++ b/mm2src/mm2_net/src/transport.rs
@@ -6,10 +6,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Error, Value as Json};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use crate::native_http::{slurp_post_json, slurp_req, slurp_req_body, slurp_url, slurp_url_with_headers};
+pub use crate::native_http::{
+    slurp_post_json, slurp_post_json_with_headers, slurp_req, slurp_req_body, slurp_url, slurp_url_with_headers,
+};
 
 #[cfg(target_arch = "wasm32")]
-pub use crate::wasm::http::{slurp_post_json, slurp_url, slurp_url_with_headers};
+pub use crate::wasm::http::{slurp_post_json, slurp_post_json_with_headers, slurp_url, slurp_url_with_headers};
 
 pub type SlurpResult = Result<(StatusCode, HeaderMap, Vec<u8>), MmError<SlurpError>>;
 

--- a/mm2src/mm2_net/src/wasm/http.rs
+++ b/mm2src/mm2_net/src/wasm/http.rs
@@ -1,12 +1,11 @@
 use crate::transport::{GetInfoFromUriError, SlurpError, SlurpResult};
 use crate::wasm::body_stream::ResponseBody;
 use common::executor::spawn_local;
-use common::{drop_mutability, stringify_js_error, APPLICATION_JSON, X_AUTH_PAYLOAD};
+use common::{stringify_js_error, APPLICATION_JSON, X_AUTH_PAYLOAD};
 use futures::channel::oneshot;
 use gstuff::ERRL;
 use http::header::{ACCEPT, CONTENT_TYPE};
-use http::response::Builder;
-use http::{HeaderMap, Response, StatusCode};
+use http::{HeaderMap, HeaderName, HeaderValue, Response, StatusCode};
 use js_sys::Array;
 use js_sys::Uint8Array;
 use mm2_err_handle::prelude::*;
@@ -21,68 +20,72 @@ use web_sys::{Request as JsRequest, RequestInit, RequestMode, Response as JsResp
 pub type FetchResult<T> = Result<(StatusCode, T), MmError<SlurpError>>;
 
 /// Executes a GET request, returning the response status, headers and body.
-/// Please note the return header map is empty, because `wasm_bindgen` doesn't provide the way to extract all headers.
 pub async fn slurp_url(url: &str) -> SlurpResult {
-    FetchRequest::get(url)
-        .request_str()
-        .await
-        .map(|(status_code, response)| (status_code, HeaderMap::new(), response.into_bytes()))
+    FetchRequest::get(url).slurp().await
 }
 
 /// Executes a GET request with additional headers.
 /// Returning the response status, headers and body.
-/// Please note the return header map is empty, because `wasm_bindgen` doesn't provide the way to extract all headers.
 pub async fn slurp_url_with_headers(url: &str, headers: Vec<(&str, &str)>) -> SlurpResult {
-    FetchRequest::get(url)
-        .headers(headers)
-        .request_str()
-        .await
-        .map(|(status_code, response)| (status_code, HeaderMap::new(), response.into_bytes()))
+    FetchRequest::get(url).headers(headers).slurp().await
 }
 
 /// Executes a POST request, returning the response status, headers and body.
-/// Please note the return header map is empty, because `wasm_bindgen` doesn't provide the way to extract all headers.
 pub async fn slurp_post_json(url: &str, body: String) -> SlurpResult {
     FetchRequest::post(url)
         .header(CONTENT_TYPE.as_str(), APPLICATION_JSON)
         .body_utf8(body)
-        .request_str()
+        .slurp()
         .await
-        .map(|(status_code, response)| (status_code, HeaderMap::new(), response.into_bytes()))
 }
 
-/// Sets the response headers and extracts the content type.
+/// Executes a POST request with a JSON body and additional headers.
+/// `Content-Type: application/json` is enforced after custom headers so callers cannot override it.
+pub async fn slurp_post_json_with_headers(url: &str, body: String, headers: Vec<(&str, &str)>) -> SlurpResult {
+    build_post_json_fetch_request(url, body, headers).slurp().await
+}
+
+/// Builds a `FetchRequest` for POST JSON with custom headers.
+/// `Content-Type: application/json` is inserted last so callers cannot override it.
+/// Header names are already normalized to lowercase by `FetchRequest::header`/`headers`,
+/// so a plain insert overwrites any caller-provided content-type.
+fn build_post_json_fetch_request(url: &str, body: String, headers: Vec<(&str, &str)>) -> FetchRequest {
+    FetchRequest::post(url)
+        .headers(headers)
+        .header(CONTENT_TYPE.as_str(), APPLICATION_JSON)
+        .body_utf8(body)
+}
+
+/// Extracts response headers from a `JsResponse` into an `http::HeaderMap`.
 ///
-/// This function takes a `Builder` for a response and a `JsResponse` from which it extracts
-/// the headers and the content type.
-fn set_response_headers_and_content_type(
-    mut result: Builder,
-    response: &JsResponse,
-) -> Result<(Builder, String), MmError<SlurpError>> {
-    let headers = match js_sys::try_iter(response.headers().as_ref()) {
-        Ok(Some(headers)) => headers,
-        Ok(None) => return MmError::err(SlurpError::InvalidRequest("MissingHeaders".to_string())),
-        Err(err) => return MmError::err(SlurpError::InvalidRequest(format!("{err:?}"))),
+/// Uses `js_sys::try_iter` on the JS `Headers` object, which works via the
+/// Symbol.iterator protocol even on `web-sys 0.3.55` (before explicit
+/// `entries()`/`keys()`/`values()` methods were added in 0.3.94).
+///
+/// Note: in browsers, CORS may limit which headers are visible. The returned
+/// `HeaderMap` contains whatever the browser exposes, which is still better
+/// than always returning an empty map.
+fn extract_response_headers(response: &JsResponse) -> HeaderMap {
+    let iter = match js_sys::try_iter(response.headers().as_ref()) {
+        Ok(Some(iter)) => iter,
+        _ => return HeaderMap::new(),
     };
 
-    let mut content_type = None;
-    for header in headers {
-        let pair: Array = header
-            .map_to_mm(|err| SlurpError::InvalidRequest(format!("{err:?}")))?
-            .into();
-        if let (Some(header_name), Some(header_value)) = (pair.get(0).as_string(), pair.get(1).as_string()) {
-            if header_name == CONTENT_TYPE.as_str() {
-                content_type = Some(header_value.clone());
+    let mut header_map = HeaderMap::new();
+    for item in iter {
+        let pair: Array = match item {
+            Ok(val) => val.into(),
+            Err(_) => continue,
+        };
+        if let (Some(name), Some(value)) = (pair.get(0).as_string(), pair.get(1).as_string()) {
+            if let (Ok(header_name), Ok(header_value)) =
+                (HeaderName::from_bytes(name.as_bytes()), HeaderValue::from_str(&value))
+            {
+                header_map.append(header_name, header_value);
             }
-            result = result.header(header_name, header_value);
         }
     }
-    drop_mutability!(content_type);
-
-    match content_type {
-        Some(content_type) => Ok((result, content_type)),
-        None => MmError::err(SlurpError::InvalidRequest("MissingContentType".to_string())),
-    }
+    header_map
 }
 
 /// This function is a wrapper around the `fetch_with_request`, providing compatibility across
@@ -147,14 +150,18 @@ impl FetchRequest {
         self
     }
 
+    /// Insert a header. Names are normalized to ASCII lowercase to match
+    /// native `http::HeaderMap` case-insensitive semantics.
     pub fn header(mut self, key: &str, val: &str) -> FetchRequest {
-        self.headers.insert(key.to_owned(), val.to_owned());
+        self.headers.insert(key.to_ascii_lowercase(), val.to_owned());
         self
     }
 
+    /// Insert multiple headers. Names are normalized to ASCII lowercase to match
+    /// native `http::HeaderMap` case-insensitive semantics.
     pub fn headers(mut self, headers: Vec<(&str, &str)>) -> FetchRequest {
         for (key, value) in headers {
-            self.headers.insert(key.to_owned(), value.to_owned());
+            self.headers.insert(key.to_ascii_lowercase(), value.to_owned());
         }
         self
     }
@@ -182,6 +189,25 @@ impl FetchRequest {
         Self::spawn_fetch_stream_response(self, tx);
         rx.await
             .map_to_mm(|_| SlurpError::Internal("Spawned future has been canceled".to_owned()))?
+    }
+
+    /// Fetch and return the full response as raw bytes with actual response headers.
+    /// Used by the cross-platform `slurp_*` helpers to match native `SlurpResult` semantics.
+    async fn slurp(self) -> SlurpResult {
+        let (tx, rx) = oneshot::channel();
+        Self::spawn_slurp(self, tx);
+        match rx.await {
+            Ok(res) => res,
+            Err(_) => MmError::err(SlurpError::Internal("Spawned future has been canceled".to_owned())),
+        }
+    }
+
+    fn spawn_slurp(request: Self, tx: oneshot::Sender<SlurpResult>) {
+        let fut = async move {
+            let result = Self::fetch_slurp(request).await;
+            tx.send(result).ok();
+        };
+        spawn_local(fut);
     }
 
     fn spawn_fetch_str(request: Self, tx: oneshot::Sender<FetchResult<String>>) {
@@ -232,12 +258,12 @@ impl FetchRequest {
         }
 
         let js_request = JsRequest::new_with_str_and_init(&uri, &req_init)
-            .map_to_mm(|e| SlurpError::Internal(stringify_js_error(&e)))?;
+            .map_to_mm(|e| SlurpError::InvalidRequest(stringify_js_error(&e)))?;
         for (hkey, hval) in request.headers {
             js_request
                 .headers()
                 .set(&hkey, &hval)
-                .map_to_mm(|e| SlurpError::Internal(stringify_js_error(&e)))?;
+                .map_to_mm(|e| SlurpError::InvalidRequest(stringify_js_error(&e)))?;
         }
 
         let request_promise = compatible_fetch_with_request(&js_request)?;
@@ -265,6 +291,31 @@ impl FetchRequest {
         };
 
         Ok((status_code, js_response))
+    }
+
+    /// Fetch and return raw bytes with actual response headers.
+    async fn fetch_slurp(request: Self) -> SlurpResult {
+        let uri = request.uri.clone();
+        let (status_code, js_response) = Self::fetch(request).await?;
+
+        let response_headers = extract_response_headers(&js_response);
+
+        let resp_array_fut = match js_response.array_buffer() {
+            Ok(buf) => buf,
+            Err(e) => {
+                let error = format!("Expected array buffer: {}", stringify_js_error(&e));
+                return MmError::err(SlurpError::ErrorDeserializing { uri, error });
+            },
+        };
+        let resp_array = JsFuture::from(resp_array_fut)
+            .await
+            .map_to_mm(|e| SlurpError::ErrorDeserializing {
+                uri,
+                error: stringify_js_error(&e),
+            })?;
+
+        let bytes = Uint8Array::new(&resp_array).to_vec();
+        Ok((status_code, response_headers, bytes))
     }
 
     /// The private non-Send method that is called in a spawned future.
@@ -336,8 +387,18 @@ impl FetchRequest {
             },
         };
 
-        let builder = Response::builder().status(status_code);
-        let (builder, content_type) = set_response_headers_and_content_type(builder, &js_response)?;
+        let response_headers = extract_response_headers(&js_response);
+        let content_type = response_headers
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| MmError::new(SlurpError::InvalidRequest("MissingContentType".to_string())))?
+            .to_owned();
+
+        let mut builder = Response::builder().status(status_code);
+        for (name, value) in response_headers.iter() {
+            builder = builder.header(name, value);
+        }
+
         let body = ResponseBody::new(resp_stream, &content_type)
             .await
             .map_to_mm(|err| SlurpError::InvalidRequest(format!("{err:?}")))?;
@@ -421,6 +482,56 @@ mod tests {
     use wasm_bindgen_test::*;
 
     wasm_bindgen_test_configure!(run_in_browser);
+
+    #[test]
+    fn test_header_names_normalized_to_lowercase() {
+        let req = FetchRequest::get("https://example.com")
+            .header("X-Api-Key", "key1")
+            .header("x-api-key", "key2");
+
+        // Second insert overwrites first because both normalize to "x-api-key".
+        assert_eq!(req.headers.len(), 1);
+        assert_eq!(req.headers.get("x-api-key").unwrap(), "key2");
+    }
+
+    #[test]
+    fn test_headers_batch_normalized_to_lowercase() {
+        let req = FetchRequest::get("https://example.com")
+            .headers(vec![("Content-Type", "text/plain"), ("ACCEPT", "application/json")]);
+
+        assert_eq!(req.headers.get("content-type").unwrap(), "text/plain");
+        assert_eq!(req.headers.get("accept").unwrap(), "application/json");
+        // Original casing keys should not exist.
+        assert!(req.headers.get("Content-Type").is_none());
+        assert!(req.headers.get("ACCEPT").is_none());
+    }
+
+    #[test]
+    fn test_build_post_json_fetch_request_with_headers() {
+        let headers = vec![("X-Api-Key", "test-key"), ("X-Signature", "abc123")];
+        let body = r#"{"amount":"100"}"#.to_string();
+        let req = build_post_json_fetch_request("https://example.com/api", body.clone(), headers);
+
+        assert_eq!(req.uri, "https://example.com/api");
+        assert!(matches!(req.method, FetchMethod::Post));
+        assert_eq!(req.headers.get("x-api-key").unwrap(), "test-key");
+        assert_eq!(req.headers.get("x-signature").unwrap(), "abc123");
+        assert_eq!(req.headers.get("content-type").unwrap(), APPLICATION_JSON);
+        match req.body {
+            Some(RequestBody::Utf8(b)) => assert_eq!(b, body),
+            _ => panic!("Expected Utf8 body"),
+        }
+    }
+
+    #[test]
+    fn test_post_json_content_type_cannot_be_overridden() {
+        let headers = vec![("Content-Type", "text/plain")];
+        let req = build_post_json_fetch_request("https://example.com", "{}".to_string(), headers);
+
+        // Only one content-type key should exist (normalized + overwritten).
+        assert_eq!(req.headers.len(), 1);
+        assert_eq!(req.headers.get("content-type").unwrap(), APPLICATION_JSON);
+    }
 
     #[wasm_bindgen_test]
     async fn fetch_get_test() {

--- a/mm2src/mm2_rpc/src/data/legacy/wallet.rs
+++ b/mm2src/mm2_rpc/src/data/legacy/wallet.rs
@@ -8,4 +8,8 @@ pub struct BalanceResponse {
     pub balance: BigDecimal,
     pub unspendable_balance: BigDecimal,
     pub address: String,
+    /// TRON GasFree receive address derived locally via CREATE2.
+    /// Only populated when this is a TRON coin with a configured GasFree provider.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gasfree_address: Option<String>,
 }

--- a/mm2src/mm2_test_helpers/src/structs.rs
+++ b/mm2src/mm2_test_helpers/src/structs.rs
@@ -499,6 +499,7 @@ pub struct TransactionDetails {
 pub struct IguanaWalletBalance {
     pub address: String,
     pub balance: CoinBalance,
+    pub gasfree_address: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -506,6 +507,7 @@ pub struct IguanaWalletBalance {
 pub struct IguanaWalletBalanceMap {
     pub address: String,
     pub balance: HashMap<String, CoinBalance>,
+    pub gasfree_address: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -551,6 +553,7 @@ pub struct HDAddressBalance {
     pub derivation_path: String,
     pub chain: Bip44Chain,
     pub balance: CoinBalance,
+    pub gasfree_address: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -560,6 +563,7 @@ pub struct HDAddressBalanceMap {
     pub derivation_path: String,
     pub chain: Bip44Chain,
     pub balance: HashMap<String, CoinBalance>,
+    pub gasfree_address: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -907,6 +911,7 @@ pub struct CoinAddressInfo<Balance> {
     pub pubkey: String,
     pub balances: Option<Balance>,
     pub tickers: Option<HashSet<String>>,
+    pub gasfree_address: Option<String>,
 }
 
 pub type TokenBalances = HashMap<String, CoinBalance>;


### PR DESCRIPTION
## Summary

Implement GasFree protocol support for gasless TRC-20 token transfers on TRON. Users can send TRC-20 tokens (e.g. USDT) without holding TRX for gas — fees are deducted from the transferred token via off-chain TIP-712 signed authorizations submitted to a GasFree service provider.

- Extends existing withdraw + send_raw_transaction APIs
- TRON GasFree wallet transfers only (no swaps in v1)
- No new RPCs
- GasFree receive address shown in activation and balance responses

### How it works

Each user EOA has a deterministic GasFree custody address derived via TVM CREATE2 (0x41 prefix, controller contract per network) — funds sent there become gasless-eligible. The user signs a TIP-712 `PermitTransferMessage` binding `{token, serviceProvider, user, receiver, value, maxFee, deadline, nonce}`. The signed permit is submitted to the GasFree provider, who pays TRX gas and settles the transfer on-chain. Inactive accounts auto-activate on first transfer (extra `activate_fee` rolled into the same submit). Status is tracked via `traceId` polling.

### Key architecture decisions

- Code lives inside the existing TRON subtree (`mm2src/coins/eth/tron/gasfree/`), reusing `EthCoin` with `ChainSpec::Tron`. No new top-level crate.
- TIP-712 signing extends `mm2_eth::eip712` (with corrected `bytes32` and new dynamic-`bytes` support) instead of introducing a new typed-data stack.
- Pluggable transport: `DirectHmac` (active) and `KomodoProxy` (stubbed for future proxy integration).
- Long-lived `ResolvedTronGaslessProvider` on `EthCoinImpl` owns the `Arc<TronGasfreeClient>` so supported-tokens cache and connection state survive across withdraws.
- Stateless per-request `GasfreeAccountService` sits above the provider, composing account state with on-chain TRC-20 balance via the `OnChainBalanceFetcher` trait (decouples the service from `EthCoin`).
- CREATE2 mismatch between provider-reported and locally-derived `gasFreeAddress` is treated as a safety stop — withdraw must not sign against unverifiable custody.

## Test plan

- [x] Unit tests added per commit (CREATE2 vectors per network, HMAC vector, transport routing/redaction, serde protocol-contract tests, service preflight decisions, address-mismatch safety stop)
- [ ] End-to-end integration test on Nile testnet (lands with the withdraw path)
- [ ] WASM smoke test of the gasless withdraw flow (lands once the path is wired)

## Status

### Done

- [x] **Foundations** — `mm2_eth::eip712` hardening (correct `bytes32`, dynamic-`bytes` support, strict hex validation); cross-platform `mm2_net` POST-with-headers helper for native + WASM
- [x] **Activation + addressing** — provider config validated and stored on `EthCoinImpl` at activation; deterministic CREATE2 GasFree address surfaced in HD/Iguana response shapes
- [x] **Provider client + service layer** — `TronGasfreeClient` with HMAC auth, pluggable transport, strict serde wire types, network-prefix `base_url` resolution; stateless `GasfreeAccountService` preflight combining provider + on-chain state with the CREATE2 safety stop and inactive-account preflight enforcement
- [x] **Withdraw schema** — `WithdrawFeeMethod { Native, Gasless, Auto }`, `GaslessWithdrawOptions`, new `WithdrawError` variants, gasless task-status variants, optional gasless metadata on `TronTxFeeDetails`
- [x] **TIP-712 signer** — typed-data construction over `mm2_eth::eip712`, sign-only flow with `r || s || v` output, official Nile + Mainnet domain-separator and PermitTransfer hash vectors

### To do
- [ ] **Withdraw path** — consume the service layer, deterministic native-vs-gasless auto-select, integration with `EthWithdraw`
- [ ] **`send_raw_transaction` gasless submission + Nile integration tests** — `GasfreeSubmitRequest` from a signed permit, `traceId` polling, end-to-end test against Nile
- [ ] **Address recovery / sweep** — surface stranded balances at the GasFree address; allow sweeping back to the EOA
- [ ] **KDF proxy integration** — implement the `KomodoProxy` transport variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)