### PR TITLE
fix(tron): account for new account creation fee

### DIFF
--- a/mm2src/coins/eth/eth_withdraw.rs
+++ b/mm2src/coins/eth/eth_withdraw.rs
@@ -378,6 +378,7 @@ where
             DestAccountState::NewAccount {
                 creation_fee_sun: prices.create_new_account_fee_sun,
                 bandwidth_fallback_sun: prices.create_account_bandwidth_fee_sun,
+                bandwidth_rate: prices.create_new_account_bandwidth_rate,
             }
         };
 

--- a/mm2src/coins/eth/eth_withdraw.rs
+++ b/mm2src/coins/eth/eth_withdraw.rs
@@ -353,33 +353,37 @@ where
         // 5. Fetch TAPOS block data (timestamp/expiration are derived inside the tx builders).
         let block_data = tron.get_block_for_tapos().await.map_mm_err()?;
 
-        // 6. Check if destination account is activated (for account creation fee estimation).
-        let dest_account = tron.get_account(&to_tron).await.map_mm_err()?;
-
-        // 7. Fetch account resources and chain prices.
+        // 6. Fetch account resources and chain prices.
         let resources = tron.get_account_resource(&from_tron).await.map_mm_err()?;
         let prices = tron.get_chain_prices().await.map_mm_err()?;
 
-        // 8. Compute destination state — only native TRX transfers pay system-contract
-        //    account creation fees. TRC20 uses energy for activation instead.
-        let dest_state = if dest_account.exists_meaningfully() {
-            DestAccountState::Activated
-        } else {
-            // Validate that the RPC node actually provided account creation fee params.
-            // A zero value here means the node omitted them (defaulted), which would
-            // silently underprice the transaction and cause broadcast failure.
-            if prices.create_new_account_fee_sun == 0 {
-                return MmError::err(WithdrawError::InternalError(
-                    "TRON node did not provide CreateNewAccountFeeInSystemContract chain parameter; \
-                     cannot estimate fees for transfer to unactivated address"
-                        .to_owned(),
-                ));
-            }
-            DestAccountState::NewAccount {
-                creation_fee_sun: prices.create_new_account_fee_sun,
-                bandwidth_fallback_sun: prices.create_account_bandwidth_fee_sun,
-                bandwidth_rate: prices.create_new_account_bandwidth_rate,
-            }
+        // 7. Compute destination state — only native TRX transfers pay system-contract
+        //    account creation fees.
+        let dest_state = match &coin.coin_type {
+            EthCoinType::Eth => {
+                let dest_account = tron.get_account(&to_tron).await.map_mm_err()?;
+                if dest_account.exists_meaningfully() {
+                    DestAccountState::Activated
+                } else {
+                    // Validate that the RPC node actually provided account creation fee params.
+                    // A zero value here means the node omitted them (defaulted), which would
+                    // silently underprice the transaction and cause broadcast failure.
+                    if prices.create_new_account_fee_sun == 0 {
+                        return MmError::err(WithdrawError::InternalError(
+                            "TRON node did not provide CreateNewAccountFeeInSystemContract chain parameter; \
+                             cannot estimate fees for transfer to unactivated address"
+                                .to_owned(),
+                        ));
+                    }
+                    DestAccountState::NewAccount {
+                        creation_fee_sun: prices.create_new_account_fee_sun,
+                        bandwidth_fallback_sun: prices.create_account_bandwidth_fee_sun,
+                        bandwidth_rate: prices.create_new_account_bandwidth_rate,
+                    }
+                }
+            },
+            EthCoinType::Erc20 { .. } => DestAccountState::Activated,
+            EthCoinType::Nft { .. } => DestAccountState::Activated,
         };
 
         // 9. Build tx, estimate fees — branching on coin type

--- a/mm2src/coins/eth/eth_withdraw.rs
+++ b/mm2src/coins/eth/eth_withdraw.rs
@@ -382,6 +382,8 @@ where
                     }
                 }
             },
+            // No need for destination account to be activated in TRC20 transfers, so we just assume
+            // it is activated and calculate the fees accordingly.
             EthCoinType::Erc20 { .. } => DestAccountState::Activated,
             EthCoinType::Nft { .. } => DestAccountState::Activated,
         };

--- a/mm2src/coins/eth/eth_withdraw.rs
+++ b/mm2src/coins/eth/eth_withdraw.rs
@@ -2,6 +2,7 @@ use super::{
     u256_from_big_decimal, u256_to_big_decimal, ChainSpec, ChainTaggedAddress, EthCoinType, EthDerivationMethod,
     EthPrivKeyPolicy, Public, WithdrawError, WithdrawRequest, WithdrawResult, ERC20_CONTRACT, H256,
 };
+use crate::eth::tron::fee::DestAccountState;
 use crate::eth::tron::sign::sign_tron_transaction;
 use crate::eth::tron::withdraw::{
     build_tron_trc20_withdraw, build_tron_trx_withdraw, validate_tron_fee_policy, TronWithdrawContext,
@@ -352,11 +353,35 @@ where
         // 5. Fetch TAPOS block data (timestamp/expiration are derived inside the tx builders).
         let block_data = tron.get_block_for_tapos().await.map_mm_err()?;
 
-        // 6. Fetch account resources and chain prices.
+        // 6. Check if destination account is activated (for account creation fee estimation).
+        let dest_account = tron.get_account(&to_tron).await.map_mm_err()?;
+
+        // 7. Fetch account resources and chain prices.
         let resources = tron.get_account_resource(&from_tron).await.map_mm_err()?;
         let prices = tron.get_chain_prices().await.map_mm_err()?;
 
-        // 7. Build tx, estimate fees — branching on coin type
+        // 8. Compute destination state — only native TRX transfers pay system-contract
+        //    account creation fees. TRC20 uses energy for activation instead.
+        let dest_state = if dest_account.exists_meaningfully() {
+            DestAccountState::Activated
+        } else {
+            // Validate that the RPC node actually provided account creation fee params.
+            // A zero value here means the node omitted them (defaulted), which would
+            // silently underprice the transaction and cause broadcast failure.
+            if prices.create_new_account_fee_sun == 0 {
+                return MmError::err(WithdrawError::InternalError(
+                    "TRON node did not provide CreateNewAccountFeeInSystemContract chain parameter; \
+                     cannot estimate fees for transfer to unactivated address"
+                        .to_owned(),
+                ));
+            }
+            DestAccountState::NewAccount {
+                creation_fee_sun: prices.create_new_account_fee_sun,
+                bandwidth_fallback_sun: prices.create_account_bandwidth_fee_sun,
+            }
+        };
+
+        // 9. Build tx, estimate fees — branching on coin type
         let withdraw_ctx = TronWithdrawContext {
             from: &from_tron,
             to: &to_tron,
@@ -365,6 +390,7 @@ where
             prices,
             fee_coin: ticker,
             expiration_seconds: req.expiration_seconds,
+            dest_state,
         };
         let (raw, tron_fee_details, final_amount) = match &coin.coin_type {
             EthCoinType::Eth => {

--- a/mm2src/coins/eth/tron.rs
+++ b/mm2src/coins/eth/tron.rs
@@ -117,6 +117,7 @@ pub(super) mod test_fixtures {
             energy_price_sun: 420,
             create_new_account_fee_sun: 1_000_000,     // 1 TRX
             create_account_bandwidth_fee_sun: 100_000, // 0.1 TRX
+            create_new_account_bandwidth_rate: 1,
         }
     }
 
@@ -125,6 +126,7 @@ pub(super) mod test_fixtures {
         DestAccountState::NewAccount {
             creation_fee_sun: 1_000_000,     // 1 TRX
             bandwidth_fallback_sun: 100_000, // 0.1 TRX
+            bandwidth_rate: 1,
         }
     }
 }

--- a/mm2src/coins/eth/tron.rs
+++ b/mm2src/coins/eth/tron.rs
@@ -91,6 +91,7 @@ pub fn validate_tron_raw_tx_len(len: usize) -> Result<(), String> {
 #[cfg(test)]
 pub(super) mod test_fixtures {
     use super::api::TaposBlockData;
+    use super::fee::{DestAccountState, TronChainPrices};
 
     pub const TEST_FROM_HEX: &str = "4123b00d15c601b30613bf5a3b2f72527c79cc08b6";
     pub const TEST_TO_HEX: &str = "418840e6c55b9ada326d211d818c34a994aeced808";
@@ -106,6 +107,24 @@ pub(super) mod test_fixtures {
                 arr
             },
             timestamp: 1_770_522_369_000,
+        }
+    }
+
+    /// Mainnet-like chain prices for tests.
+    pub fn mainnet_prices() -> TronChainPrices {
+        TronChainPrices {
+            bandwidth_price_sun: 1_000,
+            energy_price_sun: 420,
+            create_new_account_fee_sun: 1_000_000,     // 1 TRX
+            create_account_bandwidth_fee_sun: 100_000, // 0.1 TRX
+        }
+    }
+
+    /// `DestAccountState` for an unactivated address with mainnet-like fees.
+    pub fn new_account_state() -> DestAccountState {
+        DestAccountState::NewAccount {
+            creation_fee_sun: 1_000_000,     // 1 TRX
+            bandwidth_fallback_sun: 100_000, // 0.1 TRX
         }
     }
 }

--- a/mm2src/coins/eth/tron/api.rs
+++ b/mm2src/coins/eth/tron/api.rs
@@ -656,6 +656,7 @@ fn parse_chain_prices_sun(chain_params: &GetChainParametersResponse) -> Web3RpcR
     let mut energy_price_sun = None;
     let mut create_new_account_fee_sun = None;
     let mut create_account_bandwidth_fee_sun = None;
+    let mut create_new_account_bandwidth_rate = None;
 
     for param in &chain_params.chain_parameter {
         match param.key.as_str() {
@@ -665,6 +666,9 @@ fn parse_chain_prices_sun(chain_params: &GetChainParametersResponse) -> Web3RpcR
                 create_new_account_fee_sun = param.value.and_then(|v| v.try_into().ok())
             },
             "getCreateAccountFee" => create_account_bandwidth_fee_sun = param.value.and_then(|v| v.try_into().ok()),
+            "getCreateNewAccountBandwidthRate" => {
+                create_new_account_bandwidth_rate = param.value.and_then(|v| v.try_into().ok())
+            },
             _ => {},
         }
     }
@@ -679,6 +683,8 @@ fn parse_chain_prices_sun(chain_params: &GetChainParametersResponse) -> Web3RpcR
     // not return these parameters, and they are only needed for transfers to new addresses.
     let create_new_account_fee_sun = create_new_account_fee_sun.unwrap_or(0);
     let create_account_bandwidth_fee_sun = create_account_bandwidth_fee_sun.unwrap_or(0);
+    // Default to 1 when missing/invalid to match java-tron behavior.
+    let create_new_account_bandwidth_rate = create_new_account_bandwidth_rate.filter(|rate| *rate > 0).unwrap_or(1);
 
     if bandwidth_price_sun == 0 || energy_price_sun == 0 {
         return Err(Web3RpcError::BadResponse(
@@ -692,6 +698,7 @@ fn parse_chain_prices_sun(chain_params: &GetChainParametersResponse) -> Web3RpcR
         energy_price_sun,
         create_new_account_fee_sun,
         create_account_bandwidth_fee_sun,
+        create_new_account_bandwidth_rate,
     })
 }
 
@@ -1214,6 +1221,10 @@ mod tests {
                 key: "getCreateAccountFee".to_owned(),
                 value: Some(100_000),
             },
+            ChainParameterEntry {
+                key: "getCreateNewAccountBandwidthRate".to_owned(),
+                value: Some(1),
+            },
         ]
     }
 
@@ -1228,6 +1239,7 @@ mod tests {
         assert_eq!(prices.energy_price_sun, 100);
         assert_eq!(prices.create_new_account_fee_sun, 1_000_000);
         assert_eq!(prices.create_account_bandwidth_fee_sun, 100_000);
+        assert_eq!(prices.create_new_account_bandwidth_rate, 1);
     }
 
     #[test]
@@ -1257,6 +1269,7 @@ mod tests {
         let prices = parse_chain_prices_sun(&response).unwrap();
         assert_eq!(prices.create_new_account_fee_sun, 0);
         assert_eq!(prices.create_account_bandwidth_fee_sun, 0);
+        assert_eq!(prices.create_new_account_bandwidth_rate, 1);
     }
 
     #[test]
@@ -1278,6 +1291,7 @@ mod tests {
         let prices = parse_chain_prices_sun(&response).unwrap();
         assert_eq!(prices.create_new_account_fee_sun, 0);
         assert_eq!(prices.create_account_bandwidth_fee_sun, 0);
+        assert_eq!(prices.create_new_account_bandwidth_rate, 1);
     }
 
     #[test]
@@ -1288,7 +1302,8 @@ mod tests {
                 { "key": "getTransactionFee", "value": 1000 },
                 { "key": "getEnergyFee", "value": 100 },
                 { "key": "getCreateNewAccountFeeInSystemContract", "value": 1000000 },
-                { "key": "getCreateAccountFee", "value": 100000 }
+                { "key": "getCreateAccountFee", "value": 100000 },
+                { "key": "getCreateNewAccountBandwidthRate", "value": 1 }
             ]
         }"#;
 
@@ -1298,6 +1313,34 @@ mod tests {
         assert_eq!(prices.energy_price_sun, 100);
         assert_eq!(prices.create_new_account_fee_sun, 1_000_000);
         assert_eq!(prices.create_account_bandwidth_fee_sun, 100_000);
+        assert_eq!(prices.create_new_account_bandwidth_rate, 1);
+    }
+
+    #[test]
+    fn parse_chain_prices_defaults_missing_bandwidth_rate_to_one() {
+        let response = GetChainParametersResponse {
+            chain_parameter: vec![
+                ChainParameterEntry {
+                    key: "getTransactionFee".to_owned(),
+                    value: Some(1000),
+                },
+                ChainParameterEntry {
+                    key: "getEnergyFee".to_owned(),
+                    value: Some(100),
+                },
+                ChainParameterEntry {
+                    key: "getCreateNewAccountFeeInSystemContract".to_owned(),
+                    value: Some(1_000_000),
+                },
+                ChainParameterEntry {
+                    key: "getCreateAccountFee".to_owned(),
+                    value: Some(100_000),
+                },
+            ],
+        };
+
+        let prices = parse_chain_prices_sun(&response).unwrap();
+        assert_eq!(prices.create_new_account_bandwidth_rate, 1);
     }
 
     /// Verifies that all 6 mixed-case field renames map correctly to `TronAccountResources`.

--- a/mm2src/coins/eth/tron/api.rs
+++ b/mm2src/coins/eth/tron/api.rs
@@ -654,11 +654,17 @@ pub struct TronTxReceipt {
 fn parse_chain_prices_sun(chain_params: &GetChainParametersResponse) -> Web3RpcResult<TronChainPrices> {
     let mut bandwidth_price_sun = None;
     let mut energy_price_sun = None;
+    let mut create_new_account_fee_sun = None;
+    let mut create_account_bandwidth_fee_sun = None;
 
     for param in &chain_params.chain_parameter {
         match param.key.as_str() {
             "getTransactionFee" => bandwidth_price_sun = param.value.and_then(|v| v.try_into().ok()),
             "getEnergyFee" => energy_price_sun = param.value.and_then(|v| v.try_into().ok()),
+            "getCreateNewAccountFeeInSystemContract" => {
+                create_new_account_fee_sun = param.value.and_then(|v| v.try_into().ok())
+            },
+            "getCreateAccountFee" => create_account_bandwidth_fee_sun = param.value.and_then(|v| v.try_into().ok()),
             _ => {},
         }
     }
@@ -669,6 +675,10 @@ fn parse_chain_prices_sun(chain_params: &GetChainParametersResponse) -> Web3RpcR
     let energy_price_sun = energy_price_sun.ok_or_else(|| {
         Web3RpcError::BadResponse("Missing or invalid getEnergyFee in getchainparameters response".to_owned())
     })?;
+    // Account creation fees default to 0 if missing — some TRON RPC providers may
+    // not return these parameters, and they are only needed for transfers to new addresses.
+    let create_new_account_fee_sun = create_new_account_fee_sun.unwrap_or(0);
+    let create_account_bandwidth_fee_sun = create_account_bandwidth_fee_sun.unwrap_or(0);
 
     if bandwidth_price_sun == 0 || energy_price_sun == 0 {
         return Err(Web3RpcError::BadResponse(
@@ -680,6 +690,8 @@ fn parse_chain_prices_sun(chain_params: &GetChainParametersResponse) -> Web3RpcR
     Ok(TronChainPrices {
         bandwidth_price_sun,
         energy_price_sun,
+        create_new_account_fee_sun,
+        create_account_bandwidth_fee_sun,
     })
 }
 
@@ -1184,8 +1196,72 @@ mod tests {
         );
     }
 
+    fn sample_chain_params() -> Vec<ChainParameterEntry> {
+        vec![
+            ChainParameterEntry {
+                key: "getTransactionFee".to_owned(),
+                value: Some(1000),
+            },
+            ChainParameterEntry {
+                key: "getEnergyFee".to_owned(),
+                value: Some(100),
+            },
+            ChainParameterEntry {
+                key: "getCreateNewAccountFeeInSystemContract".to_owned(),
+                value: Some(1_000_000),
+            },
+            ChainParameterEntry {
+                key: "getCreateAccountFee".to_owned(),
+                value: Some(100_000),
+            },
+        ]
+    }
+
     #[test]
     fn parse_chain_prices_accepts_valid_parameters() {
+        let response = GetChainParametersResponse {
+            chain_parameter: sample_chain_params(),
+        };
+
+        let prices = parse_chain_prices_sun(&response).unwrap();
+        assert_eq!(prices.bandwidth_price_sun, 1000);
+        assert_eq!(prices.energy_price_sun, 100);
+        assert_eq!(prices.create_new_account_fee_sun, 1_000_000);
+        assert_eq!(prices.create_account_bandwidth_fee_sun, 100_000);
+    }
+
+    #[test]
+    fn parse_chain_prices_rejects_zero_values_as_retryable_bad_response() {
+        let mut params = sample_chain_params();
+        // Set getTransactionFee to 0
+        params[0].value = Some(0);
+        let response = GetChainParametersResponse {
+            chain_parameter: params,
+        };
+
+        let err = parse_chain_prices_sun(&response).unwrap_err().into_inner();
+        assert!(matches!(err, Web3RpcError::BadResponse(_)));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn parse_chain_prices_allows_zero_account_creation_fees() {
+        let mut params = sample_chain_params();
+        // Governance could set account creation fees to 0
+        params[2].value = Some(0); // getCreateNewAccountFeeInSystemContract
+        params[3].value = Some(0); // getCreateAccountFee
+        let response = GetChainParametersResponse {
+            chain_parameter: params,
+        };
+
+        let prices = parse_chain_prices_sun(&response).unwrap();
+        assert_eq!(prices.create_new_account_fee_sun, 0);
+        assert_eq!(prices.create_account_bandwidth_fee_sun, 0);
+    }
+
+    #[test]
+    fn parse_chain_prices_defaults_missing_account_creation_params_to_zero() {
+        // Only bandwidth/energy params, missing account creation params — should not fail
         let response = GetChainParametersResponse {
             chain_parameter: vec![
                 ChainParameterEntry {
@@ -1200,28 +1276,8 @@ mod tests {
         };
 
         let prices = parse_chain_prices_sun(&response).unwrap();
-        assert_eq!(prices.bandwidth_price_sun, 1000);
-        assert_eq!(prices.energy_price_sun, 100);
-    }
-
-    #[test]
-    fn parse_chain_prices_rejects_zero_values_as_retryable_bad_response() {
-        let response = GetChainParametersResponse {
-            chain_parameter: vec![
-                ChainParameterEntry {
-                    key: "getTransactionFee".to_owned(),
-                    value: Some(0),
-                },
-                ChainParameterEntry {
-                    key: "getEnergyFee".to_owned(),
-                    value: Some(100),
-                },
-            ],
-        };
-
-        let err = parse_chain_prices_sun(&response).unwrap_err().into_inner();
-        assert!(matches!(err, Web3RpcError::BadResponse(_)));
-        assert!(err.is_retryable());
+        assert_eq!(prices.create_new_account_fee_sun, 0);
+        assert_eq!(prices.create_account_bandwidth_fee_sun, 0);
     }
 
     #[test]
@@ -1230,7 +1286,9 @@ mod tests {
             "chainParameter": [
                 { "key": "getAllowUpdateAccountName" },
                 { "key": "getTransactionFee", "value": 1000 },
-                { "key": "getEnergyFee", "value": 100 }
+                { "key": "getEnergyFee", "value": 100 },
+                { "key": "getCreateNewAccountFeeInSystemContract", "value": 1000000 },
+                { "key": "getCreateAccountFee", "value": 100000 }
             ]
         }"#;
 
@@ -1238,6 +1296,8 @@ mod tests {
         let prices = parse_chain_prices_sun(&response).unwrap();
         assert_eq!(prices.bandwidth_price_sun, 1000);
         assert_eq!(prices.energy_price_sun, 100);
+        assert_eq!(prices.create_new_account_fee_sun, 1_000_000);
+        assert_eq!(prices.create_account_bandwidth_fee_sun, 100_000);
     }
 
     /// Verifies that all 6 mixed-case field renames map correctly to `TronAccountResources`.

--- a/mm2src/coins/eth/tron/api_integration_tests.rs
+++ b/mm2src/coins/eth/tron/api_integration_tests.rs
@@ -470,6 +470,10 @@ async fn test_chain_fee_parameters_are_present_and_valid_impl() {
         chain_prices.create_account_bandwidth_fee_sun > 0,
         "Nile should have non-zero CreateAccountFee"
     );
+    assert!(
+        chain_prices.create_new_account_bandwidth_rate > 0,
+        "Nile should have non-zero CreateNewAccountBandwidthRate"
+    );
 }
 
 cross_test!(tron_nile_known_trc20_tx_fee_receipt, {

--- a/mm2src/coins/eth/tron/api_integration_tests.rs
+++ b/mm2src/coins/eth/tron/api_integration_tests.rs
@@ -460,6 +460,16 @@ async fn test_chain_fee_parameters_are_present_and_valid_impl() {
 
     assert!(chain_prices.bandwidth_price_sun > 0);
     assert!(chain_prices.energy_price_sun > 0);
+    // Account creation fees should be present on Nile testnet.
+    // These are governance-set params; on Nile they mirror mainnet values.
+    assert!(
+        chain_prices.create_new_account_fee_sun > 0,
+        "Nile should have non-zero CreateNewAccountFeeInSystemContract"
+    );
+    assert!(
+        chain_prices.create_account_bandwidth_fee_sun > 0,
+        "Nile should have non-zero CreateAccountFee"
+    );
 }
 
 cross_test!(tron_nile_known_trc20_tx_fee_receipt, {
@@ -576,4 +586,37 @@ cross_test!(tron_nile_get_account_resource_known_address, {
 
 cross_test!(tron_nile_get_account_resource_unactivated_address, {
     test_get_account_resource_unactivated_address_impl().await;
+});
+
+// ============================================================================
+// Account Creation Fee Integration Tests
+// ============================================================================
+
+async fn test_unactivated_address_detected_for_fee_estimation_impl() {
+    let client = tron_nile_api_client();
+    let random_addr = random_tron_address();
+
+    // Random address should be unactivated
+    let account = client
+        .get_account(&random_addr)
+        .await
+        .expect("getaccount should succeed for random address");
+    assert!(
+        !account.exists_meaningfully(),
+        "random address should not be activated on Nile"
+    );
+
+    // Chain prices should include account creation fee params
+    let prices = client
+        .get_chain_prices()
+        .await
+        .expect("getchainparameters should succeed");
+    assert!(
+        prices.create_new_account_fee_sun > 0,
+        "CreateNewAccountFeeInSystemContract should be set on Nile"
+    );
+}
+
+cross_test!(tron_nile_unactivated_address_detected_for_fee_estimation, {
+    test_unactivated_address_detected_for_fee_estimation_impl().await;
 });

--- a/mm2src/coins/eth/tron/fee.rs
+++ b/mm2src/coins/eth/tron/fee.rs
@@ -103,6 +103,9 @@ pub struct TronChainPrices {
     /// Flat SUN fee charged when sender lacks bandwidth for account creation
     /// (`getCreateAccountFee`). Currently 0.1 TRX on mainnet.
     pub create_account_bandwidth_fee_sun: u64,
+    /// Multiplier for bandwidth consumed by account creation
+    /// (`getCreateNewAccountBandwidthRate`).
+    pub create_new_account_bandwidth_rate: u64,
 }
 
 /// Account creation fee context for a withdrawal destination.
@@ -122,6 +125,9 @@ pub enum DestAccountState {
         /// `CreateAccountFee` in SUN — flat fallback if sender lacks bandwidth
         /// for the account creation bandwidth portion.
         bandwidth_fallback_sun: u64,
+        /// `CreateNewAccountBandwidthRate` multiplier applied to account
+        /// creation bandwidth cost.
+        bandwidth_rate: u64,
     },
 }
 
@@ -222,14 +228,17 @@ fn estimate_fee_details(
         DestAccountState::NewAccount {
             creation_fee_sun,
             bandwidth_fallback_sun,
+            bandwidth_rate,
         } => {
             let available = resources.available_bandwidth();
             // Account creation bandwidth uses raw serialized size (not charged bandwidth
-            // which includes per-contract overhead), at CREATE_NEW_ACCOUNT_BANDWIDTH_RATE=1.
+            // which includes per-contract overhead), multiplied by
+            // `getCreateNewAccountBandwidthRate`.
             // If sender has enough bandwidth, it's consumed; otherwise the flat fallback fee applies.
-            if available >= tx_serialized_size {
+            let create_account_bw_cost = tx_serialized_size.saturating_mul(bandwidth_rate);
+            if available >= create_account_bw_cost {
                 // Bandwidth covers account creation — pool reduced, no flat fee.
-                let remaining_bw = available.saturating_sub(tx_serialized_size);
+                let remaining_bw = available.saturating_sub(create_account_bw_cost);
                 (creation_fee_sun, 0, remaining_bw)
             } else {
                 // Bandwidth insufficient — flat fallback fee, pool untouched for this part.
@@ -341,6 +350,7 @@ mod tests {
             energy_price_sun: 420,
             create_new_account_fee_sun: 0,
             create_account_bandwidth_fee_sun: 0,
+            create_new_account_bandwidth_rate: 1,
         };
 
         let details = estimate_trx_transfer_fee(&tx, resources, prices, "TRX", DestAccountState::Activated);
@@ -368,6 +378,7 @@ mod tests {
             energy_price_sun: 420,
             create_new_account_fee_sun: 0,
             create_account_bandwidth_fee_sun: 0,
+            create_new_account_bandwidth_rate: 1,
         };
         let energy_used = 500u64;
 
@@ -393,6 +404,7 @@ mod tests {
             energy_price_sun: u64::MAX,
             create_new_account_fee_sun: 0,
             create_account_bandwidth_fee_sun: 0,
+            create_new_account_bandwidth_rate: 1,
         };
 
         let details = estimate_trc20_transfer_fee(&tx, u64::MAX, resources, prices, "TRX");

--- a/mm2src/coins/eth/tron/fee.rs
+++ b/mm2src/coins/eth/tron/fee.rs
@@ -172,6 +172,10 @@ pub fn estimate_trx_transfer_fee(
 ///
 /// `energy_used` should come from `estimateenergy`/receipt-compatible estimation.
 ///
+/// FIXME: Looks like the doc down below is wrong. https://developers.tron.network/docs/account#:~:text=Contract%20Activation%20Method
+///        states that the 25000 is only incurred when sending trx or trx10 from within a contract.
+///        but doesn't mention trc20 transfers. and logically, trc20 transfers don't actually need the account
+///        activated as the balance is stored in the contract and not the actual account on the TVM.
 /// TRC20 transfers to unactivated addresses use energy (25,000 units) for account
 /// creation instead of the system contract fee, so `dest_state` should always be
 /// `DestAccountState::Activated`. The energy estimation API already accounts for

--- a/mm2src/coins/eth/tron/fee.rs
+++ b/mm2src/coins/eth/tron/fee.rs
@@ -84,6 +84,11 @@ impl TronAccountResources {
         free_bandwidth.saturating_add(staked_bandwidth)
     }
 
+    /// Available staked bandwidth only: `max(0, net_limit - net_used)`.
+    pub fn available_staked_bandwidth(&self) -> u64 {
+        self.net_limit.saturating_sub(self.net_used)
+    }
+
     /// Energy still available to the account: `max(0, energy_limit - energy_used)`.
     pub fn available_energy(&self) -> u64 {
         self.energy_limit.saturating_sub(self.energy_used)
@@ -227,18 +232,18 @@ fn estimate_fee_details(
             bandwidth_fallback_sun,
             bandwidth_rate,
         } => {
-            let available = resources.available_bandwidth();
+            let available = resources.available_staked_bandwidth();
             // Account creation bandwidth uses charged bandwidth units for this tx,
             // multiplied by `getCreateNewAccountBandwidthRate`.
-            // If sender has enough bandwidth, it's consumed; otherwise the flat fallback fee applies.
+            // If sender has enough staked bandwidth, it's consumed; otherwise the flat fallback fee applies.
             bandwidth_used = bandwidth_used.saturating_mul(bandwidth_rate);
             if available >= bandwidth_used {
-                // Bandwidth covers account creation.
+                // Staked bandwidth covers account creation.
                 // For create-account transactions, java-tron does not additionally apply
                 // regular per-byte bandwidth fee (`getTransactionFee`) path.
                 (creation_fee_sun, 0)
             } else {
-                // Bandwidth insufficient — flat fallback fee.
+                // Staked bandwidth insufficient — flat fallback fee.
                 bandwidth_used = 0;
                 (creation_fee_sun, bandwidth_fallback_sun)
             }
@@ -427,7 +432,32 @@ mod tests {
     cross_test!(account_creation_fee_no_extra_bw_fee_when_bandwidth_available, {
         let tx = tx_with_placeholder_signature(&sample_raw());
         let bandwidth_used = estimate_bandwidth(&tx);
-        // Give sender enough bandwidth only for account creation path.
+        // Give sender enough staked bandwidth only for account creation path.
+        // Free bandwidth is ignored for create-account flows.
+        let resources = TronAccountResources {
+            free_net_used: 0,
+            free_net_limit: 0,
+            net_used: 0,
+            net_limit: bandwidth_used,
+            energy_used: 0,
+            energy_limit: 0,
+        };
+        let prices = mainnet_prices();
+
+        let details = estimate_trx_transfer_fee(&tx, resources, prices, "TRX", new_account_state());
+
+        // account_creation_fee should be 1 TRX
+        assert_eq!(details.account_creation_fee, Some(sun_to_trx_decimal(1_000_000)));
+        // bandwidth_fee should be 0 — sender has enough staked bandwidth
+        assert_eq!(details.bandwidth_fee, BigDecimal::from(0));
+        // total = just the 1 TRX creation fee
+        assert_eq!(details.total_fee, sun_to_trx_decimal(1_000_000));
+    });
+
+    cross_test!(account_creation_fee_fallback_when_only_free_bandwidth_available, {
+        let tx = tx_with_placeholder_signature(&sample_raw());
+        let bandwidth_used = estimate_bandwidth(&tx);
+        // Although free bandwidth is sufficient, staked bandwidth is zero, which is mandatory for withdraws that trigger account creation.
         let resources = TronAccountResources {
             free_net_used: 0,
             free_net_limit: bandwidth_used,
@@ -440,12 +470,12 @@ mod tests {
 
         let details = estimate_trx_transfer_fee(&tx, resources, prices, "TRX", new_account_state());
 
-        // account_creation_fee should be 1 TRX
+        // account_creation_fee should be 1 TRX.
         assert_eq!(details.account_creation_fee, Some(sun_to_trx_decimal(1_000_000)));
-        // bandwidth_fee should be 0 — sender has enough for both
-        assert_eq!(details.bandwidth_fee, BigDecimal::from(0));
-        // total = just the 1 TRX creation fee
-        assert_eq!(details.total_fee, sun_to_trx_decimal(1_000_000));
+        // staked bandwidth missing triggers fallback. bandwidth_fee should be 0.1 TRX.
+        assert_eq!(details.bandwidth_fee, sun_to_trx_decimal(100_000));
+        // total = 1.1 TRX
+        assert_eq!(details.total_fee, sun_to_trx_decimal(1_100_000));
     });
 
     cross_test!(account_creation_fee_none_for_activated_destination, {

--- a/mm2src/coins/eth/tron/fee.rs
+++ b/mm2src/coins/eth/tron/fee.rs
@@ -178,14 +178,9 @@ pub fn estimate_trx_transfer_fee(
 ///
 /// `energy_used` should come from `estimateenergy`/receipt-compatible estimation.
 ///
-/// FIXME: Looks like the doc down below is wrong. https://developers.tron.network/docs/account#:~:text=Contract%20Activation%20Method
-///        states that the 25000 is only incurred when sending trx or trx10 from within a contract.
-///        but doesn't mention trc20 transfers. and logically, trc20 transfers don't actually need the account
-///        activated as the balance is stored in the contract and not the actual account on the TVM.
-/// TRC20 transfers to unactivated addresses use energy (25,000 units) for account
-/// creation instead of the system contract fee, so `dest_state` should always be
-/// `DestAccountState::Activated`. The energy estimation API already accounts for
-/// the extra energy cost of activating the destination.
+/// TRC20 transfers do not require account activation and therefore do not charge
+/// account-activation fees. The energy estimation API already accounts for the
+/// extra energy cost of sending to an unactivated address.
 pub fn estimate_trc20_transfer_fee(
     tx: &Transaction,
     energy_used: u64,
@@ -243,8 +238,8 @@ fn estimate_fee_details(
                 // regular per-byte bandwidth fee (`getTransactionFee`) path.
                 (creation_fee_sun, 0)
             } else {
-                // FIXME: Should we reset the `bandwidth_used` to zero now?
                 // Bandwidth insufficient — flat fallback fee.
+                bandwidth_used = 0;
                 (creation_fee_sun, bandwidth_fallback_sun)
             }
         },

--- a/mm2src/coins/eth/tron/fee.rs
+++ b/mm2src/coins/eth/tron/fee.rs
@@ -36,6 +36,10 @@ pub struct TronTxFeeDetails {
     pub energy_used: u64,
     pub bandwidth_fee: BigDecimal,
     pub energy_fee: BigDecimal,
+    /// Fee for creating a new account at the destination address (burned by the network).
+    /// `None` when the destination already exists on chain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_creation_fee: Option<BigDecimal>,
     pub total_fee: BigDecimal,
 }
 
@@ -93,6 +97,32 @@ pub struct TronChainPrices {
     pub bandwidth_price_sun: u64,
     /// SUN per energy unit (`getEnergyFee`).
     pub energy_price_sun: u64,
+    /// Flat SUN fee for creating a new account via system contract
+    /// (`getCreateNewAccountFeeInSystemContract`). Currently 1 TRX on mainnet.
+    pub create_new_account_fee_sun: u64,
+    /// Flat SUN fee charged when sender lacks bandwidth for account creation
+    /// (`getCreateAccountFee`). Currently 0.1 TRX on mainnet.
+    pub create_account_bandwidth_fee_sun: u64,
+}
+
+/// Account creation fee context for a withdrawal destination.
+///
+/// Used instead of a raw `bool` to make call sites self-documenting and to carry
+/// the precomputed fee values from chain parameters.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DestAccountState {
+    /// Destination account already exists on chain. No creation fees apply.
+    Activated,
+    /// Destination is a new/unactivated address. Creation fees apply for native
+    /// TRX transfers (`TransferContract`). TRC20 transfers use energy for account
+    /// creation instead, so they should always use `Activated`.
+    NewAccount {
+        /// `CreateNewAccountFeeInSystemContract` in SUN — always charged.
+        creation_fee_sun: u64,
+        /// `CreateAccountFee` in SUN — flat fallback if sender lacks bandwidth
+        /// for the account creation bandwidth portion.
+        bandwidth_fallback_sun: u64,
+    },
 }
 
 /// Builds a transaction clone with a synthetic 65-byte signature.
@@ -125,18 +155,27 @@ pub fn estimate_bandwidth(tx: &Transaction) -> u64 {
 }
 
 /// Estimates fee details for native TRX transfer (bandwidth-only path).
+///
+/// When `dest_state` is `NewAccount`, includes the account creation fee and adjusts
+/// bandwidth calculations for the extra bandwidth consumed by account creation.
 pub fn estimate_trx_transfer_fee(
     tx: &Transaction,
     resources: TronAccountResources,
     prices: TronChainPrices,
     fee_coin: &str,
+    dest_state: DestAccountState,
 ) -> TronTxFeeDetails {
-    estimate_fee_details(tx, 0, resources, prices, fee_coin)
+    estimate_fee_details(tx, 0, resources, prices, fee_coin, dest_state)
 }
 
 /// Estimates fee details for TRC20 transfer (bandwidth + energy path).
 ///
 /// `energy_used` should come from `estimateenergy`/receipt-compatible estimation.
+///
+/// TRC20 transfers to unactivated addresses use energy (25,000 units) for account
+/// creation instead of the system contract fee, so `dest_state` should always be
+/// `DestAccountState::Activated`. The energy estimation API already accounts for
+/// the extra energy cost of activating the destination.
 pub fn estimate_trc20_transfer_fee(
     tx: &Transaction,
     energy_used: u64,
@@ -144,31 +183,73 @@ pub fn estimate_trc20_transfer_fee(
     prices: TronChainPrices,
     fee_coin: &str,
 ) -> TronTxFeeDetails {
-    estimate_fee_details(tx, energy_used, resources, prices, fee_coin)
+    // TRC20 never uses system-contract account creation fees.
+    estimate_fee_details(
+        tx,
+        energy_used,
+        resources,
+        prices,
+        fee_coin,
+        DestAccountState::Activated,
+    )
 }
 
 /// Shared fee computation used by TRX/TRC20 paths.
 ///
 /// Steps:
 /// 1. Estimate bandwidth usage from serialized tx size.
-/// 2. Compute deficits against account resources.
-/// 3. Price deficits using chain prices.
-/// 4. Return fixed-scale TRX decimals.
+/// 2. If destination is unactivated, compute account creation fees and adjust available bandwidth.
+/// 3. Compute deficits against (remaining) account resources.
+/// 4. Price deficits using chain prices.
+/// 5. Return fixed-scale TRX decimals.
 fn estimate_fee_details(
     tx: &Transaction,
     energy_used: u64,
     resources: TronAccountResources,
     prices: TronChainPrices,
     fee_coin: &str,
+    dest_state: DestAccountState,
 ) -> TronTxFeeDetails {
     let bandwidth_used = estimate_bandwidth(tx);
+    let tx_serialized_size = tx.encoded_len() as u64;
 
-    let bandwidth_deficit = bandwidth_used.saturating_sub(resources.available_bandwidth());
+    let (account_creation_fee_sun, extra_bw_fee_sun, available_bw_after_creation) = match dest_state {
+        DestAccountState::Activated => (0u64, 0u64, resources.available_bandwidth()),
+        DestAccountState::NewAccount {
+            creation_fee_sun,
+            bandwidth_fallback_sun,
+        } => {
+            let available = resources.available_bandwidth();
+            // Account creation bandwidth uses raw serialized size (not charged bandwidth
+            // which includes per-contract overhead), at CREATE_NEW_ACCOUNT_BANDWIDTH_RATE=1.
+            // If sender has enough bandwidth, it's consumed; otherwise the flat fallback fee applies.
+            if available >= tx_serialized_size {
+                // Bandwidth covers account creation — pool reduced, no flat fee.
+                let remaining_bw = available.saturating_sub(tx_serialized_size);
+                (creation_fee_sun, 0, remaining_bw)
+            } else {
+                // Bandwidth insufficient — flat fallback fee, pool untouched for this part.
+                (creation_fee_sun, bandwidth_fallback_sun, available)
+            }
+        },
+    };
+
+    let bandwidth_deficit = bandwidth_used.saturating_sub(available_bw_after_creation);
     let energy_deficit = energy_used.saturating_sub(resources.available_energy());
 
-    let bandwidth_fee_sun = bandwidth_deficit.saturating_mul(prices.bandwidth_price_sun);
+    let bandwidth_fee_sun = bandwidth_deficit
+        .saturating_mul(prices.bandwidth_price_sun)
+        .saturating_add(extra_bw_fee_sun);
     let energy_fee_sun = energy_deficit.saturating_mul(prices.energy_price_sun);
-    let total_fee_sun = bandwidth_fee_sun.saturating_add(energy_fee_sun);
+    let total_fee_sun = bandwidth_fee_sun
+        .saturating_add(energy_fee_sun)
+        .saturating_add(account_creation_fee_sun);
+
+    let account_creation_fee = if account_creation_fee_sun > 0 {
+        Some(sun_to_trx_decimal(account_creation_fee_sun))
+    } else {
+        None
+    };
 
     TronTxFeeDetails {
         coin: fee_coin.to_owned(),
@@ -176,6 +257,7 @@ fn estimate_fee_details(
         energy_used,
         bandwidth_fee: sun_to_trx_decimal(bandwidth_fee_sun),
         energy_fee: sun_to_trx_decimal(energy_fee_sun),
+        account_creation_fee,
         total_fee: sun_to_trx_decimal(total_fee_sun),
     }
 }
@@ -189,6 +271,7 @@ fn sun_to_trx_decimal(sun: u64) -> BigDecimal {
 mod tests {
     use super::*;
     use crate::eth::tron::proto::{ContractType, TransactionContract, TYPE_URL_TRANSFER_CONTRACT};
+    use crate::eth::tron::test_fixtures::{mainnet_prices, new_account_state};
     use crate::eth::tron::tx_builder::wrap_contract;
     use common::cross_test;
 
@@ -252,13 +335,16 @@ mod tests {
         let prices = TronChainPrices {
             bandwidth_price_sun: 1_000,
             energy_price_sun: 420,
+            create_new_account_fee_sun: 0,
+            create_account_bandwidth_fee_sun: 0,
         };
 
-        let details = estimate_trx_transfer_fee(&tx, resources, prices, "TRX");
+        let details = estimate_trx_transfer_fee(&tx, resources, prices, "TRX", DestAccountState::Activated);
         assert_eq!(details.coin, "TRX");
         assert_eq!(details.energy_used, 0);
         assert_eq!(details.bandwidth_fee, BigDecimal::from(0));
         assert_eq!(details.energy_fee, BigDecimal::from(0));
+        assert_eq!(details.account_creation_fee, None);
         assert_eq!(details.total_fee, BigDecimal::from(0));
     });
 
@@ -276,6 +362,8 @@ mod tests {
         let prices = TronChainPrices {
             bandwidth_price_sun: 1_000,
             energy_price_sun: 420,
+            create_new_account_fee_sun: 0,
+            create_account_bandwidth_fee_sun: 0,
         };
         let energy_used = 500u64;
 
@@ -299,12 +387,101 @@ mod tests {
         let prices = TronChainPrices {
             bandwidth_price_sun: u64::MAX,
             energy_price_sun: u64::MAX,
+            create_new_account_fee_sun: 0,
+            create_account_bandwidth_fee_sun: 0,
         };
 
         let details = estimate_trc20_transfer_fee(&tx, u64::MAX, resources, prices, "TRX");
         assert_eq!(details.bandwidth_fee, sun_to_trx_decimal(u64::MAX));
         assert_eq!(details.energy_fee, sun_to_trx_decimal(u64::MAX));
         assert_eq!(details.total_fee, sun_to_trx_decimal(u64::MAX));
+    });
+
+    cross_test!(account_creation_fee_included_for_new_dest_no_bandwidth, {
+        let tx = tx_with_placeholder_signature(&sample_raw());
+        let resources = TronAccountResources::default(); // no bandwidth
+        let prices = mainnet_prices();
+
+        let details = estimate_trx_transfer_fee(&tx, resources, prices, "TRX", new_account_state());
+
+        // account_creation_fee should be 1 TRX
+        assert_eq!(details.account_creation_fee, Some(sun_to_trx_decimal(1_000_000)));
+        // bandwidth_fee should include the 0.1 TRX flat fee + regular bandwidth fee
+        let bandwidth_used = estimate_bandwidth(&tx);
+        let expected_regular_bw_fee = bandwidth_used * 1_000; // no bandwidth available
+        let expected_bw_fee = expected_regular_bw_fee + 100_000; // + 0.1 TRX flat
+        assert_eq!(details.bandwidth_fee, sun_to_trx_decimal(expected_bw_fee));
+        // total = bandwidth_fee + account_creation_fee
+        let expected_total = expected_bw_fee + 1_000_000;
+        assert_eq!(details.total_fee, sun_to_trx_decimal(expected_total));
+    });
+
+    cross_test!(account_creation_fee_no_extra_bw_fee_when_bandwidth_available, {
+        let tx = tx_with_placeholder_signature(&sample_raw());
+        let tx_serialized_size = tx.encoded_len() as u64;
+        let bandwidth_used = estimate_bandwidth(&tx);
+        // Give sender enough bandwidth for account creation (tx_serialized_size)
+        // + regular tx (bandwidth_used).
+        let resources = TronAccountResources {
+            free_net_used: 0,
+            free_net_limit: tx_serialized_size + bandwidth_used, // enough for both
+            net_used: 0,
+            net_limit: 0,
+            energy_used: 0,
+            energy_limit: 0,
+        };
+        let prices = mainnet_prices();
+
+        let details = estimate_trx_transfer_fee(&tx, resources, prices, "TRX", new_account_state());
+
+        // account_creation_fee should be 1 TRX
+        assert_eq!(details.account_creation_fee, Some(sun_to_trx_decimal(1_000_000)));
+        // bandwidth_fee should be 0 — sender has enough for both
+        assert_eq!(details.bandwidth_fee, BigDecimal::from(0));
+        // total = just the 1 TRX creation fee
+        assert_eq!(details.total_fee, sun_to_trx_decimal(1_000_000));
+    });
+
+    cross_test!(account_creation_fee_none_for_activated_destination, {
+        let tx = tx_with_placeholder_signature(&sample_raw());
+        let resources = TronAccountResources::default();
+        let prices = mainnet_prices();
+
+        let details = estimate_trx_transfer_fee(&tx, resources, prices, "TRX", DestAccountState::Activated);
+        assert_eq!(details.account_creation_fee, None);
+    });
+
+    cross_test!(serde_roundtrip_with_account_creation_fee, {
+        let with_fee = TronTxFeeDetails {
+            coin: "TRX".to_owned(),
+            bandwidth_used: 300,
+            energy_used: 0,
+            bandwidth_fee: sun_to_trx_decimal(400_000),
+            energy_fee: sun_to_trx_decimal(0),
+            account_creation_fee: Some(sun_to_trx_decimal(1_000_000)),
+            total_fee: sun_to_trx_decimal(1_400_000),
+        };
+        let json = serde_json::to_string(&with_fee).unwrap();
+        assert!(json.contains("account_creation_fee"));
+        let deserialized: TronTxFeeDetails = serde_json::from_str(&json).unwrap();
+        assert_eq!(with_fee, deserialized);
+    });
+
+    cross_test!(serde_roundtrip_without_account_creation_fee, {
+        let without_fee = TronTxFeeDetails {
+            coin: "TRX".to_owned(),
+            bandwidth_used: 300,
+            energy_used: 0,
+            bandwidth_fee: sun_to_trx_decimal(400_000),
+            energy_fee: sun_to_trx_decimal(0),
+            account_creation_fee: None,
+            total_fee: sun_to_trx_decimal(400_000),
+        };
+        let json = serde_json::to_string(&without_fee).unwrap();
+        // skip_serializing_if omits the field when None
+        assert!(!json.contains("account_creation_fee"));
+        let deserialized: TronTxFeeDetails = serde_json::from_str(&json).unwrap();
+        assert_eq!(without_fee, deserialized);
     });
 
     // Verifies that `sun_to_trx_decimal` preserves a fixed 6-digit scale in

--- a/mm2src/coins/eth/tron/fee.rs
+++ b/mm2src/coins/eth/tron/fee.rs
@@ -208,8 +208,8 @@ pub fn estimate_trc20_transfer_fee(
 ///
 /// Steps:
 /// 1. Estimate bandwidth usage from serialized tx size.
-/// 2. If destination is unactivated, compute account creation fees and adjust available bandwidth.
-/// 3. Compute deficits against (remaining) account resources.
+/// 2. If destination is unactivated, use account-creation charging path.
+/// 3. Otherwise (activated destination), compute regular bandwidth deficit fee.
 /// 4. Price deficits using chain prices.
 /// 5. Return fixed-scale TRX decimals.
 fn estimate_fee_details(
@@ -220,39 +220,37 @@ fn estimate_fee_details(
     fee_coin: &str,
     dest_state: DestAccountState,
 ) -> TronTxFeeDetails {
-    let bandwidth_used = estimate_bandwidth(tx);
-    let tx_serialized_size = tx.encoded_len() as u64;
+    let mut bandwidth_used = estimate_bandwidth(tx);
 
-    let (account_creation_fee_sun, extra_bw_fee_sun, available_bw_after_creation) = match dest_state {
-        DestAccountState::Activated => (0u64, 0u64, resources.available_bandwidth()),
+    let (account_creation_fee_sun, bandwidth_fee_sun) = match dest_state {
+        DestAccountState::Activated => {
+            let bandwidth_deficit = bandwidth_used.saturating_sub(resources.available_bandwidth());
+            (0u64, bandwidth_deficit.saturating_mul(prices.bandwidth_price_sun))
+        },
         DestAccountState::NewAccount {
             creation_fee_sun,
             bandwidth_fallback_sun,
             bandwidth_rate,
         } => {
             let available = resources.available_bandwidth();
-            // Account creation bandwidth uses raw serialized size (not charged bandwidth
-            // which includes per-contract overhead), multiplied by
-            // `getCreateNewAccountBandwidthRate`.
+            // Account creation bandwidth uses charged bandwidth units for this tx,
+            // multiplied by `getCreateNewAccountBandwidthRate`.
             // If sender has enough bandwidth, it's consumed; otherwise the flat fallback fee applies.
-            let create_account_bw_cost = tx_serialized_size.saturating_mul(bandwidth_rate);
-            if available >= create_account_bw_cost {
-                // Bandwidth covers account creation — pool reduced, no flat fee.
-                let remaining_bw = available.saturating_sub(create_account_bw_cost);
-                (creation_fee_sun, 0, remaining_bw)
+            bandwidth_used = bandwidth_used.saturating_mul(bandwidth_rate);
+            if available >= bandwidth_used {
+                // Bandwidth covers account creation.
+                // For create-account transactions, java-tron does not additionally apply
+                // regular per-byte bandwidth fee (`getTransactionFee`) path.
+                (creation_fee_sun, 0)
             } else {
-                // Bandwidth insufficient — flat fallback fee, pool untouched for this part.
-                (creation_fee_sun, bandwidth_fallback_sun, available)
+                // FIXME: Should we reset the `bandwidth_used` to zero now?
+                // Bandwidth insufficient — flat fallback fee.
+                (creation_fee_sun, bandwidth_fallback_sun)
             }
         },
     };
 
-    let bandwidth_deficit = bandwidth_used.saturating_sub(available_bw_after_creation);
     let energy_deficit = energy_used.saturating_sub(resources.available_energy());
-
-    let bandwidth_fee_sun = bandwidth_deficit
-        .saturating_mul(prices.bandwidth_price_sun)
-        .saturating_add(extra_bw_fee_sun);
     let energy_fee_sun = energy_deficit.saturating_mul(prices.energy_price_sun);
     let total_fee_sun = bandwidth_fee_sun
         .saturating_add(energy_fee_sun)
@@ -422,10 +420,9 @@ mod tests {
 
         // account_creation_fee should be 1 TRX
         assert_eq!(details.account_creation_fee, Some(sun_to_trx_decimal(1_000_000)));
-        // bandwidth_fee should include the 0.1 TRX flat fee + regular bandwidth fee
-        let bandwidth_used = estimate_bandwidth(&tx);
-        let expected_regular_bw_fee = bandwidth_used * 1_000; // no bandwidth available
-        let expected_bw_fee = expected_regular_bw_fee + 100_000; // + 0.1 TRX flat
+        // bandwidth_fee should be only the 0.1 TRX flat fallback fee
+        // (`getCreateAccountFee`) for create-account path.
+        let expected_bw_fee = 100_000;
         assert_eq!(details.bandwidth_fee, sun_to_trx_decimal(expected_bw_fee));
         // total = bandwidth_fee + account_creation_fee
         let expected_total = expected_bw_fee + 1_000_000;
@@ -434,13 +431,11 @@ mod tests {
 
     cross_test!(account_creation_fee_no_extra_bw_fee_when_bandwidth_available, {
         let tx = tx_with_placeholder_signature(&sample_raw());
-        let tx_serialized_size = tx.encoded_len() as u64;
         let bandwidth_used = estimate_bandwidth(&tx);
-        // Give sender enough bandwidth for account creation (tx_serialized_size)
-        // + regular tx (bandwidth_used).
+        // Give sender enough bandwidth only for account creation path.
         let resources = TronAccountResources {
             free_net_used: 0,
-            free_net_limit: tx_serialized_size + bandwidth_used, // enough for both
+            free_net_limit: bandwidth_used,
             net_used: 0,
             net_limit: 0,
             energy_used: 0,

--- a/mm2src/coins/eth/tron/withdraw.rs
+++ b/mm2src/coins/eth/tron/withdraw.rs
@@ -6,8 +6,8 @@
 
 use crate::eth::chain_rpc::ChainRpcOps;
 use crate::eth::tron::fee::{
-    estimate_trc20_transfer_fee, estimate_trx_transfer_fee, tx_with_placeholder_signature, TronAccountResources,
-    TronChainPrices, TronTxFeeDetails,
+    estimate_trc20_transfer_fee, estimate_trx_transfer_fee, tx_with_placeholder_signature, DestAccountState,
+    TronAccountResources, TronChainPrices, TronTxFeeDetails,
 };
 use crate::eth::tron::proto::TransactionRaw;
 use crate::eth::tron::tx_builder::{build_trc20_transfer, build_trx_transfer};
@@ -33,6 +33,9 @@ pub struct TronWithdrawContext<'a> {
     pub fee_coin: &'a str,
     /// Transaction expiration window in seconds. `None` uses the protocol default (60s).
     pub expiration_seconds: Option<u64>,
+    /// Destination account state. When `NewAccount`, account creation fees are
+    /// included in fee estimation for native TRX transfers.
+    pub dest_state: DestAccountState,
 }
 
 /// Reject EVM gas fee policies for TRON. TRON always auto-estimates fees.
@@ -85,7 +88,7 @@ pub fn build_tron_trx_withdraw(
     loop {
         // Estimate fee for the current transaction
         let tx = tx_with_placeholder_signature(&raw);
-        let fee_details = estimate_trx_transfer_fee(&tx, ctx.resources, ctx.prices, ctx.fee_coin);
+        let fee_details = estimate_trx_transfer_fee(&tx, ctx.resources, ctx.prices, ctx.fee_coin, ctx.dest_state);
         let fee_sun = u256_to_u64_checked(u256_from_big_decimal(&fee_details.total_fee, TRX_DECIMALS).map_mm_err()?)?;
 
         // How much can we afford to send after paying the fee? (0 if fee >= balance)
@@ -156,7 +159,9 @@ pub async fn build_tron_trc20_withdraw(
     )
     .map_to_mm(|e| WithdrawError::InternalError(format!("TRC20 ABI encoding failed: {e}")))?;
 
-    // Estimate fee details (bandwidth + energy)
+    // Estimate fee details (bandwidth + energy).
+    // TRC20 uses energy (not system contract fee) for account creation, so the
+    // energy estimation API already accounts for unactivated destinations.
     let tx = tx_with_placeholder_signature(&raw);
     let fee_details = estimate_trc20_transfer_fee(&tx, energy_used, ctx.resources, ctx.prices, ctx.fee_coin);
 
@@ -183,7 +188,9 @@ mod tests {
     use crate::eth::tron::fee::estimate_trx_transfer_fee;
     #[cfg(not(target_arch = "wasm32"))]
     use crate::eth::tron::sign::sign_tron_transaction;
-    use crate::eth::tron::test_fixtures::{nile_block_64687673, TEST_FROM_HEX, TEST_TO_HEX};
+    use crate::eth::tron::test_fixtures::{
+        mainnet_prices, new_account_state, nile_block_64687673, TEST_FROM_HEX, TEST_TO_HEX,
+    };
     use crate::eth::tron::tx_builder::build_trx_transfer;
     use crate::eth::tron::TronAddress;
     use common::cross_test;
@@ -258,10 +265,7 @@ mod tests {
         let balance = U256::from(10_000_000u64); // 10 TRX
         let balance_dec = BigDecimal::from(10);
         let resources = TronAccountResources::default(); // no free bandwidth
-        let prices = TronChainPrices {
-            bandwidth_price_sun: 1_000,
-            energy_price_sun: 420,
-        };
+        let prices = mainnet_prices();
 
         let ctx = TronWithdrawContext {
             from: &from,
@@ -271,6 +275,7 @@ mod tests {
             prices,
             fee_coin: "TRX",
             expiration_seconds: None,
+            dest_state: DestAccountState::Activated,
         };
         let (raw, fee_details, final_amount) =
             build_tron_trx_withdraw(&ctx, balance, balance, &balance_dec, true).unwrap();
@@ -280,10 +285,11 @@ mod tests {
             u256_to_u64_checked(u256_from_big_decimal(&fee_details.total_fee, TRX_DECIMALS).unwrap()).unwrap();
         assert!(final_amount.as_u64() + fee_sun <= balance.as_u64());
         assert!(final_amount > U256::zero());
+        assert_eq!(fee_details.account_creation_fee, None);
 
         // Verify fee_details corresponds to the final raw tx
         let tx = tx_with_placeholder_signature(&raw);
-        let recomputed = estimate_trx_transfer_fee(&tx, resources, prices, "TRX");
+        let recomputed = estimate_trx_transfer_fee(&tx, resources, prices, "TRX", DestAccountState::Activated);
         assert_eq!(fee_details, recomputed, "fee_details must match the final raw tx");
     });
 
@@ -296,10 +302,7 @@ mod tests {
         let balance_dec = BigDecimal::from(1);
         let amount = U256::from(999_999u64); // just under 1 TRX — fee will push it over
         let resources = TronAccountResources::default();
-        let prices = TronChainPrices {
-            bandwidth_price_sun: 1_000,
-            energy_price_sun: 420,
-        };
+        let prices = mainnet_prices();
 
         let ctx = TronWithdrawContext {
             from: &from,
@@ -309,11 +312,156 @@ mod tests {
             prices,
             fee_coin: "TRX",
             expiration_seconds: None,
+            dest_state: DestAccountState::Activated,
         };
         let result = build_tron_trx_withdraw(&ctx, amount, balance, &balance_dec, false);
 
         assert!(result.is_err());
         let err = result.unwrap_err().into_inner();
         assert!(matches!(err, WithdrawError::NotSufficientBalance { .. }));
+    });
+
+    cross_test!(trx_max_withdraw_to_new_account_deducts_creation_fee, {
+        let from = TronAddress::from_hex(TEST_FROM_HEX).unwrap();
+        let to = TronAddress::from_hex(TEST_TO_HEX).unwrap();
+        let block_data = nile_block_64687673();
+
+        let balance = U256::from(10_000_000u64); // 10 TRX
+        let balance_dec = BigDecimal::from(10);
+        let resources = TronAccountResources::default(); // no bandwidth
+        let prices = mainnet_prices();
+
+        // First: max withdraw to activated dest (no creation fee)
+        let ctx_activated = TronWithdrawContext {
+            from: &from,
+            to: &to,
+            block_data: &block_data,
+            resources,
+            prices,
+            fee_coin: "TRX",
+            expiration_seconds: None,
+            dest_state: DestAccountState::Activated,
+        };
+        let (_, _, amount_activated) =
+            build_tron_trx_withdraw(&ctx_activated, balance, balance, &balance_dec, true).unwrap();
+
+        // Then: max withdraw to unactivated dest (with creation fee)
+        let ctx_new = TronWithdrawContext {
+            dest_state: new_account_state(),
+            ..ctx_activated
+        };
+        let (_, fee_details_new, amount_new) =
+            build_tron_trx_withdraw(&ctx_new, balance, balance, &balance_dec, true).unwrap();
+
+        // Amount to new account should be less (creation fee deducted)
+        assert!(
+            amount_new < amount_activated,
+            "max amount to new account should be less than to activated"
+        );
+        // Account creation fee should be present
+        assert!(fee_details_new.account_creation_fee.is_some());
+        // final_amount + total_fee <= balance
+        let fee_sun =
+            u256_to_u64_checked(u256_from_big_decimal(&fee_details_new.total_fee, TRX_DECIMALS).unwrap()).unwrap();
+        assert!(amount_new.as_u64() + fee_sun <= balance.as_u64());
+    });
+
+    cross_test!(trx_non_max_withdraw_to_new_account_succeeds_with_sufficient_balance, {
+        let from = TronAddress::from_hex(TEST_FROM_HEX).unwrap();
+        let to = TronAddress::from_hex(TEST_TO_HEX).unwrap();
+        let block_data = nile_block_64687673();
+
+        let balance = U256::from(10_000_000u64); // 10 TRX
+        let balance_dec = BigDecimal::from(10);
+        let amount = U256::from(5_000_000u64); // 5 TRX — enough room for fees
+        let resources = TronAccountResources::default();
+        let prices = mainnet_prices();
+
+        let ctx = TronWithdrawContext {
+            from: &from,
+            to: &to,
+            block_data: &block_data,
+            resources,
+            prices,
+            fee_coin: "TRX",
+            expiration_seconds: None,
+            dest_state: new_account_state(),
+        };
+        let (_, fee_details, final_amount) =
+            build_tron_trx_withdraw(&ctx, amount, balance, &balance_dec, false).unwrap();
+
+        assert_eq!(final_amount, amount);
+        assert!(fee_details.account_creation_fee.is_some());
+        // total_fee includes creation fee + bandwidth
+        let fee_sun =
+            u256_to_u64_checked(u256_from_big_decimal(&fee_details.total_fee, TRX_DECIMALS).unwrap()).unwrap();
+        assert!(
+            fee_sun > 1_000_000,
+            "total fee should include at least the 1 TRX creation fee"
+        );
+    });
+
+    cross_test!(trx_non_max_withdraw_to_new_account_rejects_insufficient_balance, {
+        let from = TronAddress::from_hex(TEST_FROM_HEX).unwrap();
+        let to = TronAddress::from_hex(TEST_TO_HEX).unwrap();
+        let block_data = nile_block_64687673();
+
+        let balance = U256::from(5_000_000u64); // 5 TRX
+        let balance_dec = BigDecimal::from(5);
+        let amount = U256::from(4_500_000u64); // 4.5 TRX — not enough for amount + creation fee + bandwidth
+        let resources = TronAccountResources::default();
+        let prices = mainnet_prices();
+
+        let ctx = TronWithdrawContext {
+            from: &from,
+            to: &to,
+            block_data: &block_data,
+            resources,
+            prices,
+            fee_coin: "TRX",
+            expiration_seconds: None,
+            dest_state: new_account_state(),
+        };
+        let result = build_tron_trx_withdraw(&ctx, amount, balance, &balance_dec, false);
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().into_inner();
+        assert!(matches!(err, WithdrawError::NotSufficientBalance { .. }));
+    });
+
+    cross_test!(trx_max_withdraw_empties_account_no_minimum_balance, {
+        let from = TronAddress::from_hex(TEST_FROM_HEX).unwrap();
+        let to = TronAddress::from_hex(TEST_TO_HEX).unwrap();
+        let block_data = nile_block_64687673();
+
+        // Small balance — should be able to send everything (no 0.1 TRX minimum enforced)
+        let balance = U256::from(2_000_000u64); // 2 TRX
+        let balance_dec = BigDecimal::from(2);
+        let resources = TronAccountResources::default();
+        let prices = mainnet_prices();
+
+        let ctx = TronWithdrawContext {
+            from: &from,
+            to: &to,
+            block_data: &block_data,
+            resources,
+            prices,
+            fee_coin: "TRX",
+            expiration_seconds: None,
+            dest_state: DestAccountState::Activated, // sending to existing address
+        };
+        let (_, fee_details, final_amount) =
+            build_tron_trx_withdraw(&ctx, balance, balance, &balance_dec, true).unwrap();
+
+        // Account can be emptied — no minimum balance enforced
+        let fee_sun =
+            u256_to_u64_checked(u256_from_big_decimal(&fee_details.total_fee, TRX_DECIMALS).unwrap()).unwrap();
+        assert_eq!(
+            final_amount.as_u64() + fee_sun,
+            balance.as_u64(),
+            "max withdraw should use entire balance with no minimum held back"
+        );
+        assert!(final_amount > U256::zero());
+        assert_eq!(fee_details.account_creation_fee, None);
     });
 }

--- a/mm2src/mm2_main/tests/mm2_tests/tron_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/tron_tests.rs
@@ -1178,3 +1178,105 @@ fn test_trx_fee_details_structure() {
     // Do NOT broadcast — pure structure validation.
     block_on(mm.stop()).unwrap();
 }
+
+/// Test TRX withdraw to an unactivated (new) address includes account creation fee.
+/// Does NOT broadcast to avoid spending the 1 TRX creation fee from the test wallet.
+#[test]
+fn test_trx_withdraw_to_unactivated_address() {
+    let coins = serde_json::json!([trx_conf()]);
+    let conf = Mm2TestConf::seednode(TRON_WITHDRAW_TEST_PASSPHRASE, &coins);
+    let mm = block_on(MarketMakerIt::start_async(conf.conf, conf.rpc_password, None)).unwrap();
+
+    block_on(enable_trx_with_tokens(&mm, TRON_NILE_NODES, &[]));
+
+    // Generate a fresh random address that doesn't exist on Nile
+    let random_addr = {
+        use rand::RngCore;
+        let mut rng = common::small_rng();
+        let mut bytes = [0u8; 20];
+        rng.fill_bytes(&mut bytes);
+        // 0x41 prefix = TRON mainnet/testnet address
+        let hex = format!("41{}", hex::encode(bytes));
+        TronAddress::from_hex(&hex).expect("valid random TRON address")
+    };
+
+    let withdraw = block_on(mm.rpc(&serde_json::json!({
+        "userpass": mm.userpass,
+        "method": "withdraw",
+        "coin": "TRX",
+        "to": random_addr.to_base58(),
+        "amount": "1",
+    })))
+    .unwrap();
+    assert!(
+        withdraw.0.is_success(),
+        "Withdraw to unactivated address failed: {}",
+        withdraw.1
+    );
+
+    let tx_details: TransactionDetails = serde_json::from_str(&withdraw.1).unwrap();
+
+    // Fee details should include account_creation_fee
+    let fee_json = &tx_details.fee_details;
+    assert_eq!(fee_json["type"].as_str().unwrap(), "Tron");
+    assert!(
+        fee_json["account_creation_fee"].is_string(),
+        "account_creation_fee should be present for unactivated destination, got: {}",
+        fee_json
+    );
+
+    // Typed deserialization
+    let fee: TxFeeDetails = serde_json::from_value(fee_json.clone()).unwrap();
+    match fee {
+        TxFeeDetails::Tron(tron_fee) => {
+            assert!(
+                tron_fee.account_creation_fee.is_some(),
+                "account_creation_fee should be Some for unactivated address"
+            );
+            let creation_fee = tron_fee.account_creation_fee.unwrap();
+            assert!(creation_fee > BigDecimal::from(0), "account_creation_fee should be > 0");
+            // total_fee should include bandwidth + account creation
+            assert!(
+                tron_fee.total_fee > creation_fee,
+                "total_fee should exceed account_creation_fee (includes bandwidth)"
+            );
+        },
+        other => panic!("Expected TxFeeDetails::Tron, got {:?}", other),
+    }
+
+    // Do NOT broadcast — would cost 1 TRX creation fee.
+    block_on(mm.stop()).unwrap();
+}
+
+/// Test TRX withdraw to an activated address does NOT include account creation fee.
+/// Verifies backward compatibility — existing flows should not show the new field.
+#[test]
+fn test_trx_withdraw_to_activated_address_no_creation_fee() {
+    let coins = serde_json::json!([trx_conf()]);
+    let conf = Mm2TestConf::seednode(TRON_WITHDRAW_TEST_PASSPHRASE, &coins);
+    let mm = block_on(MarketMakerIt::start_async(conf.conf, conf.rpc_password, None)).unwrap();
+
+    block_on(enable_trx_with_tokens(&mm, TRON_NILE_NODES, &[]));
+
+    // Withdraw to a known activated address
+    let tx_details = block_on(withdraw_v1(&mm, "TRX", TRON_WITHDRAW_ADDR_INDEX_0, "0.1", None));
+
+    // account_creation_fee should be absent (skip_serializing_if = None)
+    let fee_json = &tx_details.fee_details;
+    assert!(
+        fee_json.get("account_creation_fee").is_none(),
+        "account_creation_fee should be absent for activated destination, got: {}",
+        fee_json
+    );
+
+    // Typed deserialization confirms None
+    let fee: TxFeeDetails = serde_json::from_value(fee_json.clone()).unwrap();
+    match fee {
+        TxFeeDetails::Tron(tron_fee) => {
+            assert_eq!(tron_fee.account_creation_fee, None);
+        },
+        other => panic!("Expected TxFeeDetails::Tron, got {:?}", other),
+    }
+
+    block_on(mm.stop()).unwrap();
+}

--- a/mm2src/mm2_main/tests/mm2_tests/tron_tests.rs
+++ b/mm2src/mm2_main/tests/mm2_tests/tron_tests.rs
@@ -1235,10 +1235,10 @@ fn test_trx_withdraw_to_unactivated_address() {
             );
             let creation_fee = tron_fee.account_creation_fee.unwrap();
             assert!(creation_fee > BigDecimal::from(0), "account_creation_fee should be > 0");
-            // total_fee should include bandwidth + account creation
+            // total_fee must at least cover the account creation fee (+ potential bandwidth fee).
             assert!(
-                tron_fee.total_fee > creation_fee,
-                "total_fee should exceed account_creation_fee (includes bandwidth)"
+                tron_fee.total_fee >= creation_fee,
+                "total_fee should be at least account_creation_fee"
             );
         },
         other => panic!("Expected TxFeeDetails::Tron, got {:?}", other),


### PR DESCRIPTION
When sending funds (trx or trx10) to an account that has never been activated before, an activation fee of 1 TRX is charged. Also a potential flat 0.1 TRX is charged if the available bandwidth can't cover the bandwidth used by the transaction being sent.

ref.
- https://developers.tron.network/reference/wallet-getchainparameters
- https://developers.tron.network/docs/account#account-activation

We didn't account for these fees before, which broke our fee estimation and caused failures (due insufficient funds) when sending the max account balance to a non-activated account.

This PR fixes this by accounting for these fees.


---

## GUI Integration Notes

The `withdraw` response's `fee_details` (when `type: "Tron"`) now includes a new optional field:

### New field: `account_creation_fee`

- **Type:** `string` (BigDecimal) or absent
- **Present when:** the destination address has never been activated on the Tron blockchain
- **Absent when:** the destination is an existing activated address (backward compatible — field is omitted, not `null`)

Example response for withdraw to a **new/unactivated** address:
```json
{
  "type": "Tron",
  "coin": "TRX",
  "bandwidth_used": 265,
  "energy_used": 0,
  "bandwidth_fee": "0.100000",
  "energy_fee": "0.000000",
  "account_creation_fee": "1.000000",
  "total_fee": "1.100000"
}
```

Example response for withdraw to an **existing/activated** address (unchanged from before):
```json
{
  "type": "Tron",
  "coin": "TRX",
  "bandwidth_used": 265,
  "energy_used": 0,
  "bandwidth_fee": "0.265000",
  "energy_fee": "0.000000",
  "total_fee": "0.265000"
}
```

**Notes for GUI:**
- `total_fee` always includes all fees (bandwidth + energy + account creation). No change needed if you only use `total_fee`.
- `account_creation_fee` allows showing a fee breakdown to the user, e.g. "1 TRX account activation fee + 0.1 TRX bandwidth fee".
- The fee is charged to the **sender** on top of the transfer amount — the recipient receives the full amount.
- TRC20 token withdrawals are **not affected** — `account_creation_fee` will never appear for TRC20, only for native TRX transfers.