### PR TITLE
Add BLOZ to 4x atomic locktime coins

### DIFF
--- a/mm2src/mm2_main/src/lp_swap.rs
+++ b/mm2src/mm2_main/src/lp_swap.rs
@@ -766,7 +766,7 @@ impl SwapConfirmationsSettings {
 }
 
 fn coin_with_4x_locktime(ticker: &str) -> bool {
-    matches!(ticker, "BCH" | "BTG" | "SBTC")
+    matches!(ticker, "BCH" | "BTG" | "SBTC" | "BLOZ")
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

This pull request adds Blockzero (BLOZ) to the existing group of coins that use the 4× atomic-swap locktime.

BLOZ targets an average block interval of approximately 600 seconds. As a young Proof-of-Work network with a still-developing hashrate distribution, its actual block intervals may occasionally vary beyond the target. Adding BLOZ to the existing 4× atomic-locktime group provides an appropriate safety margin for confirmation and payment-spend detection during atomic swaps.

## Change

- adds `BLOZ` to `coin_with_4x_locktime`;
- applies the existing 4× behavior to both V1 and V2 atomic locktime calculations;
- does not alter the behavior of any existing coin.

## Related coin configuration

- KomodoPlatform/coins#19

## Validation

- confirmed that the change is limited to one line in `mm2src/mm2_main/src/lp_swap.rs`;
- `git diff --check` passed;
- targeted `rustfmt --check` passed;
- protobuf generation passed with `protoc 29.3`;
- `cargo check -p mm2_main --lib` progressed through `mm2_main` generation and then stopped on five pre-existing Lightning type-conversion errors in the `coins` crate;
- the same five errors were reproduced unchanged on a clean `origin/main` worktree, confirming that they are unrelated to this change.
